### PR TITLE
Add split-seq V1 and V2 to alevin

### DIFF
--- a/include/SalmonDefaults.hpp
+++ b/include/SalmonDefaults.hpp
@@ -139,6 +139,7 @@ namespace defaults {
   constexpr const bool isCITESeq{false};
   constexpr const bool isCELSeq{false};
   constexpr const bool isCELSeq2{false};
+  constexpr const bool isSplitSeqV2{false};
   constexpr const bool isQuartzSeq2{false};
   constexpr const bool isSciSeq3{false};
   constexpr const bool noQuant{false};

--- a/include/SalmonDefaults.hpp
+++ b/include/SalmonDefaults.hpp
@@ -139,6 +139,7 @@ namespace defaults {
   constexpr const bool isCITESeq{false};
   constexpr const bool isCELSeq{false};
   constexpr const bool isCELSeq2{false};
+  constexpr const bool isSplitSeqV1{false};
   constexpr const bool isSplitSeqV2{false};
   constexpr const bool isQuartzSeq2{false};
   constexpr const bool isSciSeq3{false};

--- a/include/SingleCellProtocols.hpp
+++ b/include/SingleCellProtocols.hpp
@@ -182,6 +182,11 @@ namespace alevin{
         std::size_t const bcLen = 8, bc1Pos = 78, bc2Pos = 48, bc3Pos = 10;
     };
 
+    struct SplitSeqV1 : Rule{
+        SplitSeqV1(): Rule(24, 10, BarcodeEnd::FIVE, 4294967295){}
+        std::size_t const bcLen = 8, bc1Pos = 86, bc2Pos = 48, bc3Pos = 10;
+    };
+
     //dummy class
     struct Custom : Rule{
       Custom() : Rule(0,0,BarcodeEnd::FIVE,0){}

--- a/include/SingleCellProtocols.hpp
+++ b/include/SingleCellProtocols.hpp
@@ -177,6 +177,10 @@ namespace alevin{
       CELSeq2(): Rule(6, 6, BarcodeEnd::FIVE, 4096){}
     };
 
+    struct SplitSeqV2 : Rule{
+        SplitSeqV2(): Rule(24, 10, BarcodeEnd::FIVE, 4294967295){}
+    };
+
     //dummy class
     struct Custom : Rule{
       Custom() : Rule(0,0,BarcodeEnd::FIVE,0){}

--- a/include/SingleCellProtocols.hpp
+++ b/include/SingleCellProtocols.hpp
@@ -179,6 +179,7 @@ namespace alevin{
 
     struct SplitSeqV2 : Rule{
         SplitSeqV2(): Rule(24, 10, BarcodeEnd::FIVE, 4294967295){}
+        std::size_t const bcLen = 8, bc1Pos = 78, bc2Pos = 48, bc3Pos = 10;
     };
 
     //dummy class

--- a/include/SingleCellProtocols.hpp
+++ b/include/SingleCellProtocols.hpp
@@ -179,12 +179,12 @@ namespace alevin{
 
     struct SplitSeqV2 : Rule{
         SplitSeqV2(): Rule(24, 10, BarcodeEnd::FIVE, 4294967295){}
-        std::size_t const bcLen = 8, bc1Pos = 78, bc2Pos = 48, bc3Pos = 10;
+        std::size_t const bcLen = 8, bc1Pos = 10, bc2Pos = 48, bc3Pos = 78;
     };
 
     struct SplitSeqV1 : Rule{
         SplitSeqV1(): Rule(24, 10, BarcodeEnd::FIVE, 4294967295){}
-        std::size_t const bcLen = 8, bc1Pos = 86, bc2Pos = 48, bc3Pos = 10;
+        std::size_t const bcLen = 8, bc1Pos = 10, bc2Pos = 48, bc3Pos = 86;
     };
 
     //dummy class

--- a/src/Alevin.cpp
+++ b/src/Alevin.cpp
@@ -1029,6 +1029,7 @@ salmon-based processing of single-cell RNA-seq data.
     bool gemcode = vm["gemcode"].as<bool>();
     bool celseq = vm["celseq"].as<bool>();
     bool celseq2 = vm["celseq2"].as<bool>();
+    bool splitseqV1 = vm["splitseqV1"].as<bool>();
     bool splitseqV2 = vm["splitseqV2"].as<bool>();
     bool quartzseq2 = vm["quartzseq2"].as<bool>();
     bool sciseq3 = vm["sciseq3"].as<bool>();
@@ -1048,6 +1049,7 @@ salmon-based processing of single-cell RNA-seq data.
     if (gemcode) validate_num_protocols += 1;
     if (celseq) validate_num_protocols += 1;
     if (celseq2) validate_num_protocols += 1;
+    if (splitseqV1) validate_num_protocols += 1;
     if (splitseqV2) validate_num_protocols += 1;
     if (quartzseq2) validate_num_protocols += 1;
     if (sciseq3) validate_num_protocols += 1;
@@ -1145,6 +1147,13 @@ salmon-based processing of single-cell RNA-seq data.
     else if(celseq2){
       AlevinOpts<apt::CELSeq2> aopt;
       //aopt.jointLog->warn("Using CEL-Seq2 Setting for Alevin");
+      initiatePipeline(aopt, sopt, orderedOptions,
+                       vm, commentString, noTgMap,
+                       barcodeFiles, readFiles, salmonIndex);
+    }
+    else if(splitseqV1){
+      AlevinOpts<apt::SplitSeqV1> aopt;
+      //aopt.jointLog->warn("Using Split-SeqV2 Setting for Alevin");
       initiatePipeline(aopt, sopt, orderedOptions,
                        vm, commentString, noTgMap,
                        barcodeFiles, readFiles, salmonIndex);

--- a/src/Alevin.cpp
+++ b/src/Alevin.cpp
@@ -1029,6 +1029,7 @@ salmon-based processing of single-cell RNA-seq data.
     bool gemcode = vm["gemcode"].as<bool>();
     bool celseq = vm["celseq"].as<bool>();
     bool celseq2 = vm["celseq2"].as<bool>();
+    bool splitseqV2 = vm["splitseqV2"].as<bool>();
     bool quartzseq2 = vm["quartzseq2"].as<bool>();
     bool sciseq3 = vm["sciseq3"].as<bool>();
     bool custom_old =  vm.count("barcodeLength") and
@@ -1143,6 +1144,13 @@ salmon-based processing of single-cell RNA-seq data.
     else if(celseq2){
       AlevinOpts<apt::CELSeq2> aopt;
       //aopt.jointLog->warn("Using CEL-Seq2 Setting for Alevin");
+      initiatePipeline(aopt, sopt, orderedOptions,
+                       vm, commentString, noTgMap,
+                       barcodeFiles, readFiles, salmonIndex);
+    }
+    else if(splitseqV2){
+      AlevinOpts<apt::SplitSeqV2> aopt;
+      //aopt.jointLog->warn("Using Split-SeqV2 Setting for Alevin");
       initiatePipeline(aopt, sopt, orderedOptions,
                        vm, commentString, noTgMap,
                        barcodeFiles, readFiles, salmonIndex);

--- a/src/Alevin.cpp
+++ b/src/Alevin.cpp
@@ -1048,6 +1048,7 @@ salmon-based processing of single-cell RNA-seq data.
     if (gemcode) validate_num_protocols += 1;
     if (celseq) validate_num_protocols += 1;
     if (celseq2) validate_num_protocols += 1;
+    if (splitseqV2) validate_num_protocols += 1;
     if (quartzseq2) validate_num_protocols += 1;
     if (sciseq3) validate_num_protocols += 1;
     if (custom) validate_num_protocols += 1;

--- a/src/AlevinHash.cpp
+++ b/src/AlevinHash.cpp
@@ -306,6 +306,10 @@ int salmonHashQuantify(AlevinOpts<apt::CELSeq2>& aopt,
                        bfs::path& outputDirectory,
                        CFreqMapT& freqCounter);
 template
+int salmonHashQuantify(AlevinOpts<apt::SplitSeqV1>& aopt,
+                       bfs::path& outputDirectory,
+                       CFreqMapT& freqCounter);
+template
 int salmonHashQuantify(AlevinOpts<apt::SplitSeqV2>& aopt,
                        bfs::path& outputDirectory,
                        CFreqMapT& freqCounter);

--- a/src/AlevinHash.cpp
+++ b/src/AlevinHash.cpp
@@ -306,6 +306,10 @@ int salmonHashQuantify(AlevinOpts<apt::CELSeq2>& aopt,
                        bfs::path& outputDirectory,
                        CFreqMapT& freqCounter);
 template
+int salmonHashQuantify(AlevinOpts<apt::SplitSeqV2>& aopt,
+                       bfs::path& outputDirectory,
+                       CFreqMapT& freqCounter);
+template
 int salmonHashQuantify(AlevinOpts<apt::QuartzSeq2>& aopt,
                        bfs::path& outputDirectory,
                        CFreqMapT& freqCounter);

--- a/src/AlevinUtils.cpp
+++ b/src/AlevinUtils.cpp
@@ -368,7 +368,7 @@ namespace alevin {
                                       std::string& bc){
       (void)read;
 
-      return (read2.length() >= pt.bc1Pos + pt.bcLen) ?
+      return (read2.length() >= pt.bc3Pos + pt.bcLen) ?
         (bc.assign(read2.substr(pt.bc1Pos, pt.bcLen) + read2.substr(pt.bc2Pos, pt.bcLen)
         + read2.substr(pt.bc3Pos, pt.bcLen), 0, pt.barcodeLength), true) : false;
     }
@@ -379,7 +379,7 @@ namespace alevin {
                                       std::string& bc){
       (void)read;
 
-      return (read2.length() >= pt.bc1Pos + pt.bcLen) ?
+      return (read2.length() >= pt.bc3Pos + pt.bcLen) ?
         (bc.assign(read2.substr(pt.bc1Pos, pt.bcLen) + read2.substr(pt.bc2Pos, pt.bcLen)
         + read2.substr(pt.bc3Pos, pt.bcLen), 0, pt.barcodeLength), true) : false;
     }

--- a/src/AlevinUtils.cpp
+++ b/src/AlevinUtils.cpp
@@ -92,6 +92,7 @@ namespace alevin {
       (void)seq;
       return &seq2;
     }
+    template <>
     std::string*  getReadSequence(apt::SplitSeqV2& protocol,
                          std::string& seq,
                          std::string& seq2,
@@ -347,9 +348,11 @@ namespace alevin {
                                       std::string& read2,
                                       apt::SplitSeqV2& pt,
                                       std::string& bc){
-      (void)read2;
-      return (read.length() >= pt.barcodeLength) ?
-        (bc.assign(read, 0, pt.barcodeLength), true) : false;
+      (void)read;
+
+      return (read2.length() >= pt.barcodeLength) ?
+        (bc.assign(read2.substr(pt.bc1Pos, pt.bcLen) + read2.substr(pt.bc2Pos, pt.bcLen)
+        + read2.substr(pt.bc3Pos, pt.bcLen), 0, pt.barcodeLength), true) : false;
     }
     template <>
     bool extractBarcode<apt::Custom>(std::string& read,

--- a/src/AlevinUtils.cpp
+++ b/src/AlevinUtils.cpp
@@ -93,6 +93,14 @@ namespace alevin {
       return &seq2;
     }
     template <>
+    std::string*  getReadSequence(apt::SplitSeqV1& protocol,
+                         std::string& seq,
+                         std::string& seq2,
+                         std::string& subseq){
+      (void)seq2; // fastq2 contains barcode and umi
+      return &seq;
+    }
+    template <>
     std::string*  getReadSequence(apt::SplitSeqV2& protocol,
                          std::string& seq,
                          std::string& seq2,
@@ -186,6 +194,15 @@ namespace alevin {
       (void)read2;
       return (read.length() >= pt.barcodeLength + pt.umiLength) ?
         (umi.assign(read, pt.barcodeLength, pt.umiLength), true) : false;
+    }
+    template <>
+    bool extractUMI<apt::SplitSeqV1>(std::string& read,
+                                     std::string& read2,
+                                     apt::SplitSeqV1& pt,
+                                     std::string& umi){
+      (void)read;
+      return (read2.length() >= pt.barcodeLength + pt.umiLength) ?
+        (umi.assign(read2, 0, pt.umiLength), true) : false;
     }
     template <>
     bool extractUMI<apt::SplitSeqV2>(std::string& read,
@@ -343,6 +360,18 @@ namespace alevin {
       } else {
         return false;
       }
+    }
+    template <>
+    bool extractBarcode<apt::SplitSeqV1>(std::string& read,
+                                      std::string& read2,
+                                      apt::SplitSeqV1& pt,
+                                      std::string& bc){
+      (void)read;
+
+      return (read2.length() >= pt.bc1Pos + pt.bcLen) ?
+        (bc.assign(read2.substr(pt.bc1Pos, pt.bcLen) + read2.substr(pt.bc2Pos, pt.bcLen)
+        + read2.substr(pt.bc3Pos, pt.bcLen), 0, pt.barcodeLength), true) : false;
+    }
     template <>
     bool extractBarcode<apt::SplitSeqV2>(std::string& read,
                                       std::string& read2,
@@ -350,7 +379,7 @@ namespace alevin {
                                       std::string& bc){
       (void)read;
 
-      return (read2.length() >= pt.barcodeLength) ?
+      return (read2.length() >= pt.bc1Pos + pt.bcLen) ?
         (bc.assign(read2.substr(pt.bc1Pos, pt.bcLen) + read2.substr(pt.bc2Pos, pt.bcLen)
         + read2.substr(pt.bc3Pos, pt.bcLen), 0, pt.barcodeLength), true) : false;
     }
@@ -1411,6 +1440,10 @@ namespace alevin {
                            boost::program_options::variables_map& vm);
     template
     bool processAlevinOpts(AlevinOpts<apt::SciSeq3>& aopt,
+                           SalmonOpts& sopt, bool noTgMap,
+                           boost::program_options::variables_map& vm);
+    template
+    bool processAlevinOpts(AlevinOpts<apt::SplitSeqV1>& aopt,
                            SalmonOpts& sopt, bool noTgMap,
                            boost::program_options::variables_map& vm);
     template

--- a/src/AlevinUtils.cpp
+++ b/src/AlevinUtils.cpp
@@ -92,6 +92,13 @@ namespace alevin {
       (void)seq;
       return &seq2;
     }
+    std::string*  getReadSequence(apt::SplitSeqV2& protocol,
+                         std::string& seq,
+                         std::string& seq2,
+                         std::string& subseq){
+      (void)seq2; // fastq2 contains barcode and umi
+      return &seq;
+    }
     template <>
     std::string*  getReadSequence(apt::QuartzSeq2& protocol,
                          std::string& seq,
@@ -178,6 +185,15 @@ namespace alevin {
       (void)read2;
       return (read.length() >= pt.barcodeLength + pt.umiLength) ?
         (umi.assign(read, pt.barcodeLength, pt.umiLength), true) : false;
+    }
+    template <>
+    bool extractUMI<apt::SplitSeqV2>(std::string& read,
+                                     std::string& read2,
+                                     apt::SplitSeqV2& pt,
+                                     std::string& umi){
+      (void)read;
+      return (read2.length() >= pt.barcodeLength + pt.umiLength) ?
+        (umi.assign(read2, 0, pt.umiLength), true) : false;
     }
     template <>
     bool extractUMI<apt::Gemcode>(std::string& read,
@@ -273,8 +289,8 @@ namespace alevin {
     template <>
     bool extractBarcode<apt::CITESeq>(std::string& read,
                                       std::string& read2,
-                                                               apt::CITESeq& pt,
-                                                               std::string& bc){
+                                      apt::CITESeq& pt,
+                                      std::string& bc){
       (void)read2;
       return (read.length() >= pt.barcodeLength) ?
         (bc.assign(read, 0, pt.barcodeLength), true) : false;
@@ -282,8 +298,8 @@ namespace alevin {
     template <>
     bool extractBarcode<apt::ChromiumV3>(std::string& read,
                                          std::string& read2,
-                                                                  apt::ChromiumV3& pt,
-                                                                  std::string& bc){
+                                         apt::ChromiumV3& pt,
+                                         std::string& bc){
       (void)read2;
       return (read.length() >= pt.barcodeLength) ?
         (bc.assign(read,0, pt.barcodeLength), true) : false;
@@ -326,6 +342,14 @@ namespace alevin {
       } else {
         return false;
       }
+    template <>
+    bool extractBarcode<apt::SplitSeqV2>(std::string& read,
+                                      std::string& read2,
+                                      apt::SplitSeqV2& pt,
+                                      std::string& bc){
+      (void)read2;
+      return (read.length() >= pt.barcodeLength) ?
+        (bc.assign(read, 0, pt.barcodeLength), true) : false;
     }
     template <>
     bool extractBarcode<apt::Custom>(std::string& read,
@@ -1384,6 +1408,10 @@ namespace alevin {
                            boost::program_options::variables_map& vm);
     template
     bool processAlevinOpts(AlevinOpts<apt::SciSeq3>& aopt,
+                           SalmonOpts& sopt, bool noTgMap,
+                           boost::program_options::variables_map& vm);
+    template
+    bool processAlevinOpts(AlevinOpts<apt::SplitSeqV2>& aopt,
                            SalmonOpts& sopt, bool noTgMap,
                            boost::program_options::variables_map& vm);
     template

--- a/src/CollapsedCellOptimizer.cpp
+++ b/src/CollapsedCellOptimizer.cpp
@@ -1498,6 +1498,16 @@ template
 bool CollapsedCellOptimizer::optimize(EqMapT& fullEqMap,
                                       spp::sparse_hash_map<uint32_t, uint32_t>& txpToGeneMap,
                                       spp::sparse_hash_map<std::string, uint32_t>& geneIdxMap,
+                                      AlevinOpts<apt::SplitSeqV1>& aopt,
+                                      GZipWriter& gzw,
+                                      std::vector<std::string>& trueBarcodes,
+                                      std::vector<uint32_t>& umiCount,
+                                      CFreqMapT& freqCounter,
+                                      size_t numLowConfidentBarcode);
+template
+bool CollapsedCellOptimizer::optimize(EqMapT& fullEqMap,
+                                      spp::sparse_hash_map<uint32_t, uint32_t>& txpToGeneMap,
+                                      spp::sparse_hash_map<std::string, uint32_t>& geneIdxMap,
                                       AlevinOpts<apt::SplitSeqV2>& aopt,
                                       GZipWriter& gzw,
                                       std::vector<std::string>& trueBarcodes,

--- a/src/CollapsedCellOptimizer.cpp
+++ b/src/CollapsedCellOptimizer.cpp
@@ -1498,6 +1498,16 @@ template
 bool CollapsedCellOptimizer::optimize(EqMapT& fullEqMap,
                                       spp::sparse_hash_map<uint32_t, uint32_t>& txpToGeneMap,
                                       spp::sparse_hash_map<std::string, uint32_t>& geneIdxMap,
+                                      AlevinOpts<apt::SplitSeqV2>& aopt,
+                                      GZipWriter& gzw,
+                                      std::vector<std::string>& trueBarcodes,
+                                      std::vector<uint32_t>& umiCount,
+                                      CFreqMapT& freqCounter,
+                                      size_t numLowConfidentBarcode);
+template
+bool CollapsedCellOptimizer::optimize(EqMapT& fullEqMap,
+                                      spp::sparse_hash_map<uint32_t, uint32_t>& txpToGeneMap,
+                                      spp::sparse_hash_map<std::string, uint32_t>& geneIdxMap,
                                       AlevinOpts<apt::QuartzSeq2>& aopt,
                                       GZipWriter& gzw,
                                       std::vector<std::string>& trueBarcodes,

--- a/src/GZipWriter.cpp
+++ b/src/GZipWriter.cpp
@@ -1889,6 +1889,10 @@ bool GZipWriter::writeEquivCounts<SCExpT, apt::CELSeq2>(
                                                         const AlevinOpts<apt::CELSeq2>& aopts,
                                                         SCExpT& readExp);
 template
+bool GZipWriter::writeEquivCounts<SCExpT, apt::SplitSeqV2>(
+                                                        const AlevinOpts<apt::SplitSeqV2>& aopts,
+                                                        SCExpT& readExp);
+template
 bool GZipWriter::writeEquivCounts<SCExpT, apt::QuartzSeq2>(
                                                         const AlevinOpts<apt::QuartzSeq2>& aopts,
                                                         SCExpT& readExp);
@@ -1924,6 +1928,9 @@ GZipWriter::writeMetaAlevin<apt::CELSeq>(const AlevinOpts<apt::CELSeq>& opts,
                                          boost::filesystem::path aux_dir);
 template bool
 GZipWriter::writeMetaAlevin<apt::CELSeq2>(const AlevinOpts<apt::CELSeq2>& opts,
+                                          boost::filesystem::path aux_dir);
+template bool
+GZipWriter::writeMetaAlevin<apt::SplitSeqV2>(const AlevinOpts<apt::SplitSeqV2>& opts,
                                           boost::filesystem::path aux_dir);
 template bool
 GZipWriter::writeMetaAlevin<apt::QuartzSeq2>(const AlevinOpts<apt::QuartzSeq2>& opts,

--- a/src/GZipWriter.cpp
+++ b/src/GZipWriter.cpp
@@ -1889,6 +1889,10 @@ bool GZipWriter::writeEquivCounts<SCExpT, apt::CELSeq2>(
                                                         const AlevinOpts<apt::CELSeq2>& aopts,
                                                         SCExpT& readExp);
 template
+bool GZipWriter::writeEquivCounts<SCExpT, apt::SplitSeqV1>(
+                                                        const AlevinOpts<apt::SplitSeqV1>& aopts,
+                                                        SCExpT& readExp);
+template
 bool GZipWriter::writeEquivCounts<SCExpT, apt::SplitSeqV2>(
                                                         const AlevinOpts<apt::SplitSeqV2>& aopts,
                                                         SCExpT& readExp);
@@ -1928,6 +1932,9 @@ GZipWriter::writeMetaAlevin<apt::CELSeq>(const AlevinOpts<apt::CELSeq>& opts,
                                          boost::filesystem::path aux_dir);
 template bool
 GZipWriter::writeMetaAlevin<apt::CELSeq2>(const AlevinOpts<apt::CELSeq2>& opts,
+                                          boost::filesystem::path aux_dir);
+template bool
+GZipWriter::writeMetaAlevin<apt::SplitSeqV1>(const AlevinOpts<apt::SplitSeqV1>& opts,
                                           boost::filesystem::path aux_dir);
 template bool
 GZipWriter::writeMetaAlevin<apt::SplitSeqV2>(const AlevinOpts<apt::SplitSeqV2>& opts,

--- a/src/ProgramOptionsGenerator.cpp
+++ b/src/ProgramOptionsGenerator.cpp
@@ -411,6 +411,9 @@ namespace salmon {
        "celseq2", po::bool_switch()->default_value(alevin::defaults::isCELSeq2),
        "Use CEL-Seq2 Single Cell protocol for the library.")
       (
+       "splitseqV1", po::bool_switch()->default_value(alevin::defaults::isSplitSeqV1),
+       "Use Split-SeqV1 Single Cell protocol for the library.")
+      (
        "splitseqV2", po::bool_switch()->default_value(alevin::defaults::isSplitSeqV2),
        "Use Split-SeqV2 Single Cell protocol for the library.")
       (

--- a/src/ProgramOptionsGenerator.cpp
+++ b/src/ProgramOptionsGenerator.cpp
@@ -411,6 +411,9 @@ namespace salmon {
        "celseq2", po::bool_switch()->default_value(alevin::defaults::isCELSeq2),
        "Use CEL-Seq2 Single Cell protocol for the library.")
       (
+       "splitseqV2", po::bool_switch()->default_value(alevin::defaults::isSplitSeqV2),
+       "Use Split-SeqV2 Single Cell protocol for the library.")
+      (
        "quartzseq2", po::bool_switch()->default_value(alevin::defaults::isQuartzSeq2),
        "Use Quartz-Seq2 v3.2 Single Cell protocol for the library assumes 15 length barcode and 8 length UMI.")
       (

--- a/src/SalmonAlevin.cpp
+++ b/src/SalmonAlevin.cpp
@@ -3139,6 +3139,19 @@ alevinQuant(AlevinOpts<apt::CELSeq2>& aopt, SalmonOpts& sopt,
             std::unique_ptr<SalmonIndex>& salmonIndex);
 
 template int
+alevin_sc_align(AlevinOpts<apt::SplitSeqV2>& aopt, SalmonOpts& sopt,
+                boost::program_options::parsed_options& orderedOptions,
+                std::unique_ptr<SalmonIndex>& salmonIndex);
+template int
+alevinQuant(AlevinOpts<apt::SplitSeqV2>& aopt, SalmonOpts& sopt,
+            SoftMapT& barcodeMap, TrueBcsT& trueBarcodes,
+            spp::sparse_hash_map<uint32_t, uint32_t>& txpToGeneMap,
+            spp::sparse_hash_map<std::string, uint32_t>& geneIdxMap,
+            boost::program_options::parsed_options& orderedOptions,
+            CFreqMapT& freqCounter, size_t numLowConfidentBarcode,
+            std::unique_ptr<SalmonIndex>& salmonIndex);
+
+template int
 alevin_sc_align(AlevinOpts<apt::QuartzSeq2>& aopt, SalmonOpts& sopt,
                 boost::program_options::parsed_options& orderedOptions,
                 std::unique_ptr<SalmonIndex>& salmonIndex);

--- a/src/SalmonAlevin.cpp
+++ b/src/SalmonAlevin.cpp
@@ -3139,6 +3139,19 @@ alevinQuant(AlevinOpts<apt::CELSeq2>& aopt, SalmonOpts& sopt,
             std::unique_ptr<SalmonIndex>& salmonIndex);
 
 template int
+alevin_sc_align(AlevinOpts<apt::SplitSeqV1>& aopt, SalmonOpts& sopt,
+                boost::program_options::parsed_options& orderedOptions,
+                std::unique_ptr<SalmonIndex>& salmonIndex);
+template int
+alevinQuant(AlevinOpts<apt::SplitSeqV1>& aopt, SalmonOpts& sopt,
+            SoftMapT& barcodeMap, TrueBcsT& trueBarcodes,
+            spp::sparse_hash_map<uint32_t, uint32_t>& txpToGeneMap,
+            spp::sparse_hash_map<std::string, uint32_t>& geneIdxMap,
+            boost::program_options::parsed_options& orderedOptions,
+            CFreqMapT& freqCounter, size_t numLowConfidentBarcode,
+            std::unique_ptr<SalmonIndex>& salmonIndex);
+
+template int
 alevin_sc_align(AlevinOpts<apt::SplitSeqV2>& aopt, SalmonOpts& sopt,
                 boost::program_options::parsed_options& orderedOptions,
                 std::unique_ptr<SalmonIndex>& salmonIndex);

--- a/src/WhiteList.cpp
+++ b/src/WhiteList.cpp
@@ -284,6 +284,10 @@ namespace alevin {
                                       std::vector<std::string>& trueBarcodes,
                                       bool useRibo, bool useMito,
                                       size_t numLowConfidentBarcode);
+    template bool performWhitelisting(AlevinOpts<alevin::protocols::SplitSeqV1>& aopt,
+                                      std::vector<std::string>& trueBarcodes,
+                                      bool useRibo, bool useMito,
+                                      size_t numLowConfidentBarcode);
     template bool performWhitelisting(AlevinOpts<alevin::protocols::SplitSeqV2>& aopt,
                                       std::vector<std::string>& trueBarcodes,
                                       bool useRibo, bool useMito,

--- a/src/WhiteList.cpp
+++ b/src/WhiteList.cpp
@@ -284,6 +284,10 @@ namespace alevin {
                                       std::vector<std::string>& trueBarcodes,
                                       bool useRibo, bool useMito,
                                       size_t numLowConfidentBarcode);
+    template bool performWhitelisting(AlevinOpts<alevin::protocols::SplitSeqV2>& aopt,
+                                      std::vector<std::string>& trueBarcodes,
+                                      bool useRibo, bool useMito,
+                                      size_t numLowConfidentBarcode);
     template bool performWhitelisting(AlevinOpts<alevin::protocols::QuartzSeq2>& aopt,
                                       std::vector<std::string>& trueBarcodes,
                                       bool useRibo, bool useMito,


### PR DESCRIPTION
This PR addresses issue #699. To use the protocol, pass the `--splitseqV2` or `--splitseqV1` flag. To test the implementation correlation analysis was done on [data](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE137941) submitted with the [article](https://www.sciencedirect.com/science/article/pii/S1934590920300552). Thanks @jeremymsimon for pointing to the data. Here are the results of correlation b/w the alevin output and published counts. This test run was done as mentioned in [here](https://github.com/COMBINE-lab/salmon/issues/699#issuecomment-988185505).

![image](https://user-images.githubusercontent.com/12998572/145128352-6efe899a-ea06-49bf-9223-24ad4ba70223.png)

```
> summary(cr)
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
 0.2966  0.7128  0.8690  0.8163  0.9448  0.9963 
```
