### PR TITLE
Set the compiler to build boost from environment variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,18 @@
 cmake_minimum_required (VERSION 3.9)
 
+if(DEFINED ENV{CC})
+  set(CC $ENV{CC})
+else()
+  set(CC gcc)
+endif()
+message("CC: ${CC}")
+
+set(CC_VERSION "")
+if(${CC} MATCHES ^gcc-)
+  string(REGEX REPLACE "gcc-" "" CC_VERSION ${CC})
+endif()
+message("CC version: ${CC_VERSION}")
+
 enable_testing()
 
 project (Salmon)
@@ -167,10 +180,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
     endif()
 
     set (WARNING_IGNORE_FLAGS "${WARNING_IGNORE_FLAGS} -Wno-unused-local-typedefs")
-    set (BOOST_TOOLSET "gcc")
+    set (BOOST_TOOLSET "${CC}")
     set (BOOST_CONFIGURE_TOOLSET "--with-toolset=gcc")
     set (BCXX_FLAGS "${CXXSTDFLAG}")
-    set (BOOST_EXTRA_FLAGS toolset=gcc cxxflags=${BCXX_FLAGS})
+    set (BOOST_EXTRA_FLAGS toolset=${CC} cxxflags=${BCXX_FLAGS})
 # Tentatively, we support clang now
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set(CLANG TRUE)
@@ -410,6 +423,11 @@ elseif(FETCH_BOOST)
         INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/install
         #PATCH_COMMAND patch -p2 < ${CMAKE_CURRENT_SOURCE_DIR}/external/boost156.patch
 	CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/external/boost_1_66_0/bootstrap.sh ${BOOST_CONFIGURE_TOOLSET} ${BOOST_BUILD_LIBS} --prefix=<INSTALL_DIR>
+        ADD_CUSTOM_COMMAND(
+            OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/external/boost_1_66_0/tools/build/src/user-config.jam
+            PRE_BUILD
+            COMMAND echo "using gcc : ${CC_VERSION} : ${CMAKE_CXX_COMPILER} ;"
+        )
 	BUILD_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/external/boost_1_66_0/b2 -d0 -j2 ${BOOST_LIB_SUBSET} toolset=${BOOST_TOOLSET} ${BOOST_EXTRA_FLAGS} cxxflags=${BOOST_CXX_FLAGS} link=static install
         BUILD_IN_SOURCE 1
         INSTALL_COMMAND ""


### PR DESCRIPTION
This pull-request is for develop branch.
This fixes https://github.com/COMBINE-lab/salmon/issues/275 .

The reason of the build error was because b2 was always built with "gcc".
I added something like below code.

```
echo "using gcc : ${CC_VERSION} : ${CMAKE_CXX_COMPILER} ;" > ${CMAKE_CURRENT_SOURCE_DIR}/external/boost_1_66_0/tools/build/src/user-config.jam

/path/to/b2 .. toolset=${CC} ...
```
 
There are still challenges to fix it.

1. The `make test` was finished with timeout. When setting `travis_wait 30 make test`, still failed with the timeout. Maybe we need to change the unit test logic to output something (log or progress bar) regularly to `stdout` during the test process or change the test logic itself. It is freezing at the below point.

```
/usr/local/cmake-3.9.2/bin/ctest --force-new-ctest-process 
Test project /home/travis/build/junaruga/salmon/build
    Start 1: unit_tests
```

2. The `b2` parameter string `toolset=gcc-7 cxxflags=-std=c++14` is duplicated like this. Maybe we can change the logic in `CMakeLists.txt`.

```
CC=/usr/bin/gcc-7 CXX=/usr/bin/g++-7 /home/travis/build/junaruga/salmon/external/boost_1_66_0/b2 -d0 -j2 --with-iostreams --with-atomic --with-chrono --with-container --with-date_time --with-exception --with-filesystem --with-graph --with-graph_parallel --with-math --with-program_options --with-system --with-locale --with-timer toolset=gcc-7 toolset=gcc-7 cxxflags=-std=c++14 "cxxflags= -std=c++14 -I/home/travis/build/junaruga/salmon/external/install/include -L/home/travis/build/junaruga/salmon/external/install/lib" link=static install
```

3. `CMakeLists.txt` and `cmake/*.cmake` have a mixture of the different code formatting style.  Aligning for formatting those make us read the files easier.  I found the useful information for that. [1][2][3][4].
  * 2 or 4 space indent?
  * "Tab" indent is unintentionally used maybe.
  * `set(...)` or  `set (...)`.
  * `set or SET`.

[1] the KDE cmake coding style: https://community.kde.org/Policies/CMake_Coding_Style
[2] Asking the cmake code formatter: https://stackoverflow.com/questions/41446408/is-there-any-utility-that-can-reformat-a-cmake-file
[3] cmake code formatter: https://github.com/cheshirekow/cmake_format
[4] cmake lint: https://github.com/richq/cmake-lint
