### PR TITLE
Soft-cliping and CIGAR computation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,10 +224,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
     endif()
 
     set(WARNING_IGNORE_FLAGS "${WARNING_IGNORE_FLAGS} -Wno-unused-local-typedefs")
-    set(BOOST_TOOLSET "${CC}")
+    set(BOOST_TOOLSET "gcc")
     set(BOOST_CONFIGURE_TOOLSET "--with-toolset=gcc")
     set(BCXX_FLAGS "${CXXSTDFLAG} ${SCHAR_FLAG}")
-    set(BOOST_EXTRA_FLAGS toolset=${CC} cxxflags=${BCXX_FLAGS})
+    set(BOOST_EXTRA_FLAGS toolset=gcc cxxflags=${BCXX_FLAGS})
 # Tentatively, we support clang now
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set(CLANG TRUE)
@@ -789,6 +789,7 @@ else ()
   find_package(libstadenio)
 endif()
 
+## TODO: Update to new staden
 if (NOT LIBSTADENIO_FOUND)
   message("Build system will compile Staden IOLib")
   message("==================================================================")


### PR DESCRIPTION
The soft-clipping feature is improved in this pull request and accurate CIGAR calculation can be done by passing the corresponding user flag to salmon. This PR uses a new version of pufferfish repository that has these new features implemented.

Here's a summary of the changes:
- The soft-clipping can be enabled by `--softclip` flag in the selective-alignment mode of the quant command, same as before. 
- `--softclipOverhangs` flag is deprecated and in this release will have the same effect as `--softclip`.
- Accurate CIGAR calculation can be enabled by the new `--computeCIGAR` flag in the selective-alignment mode of the quant command.
- Another new argument `--maxSoftclipFraction` restricts the fraction of the soft-clipped part of a read. An alignment is reported if and only if `alignment_score >= minScoreFraction * max_alignment_score` where `max_alignment_score = match_score * (read_length – softclip_length)`. This threshold applies separately to the mates of a paired-end read and the soft-clip length on a mate will not affect the maximum allowed soft-clip length on the other mate. 
- If the total length of the soft-clipped regions on a read (in the beginning and the end of the read) is greater than maxSoftclipFraction * read_length, another chance will be given to the read to be aligned end-to-end. If the end-to-end alignment is acceptable based on its score, it will be reported. 
- The new `--endBonus` argument specifies how strict the soft-clipping decisions are made in the program. It specifies the extra bonus score that is added to the end-to-end alignment score, when the alignment reaches the end of query. The larger this value is set, the more likely that soft-clipping is not reported as part of the alignment of a particular query because getting to the end of the query would be preferred. 

** Note that pufferfish library is installed from a branch at the moment and it should be set to the new version of pufferfish once it is released.