### PR TITLE
Factorization develop

### DIFF
--- a/include/SalmonOpts.hpp
+++ b/include/SalmonOpts.hpp
@@ -151,6 +151,8 @@ struct SalmonOpts {
 
     bool useVBOpt; // Use Variational Bayesian EM instead of "regular" EM in the batch passes
 
+    uint32_t useRangeFactorization; // Cluster reads in each Eq Class based on the conditional probabilities
+
     bool useQuasi; // Are we using the quasi-mapping based index or not.
     
     // For writing quasi-mappings

--- a/src/CollapsedEMOptimizer.cpp
+++ b/src/CollapsedEMOptimizer.cpp
@@ -905,7 +905,7 @@ bool CollapsedEMOptimizer::optimize(ExpT& readExp, SalmonOpts& sopt,
   // Iterations in which we will allow re-computing the effective lengths
   // if bias-correction is enabled.
   // std::vector<uint32_t> recomputeIt{100, 500, 1000};
-  //minIter = 100;
+  minIter = 100;
 
   bool converged{false};
   double maxRelDiff = -std::numeric_limits<double>::max();

--- a/src/CollapsedEMOptimizer.cpp
+++ b/src/CollapsedEMOptimizer.cpp
@@ -129,7 +129,7 @@ void EMUpdate_(std::vector<std::vector<uint32_t>>& txpGroupLabels,
     const auto& auxs = txpGroupCombinedWeights[eqID];
 
     double denom = 0.0;
-    size_t groupSize = txps.size();
+    size_t groupSize = txpGroupCombinedWeights[eqID].size(); //txps.size();
     // If this is a single-transcript group,
     // then it gets the full count.  Otherwise,
     // update according to our VBEM rule.
@@ -199,7 +199,7 @@ void VBEMUpdate_(std::vector<std::vector<uint32_t>>& txpGroupLabels,
     const auto& auxs = txpGroupCombinedWeights[eqID];
 
     double denom = 0.0;
-    size_t groupSize = txps.size();
+    size_t groupSize = txpGroupCombinedWeights[eqID].size(); //txps.size();
     // If this is a single-transcript group,
     // then it gets the full count.  Otherwise,
     // update according to our VBEM rule.
@@ -258,7 +258,7 @@ void EMUpdate_(std::vector<std::pair<const TranscriptGroup, TGValue>>& eqVec,
             const auto& auxs = kv.second.combinedWeights;
 
             double denom = 0.0;
-            size_t groupSize = txps.size();
+            size_t groupSize = kv.second.weights.size(); //txps.size();
             // If this is a single-transcript group,
             // then it gets the full count.  Otherwise,
             // update according to our VBEM rule.
@@ -344,7 +344,7 @@ void VBEMUpdate_(std::vector<std::pair<const TranscriptGroup, TGValue>>& eqVec,
             const auto& auxs = kv.second.combinedWeights;
 
             double denom = 0.0;
-            size_t groupSize = txps.size();
+            size_t groupSize = kv.second.weights.size(); //txps.size();
             // If this is a single-transcript group,
             // then it gets the full count.  Otherwise,
             // update according to our VBEM rule.
@@ -395,7 +395,8 @@ size_t markDegenerateClasses(
     const auto& auxs = kv.second.combinedWeights;
 
     double denom = 0.0;
-    for (size_t i = 0; i < txps.size(); ++i) {
+    size_t groupSize = kv.second.weights.size();
+    for (size_t i = 0; i < groupSize; ++i) {
       auto tid = txps[i];
       auto aux = auxs[i];
       double v = alphaIn[tid] * aux;
@@ -437,7 +438,7 @@ size_t markDegenerateClasses(
       ++numDropped;
       kv.first.setValid(false);
     } else {
-      for (size_t i = 0; i < txps.size(); ++i) {
+      for (size_t i = 0; i < groupSize; ++i) {
         auto tid = txps[i];
         available[tid] = true;
       }
@@ -728,7 +729,7 @@ void updateEqClassWeights(
           // The label of the equivalence class
           const TranscriptGroup& k = kv.first;
           // The size of the label
-          size_t classSize = k.txps.size();
+          size_t classSize = kv.second.weights.size(); //k.txps.size();
           // The weights of the label
           TGValue& v = kv.second;
 
@@ -856,7 +857,7 @@ bool CollapsedEMOptimizer::optimize(ExpT& readExp, SalmonOpts& sopt,
           // The label of the equivalence class
           const TranscriptGroup& k = kv.first;
           // The size of the label
-          size_t classSize = k.txps.size();
+          size_t classSize = kv.second.weights.size(); //k.txps.size();
           // The weights of the label
           TGValue& v = kv.second;
 

--- a/src/CollapsedGibbsSampler.cpp
+++ b/src/CollapsedGibbsSampler.cpp
@@ -157,7 +157,7 @@ void sampleRoundNonCollapsedMultithreaded_(
 
           // for each transcript in this class
           const TranscriptGroup& tgroup = eqClass.first;
-          const size_t groupSize = tgroup.txps.size();
+          const size_t groupSize = eqClass.second.weights.size(); //tgroup.txps.size();
           if (tgroup.valid) {
             const std::vector<uint32_t>& txps = tgroup.txps;
             const auto& auxs = eqClass.second.combinedWeights;
@@ -327,7 +327,7 @@ bool CollapsedGibbsSampler::sample(
   std::vector<uint32_t> offsetMap(eqVec.size(), 0);
   for (size_t i = 0; i < eqVec.size(); ++i) {
     if (eqVec[i].first.valid) {
-      countMapSize += eqVec[i].first.txps.size();
+      countMapSize += eqVec[i].second.weights.size(); //eqVec[i].first.txps.size();
       for (auto t : eqVec[i].first.txps) { active[t] = true; }
       if (i < eqVec.size() - 1) {
         offsetMap[i + 1] = countMapSize;

--- a/src/GZipWriter.cpp
+++ b/src/GZipWriter.cpp
@@ -488,7 +488,7 @@ bool GZipWriter::writeEmptyAbundances(
   // Now posterior has the transcript fraction
   std::vector<Transcript>& transcripts_ = readExp.transcripts();
   for (auto& transcript : transcripts_) {
-      fmt::print(output.get(), "{}\t{}\t{:.3f}\t{:f}\t{}\n",
+      fmt::print(output.get(), "{}\t{}\t{:.3f}\t{:f}\t{:f}\n",
               transcript.RefName, transcript.CompleteLength, static_cast<float>(transcript.CompleteLength),
               0.0, 0.0);
   }
@@ -538,7 +538,7 @@ bool GZipWriter::writeAbundances(
       double effLength = transcript.EffectiveLength;
       double tfrac = (npm / effLength) / tfracDenom;
       double tpm = tfrac * million;
-      fmt::print(output.get(), "{}\t{}\t{:.3f}\t{:f}\t{}\n",
+      fmt::print(output.get(), "{}\t{}\t{:.3f}\t{:f}\t{:f}\n",
               transcript.RefName, transcript.CompleteLength, effLength,
               tpm, count);
   }

--- a/src/GZipWriter.cpp
+++ b/src/GZipWriter.cpp
@@ -87,9 +87,10 @@ bool GZipWriter::writeEquivCounts(
     const TranscriptGroup& tgroup = eq.first;
     const std::vector<uint32_t>& txps = tgroup.txps;
     // group size
-    equivFile << txps.size() << '\t';
+    uint32_t groupSize = eq.second.weights.size();
+    equivFile << groupSize << '\t';
     // each group member
-    for (auto tid : txps) { equivFile << tid << '\t'; }
+    for (uint32_t i=0; i<groupSize; i++) { equivFile << txps[i] << '\t'; }
     if (dumpRichWeights) {
       const auto& auxs = eq.second.combinedWeights;
       for (auto aux : auxs) { equivFile << aux << '\t'; }

--- a/src/GZipWriter.cpp
+++ b/src/GZipWriter.cpp
@@ -488,7 +488,7 @@ bool GZipWriter::writeEmptyAbundances(
   // Now posterior has the transcript fraction
   std::vector<Transcript>& transcripts_ = readExp.transcripts();
   for (auto& transcript : transcripts_) {
-      fmt::print(output.get(), "{}\t{}\t{:.3f}\t{:f}\t{:f}\n",
+      fmt::print(output.get(), "{}\t{}\t{:.3f}\t{:f}\t{}\n",
               transcript.RefName, transcript.CompleteLength, static_cast<float>(transcript.CompleteLength),
               0.0, 0.0);
   }
@@ -538,7 +538,7 @@ bool GZipWriter::writeAbundances(
       double effLength = transcript.EffectiveLength;
       double tfrac = (npm / effLength) / tfracDenom;
       double tpm = tfrac * million;
-      fmt::print(output.get(), "{}\t{}\t{:.3f}\t{:f}\t{:f}\n",
+      fmt::print(output.get(), "{}\t{}\t{:.3f}\t{:f}\t{}\n",
               transcript.RefName, transcript.CompleteLength, effLength,
               tpm, count);
   }

--- a/src/SalmonQuantify.cpp
+++ b/src/SalmonQuantify.cpp
@@ -210,6 +210,7 @@ void processMiniBatch(ReadExperiment& readExp, ForgettingMassCalculator& fmCalc,
   bool useFragLengthDist{!salmonOpts.noFragLengthDist};
   bool noFragLenFactor{salmonOpts.noFragLenFactor};
   bool useRankEqClasses{salmonOpts.rankEqClasses};
+  size_t rangeFactorization{salmonOpts.useRangeFactorization};
   bool noLengthCorrection{salmonOpts.noLengthCorrection};
   // JAN 13
   bool useAuxParams = ((localNumAssignedFragments + numAssignedFragments) >= salmonOpts.numPreBurninFrags);
@@ -537,6 +538,16 @@ void processMiniBatch(ReadExperiment& readExp, ForgettingMassCalculator& fmCalc,
                 std::swap(auxProbsNew, auxProbs);
             }
         }
+
+	if (rangeFactorization > 0) {
+	  int txpsSize = txpIDs.size();
+	  int rangeCount = std::sqrt(txpsSize)+rangeFactorization;
+	  
+	  for(size_t i=0; i<txpsSize; i++){
+	    int rangeNumber = auxProbs[i]*rangeCount;
+	    txpIDs.push_back(rangeNumber);
+	  }
+	}
         
         TranscriptGroup tg(txpIDs);
         eqBuilder.addGroup(std::move(tg), auxProbs);
@@ -2393,6 +2404,11 @@ int salmonQuantify(int argc, char* argv[]) {
      "useVBOpt", po::bool_switch(&(sopt.useVBOpt))->default_value(false),
      "Use the Variational Bayesian EM rather than the "
      "traditional EM algorithm for optimization in the batch passes.")
+    (
+     "useRangeFactorization",
+     po::value<uint32_t>(&(sopt.useRangeFactorization))->default_value(0),
+     "Cluster each in equivalence class based on the "
+     "conditional probabilities.")
     (
      "numGibbsSamples",
      po::value<uint32_t>(&(sopt.numGibbsSamples))->default_value(0),


### PR DESCRIPTION
The changes (other than adding the range factorization) are:

1- Number of minimum EM operation are set to 100. (works better for small samples of factorization paper)
2- The {:f} option for writing out "count" values are removed. This makes the Spearman correlation of RSEM simulated data 0.8245 in RF mode. (compared to 0.8232 when using the {:f} option)

