### PR TITLE
Update .travis.yml to add test case easily.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,49 @@
+dist: trusty
 sudo: false
-language: cpp
-
+git:
+  depth: 1
+language: generic
 matrix:
   include:
-    - os : linux
-      compiler : gcc-7
-      addons:
-        apt:
-          update: true
-          sources:
-              - sourceline: 'ppa:mhier/libboost-latest'
-              - ubuntu-toolchain-r-test
-          packages: ['g++-7', 'gcc-7', 'zlib1g-dev', 'libbz2-dev']
+    - env: CC=gcc-7 CXX=g++-7 AR=gcc-ar-7 NM=gcc-nm-7 RANLIB=gcc-ranlib-7
+    - env: CC=gcc-5 CXX=g++-5 AR=gcc-ar-5 NM=gcc-nm-5 RANLIB=gcc-ranlib-5
 
 install:
-    - export CXX="g++-7"
-    - export CC="gcc-7"
-    - mkdir -p latest-gcc-symlinks
-    - ln -s /usr/bin/g++-7 latest-gcc-symlinks/g++
-    - ln -s /usr/bin/gcc-7 latest-gcc-symlinks/gcc
-    - export PATH=$PWD/latest-gcc-symlinks:$PATH
-    - export AR=gcc-ar-7
-    - export RANLIB=gcc-ranlib-7
-    - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-    - mkdir ${DEPS_DIR} && cd ${DEPS_DIR}
-    - travis_retry wget --no-check-certificate https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.tar.gz
-    - tar -xzvf cmake-3.12.0-Linux-x86_64.tar.gz > /dev/null
-    - mv cmake-3.12.0-Linux-x86_64 cmake-install
-    - PATH=${DEPS_DIR}/cmake-install:${DEPS_DIR}/cmake-install/bin:$PATH
-    - cd ${TRAVIS_BUILD_DIR}
-    
-script: 
-    - mkdir build 
-    - cd build 
-    - cmake -DFETCH_BOOST=TRUE -DNO_RTM=TRUE .. 
-    - travis_wait 45 make 
-    - travis_wait make install
-    - LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/lib:$LD_LIBRARY_PATH
-    - ./src/salmon -h
-    - travis_wait make test VERBOSE=1
+    # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq zlib1g-dev libbz2-dev cmake
+    - |
+      if [[ "${CC}" =~ gcc- ]]; then
+        echo "Installing ${CC}."
+        sudo apt-get install -qq "${CC}"
+      fi
+    - |
+      if [[ "${CXX}" =~ g\+\+- ]]; then
+        echo "Installing ${CXX}."
+        sudo apt-get install -qq "${CXX}"
+      fi
 
-after_success: 
-    - cd $TRAVIS_BUILD_DIR
+script:
+    - LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/lib:$LD_LIBRARY_PATH
+    - mkdir build
+    - pushd build
+    # Set make -j N considering Travis providing 2 cores.
+    # VERBOSE=1 to show the input commands in generatd Makefile for debug.
+    - |
+      cmake \
+        -DFETCH_BOOST=TRUE \
+        -DNO_RTM=TRUE \
+        .. && \
+      make -j 4 VERBOSE=1 && \
+      make install && \
+      ./src/salmon -h && \
+      make test VERBOSE=1
+    - popd
+
+after_success:
     - ./scripts/push-binary.sh
-      
+
 after_failure:
     - echo "Failure"
     - ls -laR $TRAVIS_BUILD_DIR/build/Testing/


### PR DESCRIPTION
This is related to https://github.com/COMBINE-lab/salmon/issues/272

* Now there are 2 test cases on Travis CI, adding one case.
* Added code for speed up such as `git - depth: 1`, `make -j 4`.
* Refactoring. Removed tailing spaces.

Notes:
* I added `gcc-5`'s case as maybe it is minimal support version of gcc for this project.
* I want to replace current case `gcc-7` to latest version `gcc-8` if you like.
* Total running time ("Ran for" on the Travis page.) becomes faster than current situation. In my repository, total running time is "15 min 11 sec", seeing current master branch's test is around 17 min+. See [1]
* Removed `travis_wait`. Without the command, the default behavior is "when a long running command or compile step regularly takes longer than 10 minutes without producing any output". [2] I have not faced the situation when I  did debug. 
* There are commented out area at the bottom of `.travis.yml`. However as we can run `git log .travis.yml` to check past modification, shall we remove the commented out "whitelist" area?

[1] https://travis-ci.org/junaruga/salmon/builds/417976633
[2] https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
