### PR TITLE
typo correction

### DIFF
--- a/doc/source/salmon.rst
+++ b/doc/source/salmon.rst
@@ -340,7 +340,7 @@ given by ``--fldMean``).
 One potential artifact that may arise from *alignment-free* mapping techniques is
 *spurious mappings*.  These may either be reads that do not arise from some target being
 quantified, but nonetheless exhibit some match against them (e.g. contaminants) or, more
-commonly, mapping a read to a larget set of quantification targets than would be
+commonly, mapping a read to a larger set of quantification targets than would be
 supported by an optimal or near-optimal alignment.
 
 If you pass the ``--validateMappings`` flag to Salmon, it will run an extension


### PR DESCRIPTION
Hello,

I noticed a small typo in the documentation for one of the command line options. I haven't used .rst files before, but I believe I was able to track down the source of the typo. Thanks for your work on salmon.

Matt