### PR TITLE
add missing <string> header

### DIFF
--- a/include/BAMUtils.hpp
+++ b/include/BAMUtils.hpp
@@ -9,6 +9,7 @@ extern "C" {
 }
 
 #include <unordered_map>
+#include <string>
 
 namespace salmon {
   namespace bam_utils {


### PR DESCRIPTION
In recent versions of gcc (10.1.0) <unordered_map> doesn't pull in <string>, so you need to add that.