### PR TITLE
Check sampling method in sampling file conversion script

### DIFF
--- a/scripts/ConvertBootstrapsToTSV.py
+++ b/scripts/ConvertBootstrapsToTSV.py
@@ -5,7 +5,8 @@ import os
 import logging
 import logging.handlers
 import sys
-import errno   
+import errno
+import json
 
 # from: http://stackoverflow.com/questions/600268/mkdir-p-functionality-in-python
 def mkdir_p(path):
@@ -36,7 +37,17 @@ def main(args):
     ntxp = len(txpNames)
     logging.info("Expecting bootstrap info for {} transcripts".format(ntxp))
     
-    s = struct.Struct('@' + 'd' * ntxp)
+    with open(os.path.sep.join([quantDir, "aux", "meta_info.json"])) as fh:
+        meta_info = json.load(fh)
+        
+    if meta_info['samp_type'] == 'gibbs':
+        s = struct.Struct('<' + 'i' * ntxp)
+    elif meta_info['samp_type'] == 'bootstrap':
+        s = struct.Struct('@' + 'd' * ntxp)
+    else:
+        logging.error("Unknown sampling method: {}".format(meta_info['samp_type']))
+        sys.exit(1)
+        
     numBoot = 0
     outDir = args.outDir
     if os.path.exists(outDir):


### PR DESCRIPTION
As pointed out in #58 the format of Gibbs samples file and Bootstrap samples file is different. Here I check the `meta_info.json` file for which format should be read.