### PR TITLE
Performance fix: don't let boost promote doubles to long doubles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     # If we have libc++, then try and use it
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag(-stdlib=libc++ HAVE_LIBCPP)
-    if(HAVE_LIBCPP)
+    if(HAVE_LIBCPP AND NOT USE_ARM)
       message("It appears that you're compiling with clang and that libc++ is available, so I'll use that")
       list(APPEND TGT_COMPILE_FLAGS -stdlib=libc++)
       set(BOOST_TOOLSET "clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,9 @@ else()
   message(FATAL_ERROR "Your C++ compiler does not support C++14.")
 endif()
 
+
+list(APPEND TGT_COMPILE_FLAGS -DBOOST_MATH_PROMOTE_DOUBLE_POLICY=false)
+
 if(DO_QUIET_MAKE)
   set(QUIET_MAKE "--silent")
 else()

--- a/include/CollapsedCellOptimizer.hpp
+++ b/include/CollapsedCellOptimizer.hpp
@@ -1,6 +1,10 @@
 #ifndef COLLAPSED_CELL_OPTIMIZER_HPP
 #define COLLAPSED_CELL_OPTIMIZER_HPP
 
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
 #include <unordered_map>
 #include <unordered_set>
 #include <functional>

--- a/include/Sampler.hpp
+++ b/include/Sampler.hpp
@@ -8,6 +8,10 @@ extern "C" {
 #undef min
 }
 
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
 // for cpp-format
 #include "spdlog/fmt/fmt.h"
 #include "spdlog/spdlog.h"

--- a/include/Sampler.hpp
+++ b/include/Sampler.hpp
@@ -8,9 +8,7 @@ extern "C" {
 #undef min
 }
 
-#if defined(__aarch64__) or defined(__arm64__)
 #define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-#endif
 
 // for cpp-format
 #include "spdlog/fmt/fmt.h"

--- a/src/CollapsedCellOptimizer.cpp
+++ b/src/CollapsedCellOptimizer.cpp
@@ -1,5 +1,10 @@
 #include <assert.h>
 #include <random>
+
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
 #include <boost/math/distributions/gamma.hpp>
 
 #include "CollapsedCellOptimizer.hpp"

--- a/src/CollapsedCellOptimizer.cpp
+++ b/src/CollapsedCellOptimizer.cpp
@@ -1,9 +1,7 @@
 #include <assert.h>
 #include <random>
 
-#if defined(__aarch64__) or defined(__arm64__)
 #define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-#endif
 
 #include <boost/math/distributions/gamma.hpp>
 

--- a/src/CollapsedEMOptimizer.cpp
+++ b/src/CollapsedEMOptimizer.cpp
@@ -3,6 +3,10 @@
 #include <vector>
 #include <exception>
 
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
 #include "oneapi/tbb/task_arena.h"
 #include "oneapi/tbb/blocked_range.h"
 #include "oneapi/tbb/parallel_for.h"

--- a/src/CollapsedEMOptimizer.cpp
+++ b/src/CollapsedEMOptimizer.cpp
@@ -3,9 +3,7 @@
 #include <vector>
 #include <exception>
 
-#if defined(__aarch64__) or defined(__arm64__)
 #define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-#endif
 
 #include "oneapi/tbb/task_arena.h"
 #include "oneapi/tbb/blocked_range.h"

--- a/src/CollapsedGibbsSampler.cpp
+++ b/src/CollapsedGibbsSampler.cpp
@@ -15,6 +15,10 @@
 #include "oneapi/tbb/partitioner.h"
 
 //#include "fastapprox.h"
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
 #include <boost/filesystem.hpp>
 #include <boost/math/distributions/gamma.hpp>
 #include <boost/math/special_functions/digamma.hpp>

--- a/src/CollapsedGibbsSampler.cpp
+++ b/src/CollapsedGibbsSampler.cpp
@@ -15,9 +15,7 @@
 #include "oneapi/tbb/partitioner.h"
 
 //#include "fastapprox.h"
-#if defined(__aarch64__) or defined(__arm64__)
 #define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-#endif
 
 #include <boost/filesystem.hpp>
 #include <boost/math/distributions/gamma.hpp>

--- a/src/FragmentLengthDistribution.cpp
+++ b/src/FragmentLengthDistribution.cpp
@@ -7,9 +7,7 @@
  *  Modified 2014, 2015, 2016, 2017 by Rob Patro.
  */
 
-#if defined(__aarch64__) or defined(__arm64__)
 #define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-#endif
 
 #include "FragmentLengthDistribution.hpp"
 #include "SalmonMath.hpp"

--- a/src/FragmentLengthDistribution.cpp
+++ b/src/FragmentLengthDistribution.cpp
@@ -7,6 +7,10 @@
  *  Modified 2014, 2015, 2016, 2017 by Rob Patro.
  */
 
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
 #include "FragmentLengthDistribution.hpp"
 #include "SalmonMath.hpp"
 #include "SalmonUtils.hpp"

--- a/src/FragmentStartPositionDistribution.cpp
+++ b/src/FragmentStartPositionDistribution.cpp
@@ -6,6 +6,11 @@
  * Rob Patro; 2014, 2015
  */
 
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
+
 #include "FragmentStartPositionDistribution.hpp"
 #include "SalmonMath.hpp"
 #include <boost/assign.hpp>

--- a/src/FragmentStartPositionDistribution.cpp
+++ b/src/FragmentStartPositionDistribution.cpp
@@ -6,9 +6,7 @@
  * Rob Patro; 2014, 2015
  */
 
-#if defined(__aarch64__) or defined(__arm64__)
 #define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-#endif
 
 
 #include "FragmentStartPositionDistribution.hpp"

--- a/src/ONTAlignmentModel.cpp
+++ b/src/ONTAlignmentModel.cpp
@@ -3,9 +3,7 @@
 #include <map>
 #include <tuple>
 
-#if defined(__aarch64__) or defined(__arm64__)
 #define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-#endif
 
 #include <boost/config.hpp> // for BOOST_LIKELY/BOOST_UNLIKELY
 #include <boost/math/distributions/binomial.hpp>

--- a/src/ONTAlignmentModel.cpp
+++ b/src/ONTAlignmentModel.cpp
@@ -3,6 +3,10 @@
 #include <map>
 #include <tuple>
 
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
 #include <boost/config.hpp> // for BOOST_LIKELY/BOOST_UNLIKELY
 #include <boost/math/distributions/binomial.hpp>
 #include <boost/math/distributions/geometric.hpp>

--- a/src/SalmonQuantifyAlignments.cpp
+++ b/src/SalmonQuantifyAlignments.cpp
@@ -1,7 +1,5 @@
 
-#if defined(__aarch64__) or defined(__arm64__)
 #define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-#endif
 
 extern "C" {
 #include "io_lib/os.h"

--- a/src/SalmonQuantifyAlignments.cpp
+++ b/src/SalmonQuantifyAlignments.cpp
@@ -1,4 +1,8 @@
 
+#if defined(__aarch64__) or defined(__arm64__)
+#define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+#endif
+
 extern "C" {
 #include "io_lib/os.h"
 #include "io_lib/scram.h"


### PR DESCRIPTION
This fix resolves performance issue where Boost::math unnecessarily promotes doubles to long double, which is not fully supported by hardware leading to slow-downs.

The change is to set a define during cmake process which prevents promotion ( -DBOOST_MATH_PROMOTE_DOUBLE_POLICY=false )