### PR TITLE
Performance fix: don't let boost promote doubles to long doubles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,9 @@ else()
   message(FATAL_ERROR "Your C++ compiler does not support C++14.")
 endif()
 
+
+list(APPEND TGT_COMPILE_FLAGS -DBOOST_MATH_PROMOTE_DOUBLE_POLICY=false)
+
 if(DO_QUIET_MAKE)
   set(QUIET_MAKE "--silent")
 else()


### PR DESCRIPTION
Fixes #966 
This fix resolves performance issue where Boost::math unnecessarily promotes doubles to long double, which is not fully supported by hardware leading to slow-downs.

The change is to set a define during cmake process which prevents promotion ( -DBOOST_MATH_PROMOTE_DOUBLE_POLICY=false )