### PR TITLE
scripts fetchRapMap.sh: Fail if any command fails

### DIFF
--- a/scripts/fetchRapMap.sh
+++ b/scripts/fetchRapMap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu -o pipefail
 
 exists()
 {


### PR DESCRIPTION
In particular, fail when unzip is not available.