### PR TITLE
fix(quant): include fragment-length probability in equivalence-class weights

### DIFF
--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -397,21 +397,62 @@ fn record(
         }
     }
 
-    let mut pairs: Vec<(u32, f64)> = compat.iter().map(|(m, w)| (m.tid, *w)).collect();
-
-    // Observe a fragment length from the best concordant compatible pair.
-    let best_concordant = maps
+    // Fold the fragment-length probability into the equivalence-class weight.
+    // salmon's eq-class auxProb is `logFragProb + logFragCov + logAlignCompatProb`
+    // (SalmonQuantify.cpp) -- i.e. it includes the FLD term but NOT the
+    // start-position term (that enters only the abundance/`aln.logProb`; the
+    // effective-length factor is applied separately in `update_eff_lengths`).
+    // The port previously built the eq-class weight from the bare coverage
+    // weight, flattening it for paralogs/isoforms whose implied insert size
+    // differs and coarsening the range-factorized classes. The FLD term is only
+    // applied once the auxiliary model is trained (after `pre_burnin` fragments),
+    // matching salmon's `numPreAuxModelSamples` gating.
+    let use_aux = sh.num_processed.load(Ordering::Relaxed) >= sh.pre_burnin;
+    let mut pairs: Vec<(u32, f64)> = compat
         .iter()
-        .filter(|m| {
-            m.status == MateStatus::PairedEndPaired
-                && m.fragment_len > 0
-                && sh
-                    .expected_format
-                    .is_none_or(|exp| is_compatible(exp, m.format, m.is_fw, m.status))
+        .map(|(m, w)| {
+            let log_frag_prob = if m.status == MateStatus::PairedEndPaired && m.fragment_len > 0 {
+                if use_aux {
+                    sh.fld.pmf(m.fragment_len as usize)
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
+            (m.tid, *w * log_frag_prob.exp())
         })
-        .max_by(|a, b| a.weight.total_cmp(&b.weight));
+        .collect();
+
+    // Observe a fragment length from the best concordant compatible pair,
+    // weighted by that pair's posterior confidence among the concordant pairs.
+    // salmon trains its FLD stochastically (it accepts an alignment with
+    // probability proportional to exp(aln.logProb)), so ambiguous multimappers
+    // contribute little; adding every best pair at full weight overdisperses the
+    // FLD on paralog/near-duplicate-rich inputs. Down-weighting by confidence is
+    // the deterministic analog.
+    let mut conc_sum = 0.0_f64;
+    let mut best_concordant: Option<&ScoredMapping> = None;
+    for m in maps.iter() {
+        if m.status == MateStatus::PairedEndPaired
+            && m.fragment_len > 0
+            && sh
+                .expected_format
+                .is_none_or(|exp| is_compatible(exp, m.format, m.is_fw, m.status))
+        {
+            conc_sum += m.weight;
+            if best_concordant.is_none_or(|b| m.weight > b.weight) {
+                best_concordant = Some(m);
+            }
+        }
+    }
     if let Some(best) = best_concordant {
-        sh.fld.add_val(best.fragment_len as usize, 0.0);
+        let conf = if conc_sum > 0.0 {
+            best.weight / conc_sum
+        } else {
+            1.0
+        };
+        sh.fld.add_val(best.fragment_len as usize, conf.ln());
     }
 
     // Build the equivalence class: sorted, de-duplicated transcript ids + weights.


### PR DESCRIPTION
## Summary

Include the fragment-length-distribution (FLD) probability in the selective-alignment **equivalence-class weights**, and train the FLD weighted by per-fragment confidence. This closes most of a small per-transcript quantification gap vs C++ salmon on multimapping transcripts.

## Root cause

The SA eq-class weights were built from the bare coverage weight, omitting the FLD term that salmon folds into its per-fragment auxProb:

```
// SalmonQuantify.cpp
double auxProb = logFragProb + logFragCov + logAlignCompatProb;   // <- logFragProb (FLD) was missing in the port
```

The missing FLD term flattened the conditional weights for paralogs/isoforms whose implied insert size differs, coarsening the range-factorized equivalence classes and slightly degrading how multimapping reads are split. A secondary issue: the port trained its FLD by adding every best-pair length at full weight (vs salmon's probability-weighted, burn-in-limited stochastic training), overdispersing the FLD on near-duplicate-rich inputs.

## Changes (`crates/salmon-quant/src/processor.rs`)

1. Fold `fld.pmf(fragment_len)` into the eq-class weight. Matches salmon's auxProb composition (FLD + coverage); the start-position term is intentionally **excluded** because effective length is applied separately in `update_eff_lengths` (including it would double-count). Gated on `pre_burnin` to mirror salmon's `numPreAuxModelSamples`.
2. Train the FLD weighted by each fragment's best-pair posterior confidence — a deterministic analog of salmon's stochastic training — so ambiguous multimappers no longer overdisperse it.

## Validation (vs C++ salmon 1.12.0)

**Polyester ground truth** (human, 193,760 txps; per-transcript Spearman, expressed):

| sim / mode | C++ | Rust before | Rust after | gap closed |
|---|--:|--:|--:|--:|
| easy / VBEM | 0.8696 | 0.8534 | 0.8671 | 85% |
| easy / useEM | 0.8916 | 0.8756 | 0.8904 | 93% |
| hard / VBEM | 0.8485 | 0.8292 | 0.8479 | 97% |
| hard / useEM | 0.8770 | 0.8564 | 0.8761 | 96% |

**Real-data 36M GEUVADIS C++ parity:** NumReads Pearson 0.9986 → **0.9995**, Spearman 0.9645 → **0.9706**. Bias path (`--gcBias --seqBias`) also improved (0.9958 → 0.9984 Pearson), no drift.

**No regressions:** mapping rate identical; 36M wall within noise; sample_data parity intact (0.9999); fmt + clippy clean.

## Residual (follow-up)

A small **systematic** residual remains (~0.0026 Spearman on easy/VBEM; ~18σ above run-to-run noise, so real, not arbitrary tie-breaking). Decomposition:
- It is *not* eq-class granularity (post-fix Rust is actually finer, 424k vs 410k classes).
- It is Rust leaking ~0.03–0.04% of reads onto true-zero near-duplicates. Part of it is VBEM sparsity (C++ drives true-zero near-dups to zero slightly harder; the lean shrinks under `--useEM`), and part is a small base weight/binning difference that survives under plain EM.
- **Not** `logAlignCompatProb`: both the polyester sim and the GEUVADIS data are unstranded (IU, 100% compatible), so that term is log(1)=0 in both tools and already matches. The base residual is in the coverage-weight / range-factorization-binning interaction (~0.03% of reads), tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
