### PR TITLE
Tweaks to CEL-Seq2 support for Alevin

### DIFF
--- a/include/SalmonDefaults.hpp
+++ b/include/SalmonDefaults.hpp
@@ -109,7 +109,7 @@ namespace defaults {
   constexpr const bool isChromium{false};
   constexpr const bool isInDrop{false};
   constexpr const bool isGemcode{false};
-  constexpr const bool isCelseq{false};
+  constexpr const bool isCELSeq{false};
   constexpr const bool dumpBarcodeEq{false};
   constexpr const bool noQuant{false};
   constexpr const bool noSoftMap{true};

--- a/include/SingleCellProtocols.hpp
+++ b/include/SingleCellProtocols.hpp
@@ -56,8 +56,6 @@ namespace alevin{
     struct CELSeq : Rule{
       // WEHI SCORE's CEL-Seq2 starts from 5' end with a 8 bp barcode
       // and a 6 bp UMI.
-      // TODO: Don't really understand `maxValue`.
-      //       But observe it's approximately 2^(barcodeLength * 2).
       CELSeq(): Rule(8, 6, BarcodeEnd::FIVE, 65536){}
     };
 

--- a/include/SingleCellProtocols.hpp
+++ b/include/SingleCellProtocols.hpp
@@ -53,8 +53,12 @@ namespace alevin{
       Gemcode(): Rule(14, 10, BarcodeEnd::FIVE, 268435456){}
     };
 
-    struct Celseq : Rule{
-      Celseq(): Rule(6, 6, BarcodeEnd::FIVE, 4096){}
+    struct CELSeq : Rule{
+      // WEHI SCORE's CEL-Seq2 starts from 5' end with a 8 bp barcode
+      // and a 6 bp UMI.
+      // TODO: Don't really understand `maxValue`.
+      //       But observe it's approximately 2^(barcodeLength * 2).
+      CELSeq(): Rule(8, 6, BarcodeEnd::FIVE, 65536){}
     };
 
     //dummy class

--- a/src/Alevin.cpp
+++ b/src/Alevin.cpp
@@ -549,9 +549,15 @@ bool writeFastq(AlevinOpts<ProtocolT>& aopt,
       for (size_t i = 0; i < rangeSize; ++i) { // For all the read in this batch
         auto& rp = rg[i];
         if(aopt.protocol.end == bcEnd::FIVE){
-          barcode = rp.first.seq.substr(0, aopt.protocol.barcodeLength);
-          umi = rp.first.seq.substr(aopt.protocol.barcodeLength,
-                                    aopt.protocol.umiLength);
+          //barcode = rp.first.seq.substr(0, aopt.protocol.barcodeLength);
+          //umi = rp.first.seq.substr(aopt.protocol.barcodeLength,
+          //                          aopt.protocol.umiLength);
+          // TODO: The above isn't valid for CEL-Seq2. I temporarily commented 
+          //       it out and replaced with a CEL-Seq2-specific format so that 
+          //       I could test my changes.
+          barcode = rp.first.seq.substr(aopt.protocol.umiLength, 
+                                        aopt.protocol.barcodeLength);
+          umi = rp.first.seq.substr(0, aopt.protocol.umiLength);
         }
         else if (aopt.protocol.end == bcEnd::THREE) {
           std::string seq = rp.first.seq;
@@ -988,11 +994,11 @@ salmon-based processing of single-cell RNA-seq data.
                        unmateFiles, readFiles);
     }
     else if(celseq){
-      AlevinOpts<apt::Celseq> aopt;
-      //aopt.jointLog->warn("Using 10x v1 Setting for Alevin");
+      AlevinOpts<apt::CELSeq> aopt;
+      //aopt.jointLog->warn("Using CEL-Seq Setting for Alevin");
       initiatePipeline(aopt, sopt, orderedOptions,
                        vm, commentString,
-                       unmateFiles, readFiles);
+                       barcodeFiles, readFiles);
     }
     else{
       AlevinOpts<apt::Custom> aopt;

--- a/src/AlevinUtils.cpp
+++ b/src/AlevinUtils.cpp
@@ -69,8 +69,8 @@ namespace alevin {
       return true;
     }
     template <>
-    bool extractUMI<apt::Celseq>(std::string& read,
-                                 apt::Celseq& pt,
+    bool extractUMI<apt::CELSeq>(std::string& read,
+                                 apt::CELSeq& pt,
                                  std::string& umi){
       umi = read.substr(0, pt.umiLength);
       return true;
@@ -82,7 +82,6 @@ namespace alevin {
       std::cout<<"Incorrect call for umi extract";
       exit(0);
     }
-
 
     template <>
     nonstd::optional<std::string> extractBarcode<apt::DropSeq>(std::string& read,
@@ -120,13 +119,10 @@ namespace alevin {
       //return true;
     }
     template <>
-    nonstd::optional<std::string> extractBarcode<apt::Celseq>(std::string& read,
-                                     apt::Celseq& pt){
-      return (read.length() >= pt.barcodeLength+pt.umiLength) ?
+    nonstd::optional<std::string> extractBarcode<apt::CELSeq>(std::string& read,
+                                    apt::CELSeq& pt){
+      return (read.length() >= (pt.umiLength + pt.barcodeLength)) ?
         nonstd::optional<std::string>(read.substr(pt.umiLength, pt.barcodeLength)) : nonstd::nullopt;
-      //return (read.length() >= pt.barcodeLength) ? (bc.append(read.data(), pt.barcodeLength), true) : false;
-      //bc = read.substr(0, pt.barcodeLength);
-      //return true;
     }
     template <>
     nonstd::optional<std::string> extractBarcode<apt::InDrop>(std::string& read, apt::InDrop& pt){
@@ -546,7 +542,7 @@ namespace alevin {
                            SalmonOpts& sopt,
                            boost::program_options::variables_map& vm);
     template
-    bool processAlevinOpts(AlevinOpts<apt::Celseq>& aopt,
+    bool processAlevinOpts(AlevinOpts<apt::CELSeq>& aopt,
                            SalmonOpts& sopt,
                            boost::program_options::variables_map& vm);
 

--- a/src/CollapsedCellOptimizer.cpp
+++ b/src/CollapsedCellOptimizer.cpp
@@ -780,7 +780,7 @@ bool CollapsedCellOptimizer::optimize(SCExpT& experiment,
                                       size_t numLowConfidentBarcode);
 template
 bool CollapsedCellOptimizer::optimize(SCExpT& experiment,
-                                      AlevinOpts<apt::Celseq>& aopt,
+                                      AlevinOpts<apt::CELSeq>& aopt,
                                       GZipWriter& gzw,
                                       std::vector<std::string>& trueBarcodes,
                                       std::vector<uint32_t>& umiCount,

--- a/src/GZipWriter.cpp
+++ b/src/GZipWriter.cpp
@@ -962,8 +962,8 @@ bool GZipWriter::writeEquivCounts<SCExpT, apt::Gemcode>(
                                                         const AlevinOpts<apt::Gemcode>& aopts,
                                                         SCExpT& readExp);
 template
-bool GZipWriter::writeEquivCounts<SCExpT, apt::Celseq>(
-                                                        const AlevinOpts<apt::Celseq>& aopts,
+bool GZipWriter::writeEquivCounts<SCExpT, apt::CELSeq>(
+                                                        const AlevinOpts<apt::CELSeq>& aopts,
                                                         SCExpT& readExp);
 template
 bool GZipWriter::writeEquivCounts<SCExpT, apt::Custom>(

--- a/src/ProgramOptionsGenerator.cpp
+++ b/src/ProgramOptionsGenerator.cpp
@@ -277,8 +277,8 @@ namespace salmon {
        "gemcode", po::bool_switch()->default_value(alevin::defaults::isGemcode),
        "Use 10x gemcode v1 Single Cell protocol for the library.")
       (
-       "celseq", po::bool_switch()->default_value(alevin::defaults::isCelseq),
-       "Use CelSeq2 Single Cell protocol for the library.")
+        "celseq", po::bool_switch()->default_value(alevin::defaults::isCELSeq),
+        "Use CEL-Seq2 Single Cell protocol for the library.")
       (
        "whitelist", po::value<std::string>(),
        "File containing white-list barcodes")

--- a/src/SalmonAlevin.cpp
+++ b/src/SalmonAlevin.cpp
@@ -792,7 +792,6 @@ void processReadsQuasi(
         } else{
           //corrBarcodeIndex = barcodeMap[barcodeIndex];
           jointHitGroup.setBarcode(*barcodeIdx);
-
           aut::extractUMI(rp.first.seq, alevinOpts.protocol, umi);
 
           if ( umiLength != umi.size() ) {
@@ -1838,7 +1837,7 @@ int alevinQuant(AlevinOpts<apt::Gemcode>& aopt,
                 CFreqMapT& freqCounter,
                 size_t numLowConfidentBarcode);
 template
-int alevinQuant(AlevinOpts<apt::Celseq>& aopt,
+int alevinQuant(AlevinOpts<apt::CELSeq>& aopt,
                 SalmonOpts& sopt,
                 SoftMapT& barcodeMap,
                 TrueBcsT& trueBarcodes,
@@ -1853,4 +1852,3 @@ int alevinQuant(AlevinOpts<apt::Custom>& aopt,
                 boost::program_options::parsed_options& orderedOptions,
                 CFreqMapT& freqCounter,
                 size_t numLowConfidentBarcode);
-

--- a/src/WhiteList.cpp
+++ b/src/WhiteList.cpp
@@ -523,7 +523,7 @@ namespace alevin {
                                       CFreqMapT& freqCounter,
                                       spp::sparse_hash_map<std::string, uint32_t>& geneIdxMap,
                                       size_t numLowConfidentBarcode);
-    template bool performWhitelisting(AlevinOpts<alevin::protocols::Celseq>& aopt,
+    template bool performWhitelisting(AlevinOpts<alevin::protocols::CELSeq>& aopt,
                                       std::vector<uint32_t>& umiCount,
                                       DoubleMatrixT& geneCountsMatrix,
                                       std::vector<std::string>& trueBarcodes,


### PR DESCRIPTION
A PR noting the differences in my approach to #269.
The one that I think needs addressing is in `writeFastq` (https://github.com/COMBINE-lab/salmon/compare/develop...PeteHaitch:develop?expand=1#diff-bf2f37cd9ea77a5c454a5bd860a924ee); without some change to this the `UMI` and `CB` are incorrectly extracted for CEL-Seq2. 
I simply commented out the original lines and modified it as needed for CEL-Seq2 in order to test my modified version.
I guess some sort of protocol-specific conditional is needed here.

The remainder are minor/cosmetic choices of variable names (please feel free to ignore!).