### PR TITLE
fix(quant): parallelize bias-corrected effective-length estimation and skip decoys

### DIFF
--- a/crates/salmon-model/src/bias.rs
+++ b/crates/salmon-model/src/bias.rs
@@ -8,7 +8,7 @@
 //! with the conditional fragment-length distribution.
 
 use crate::gcbias::{GcContext, GcFragModel, GcView};
-use crate::posbias::{length_class_index, SimplePosBias, NUM_LENGTH_CLASSES};
+use crate::posbias::{length_class_index, SimplePosBias, NUM_LENGTH_CLASSES, NUM_POS_BINS};
 use crate::seqbias::{
     conditional_cdf, log_bias, revcomp_bytes, SBModel, CONTEXT_LEFT, CONTEXT_LENGTH, MIN_ALPHA,
     MIN_CDF_MASS,
@@ -223,7 +223,7 @@ pub fn corrected_effective_length_full(
 /// reverse density = fragments that can end here). Models are finalized.
 #[allow(clippy::too_many_arguments)]
 pub fn build_expected_pos<FL>(
-    num_refs: usize,
+    num_targets: usize,
     ref_len_of: FL,
     alphas: &[f64],
     eff_lens: &[f64],
@@ -232,49 +232,149 @@ pub fn build_expected_pos<FL>(
     k: usize,
 ) -> (Vec<SimplePosBias>, Vec<SimplePosBias>)
 where
-    FL: Fn(usize) -> usize,
+    FL: Fn(usize) -> usize + Sync,
 {
-    let mut pos5: Vec<SimplePosBias> = (0..NUM_LENGTH_CLASSES)
-        .map(|_| SimplePosBias::default())
-        .collect();
-    let mut pos3: Vec<SimplePosBias> = (0..NUM_LENGTH_CLASSES)
-        .map(|_| SimplePosBias::default())
-        .collect();
-    for tid in 0..num_refs {
-        if alphas[tid] < MIN_ALPHA || eff_lens[tid] <= 0.0 {
-            continue;
-        }
-        let ref_len = ref_len_of(tid) as i32;
-        if (ref_len as usize) <= k {
-            continue;
-        }
-        let unprocessed = ref_len - eff_lens[tid] as i32;
-        if unprocessed <= 0 {
-            continue;
-        }
-        let cdf_max_arg = (cdf.len() - 1).min(ref_len as usize);
-        let cdf_max_val = cdf[cdf_max_arg];
-        if cdf_max_val < MIN_CDF_MASS {
-            continue;
-        }
-        let weight = alphas[tid] / eff_lens[tid];
-        let lc = length_class_index(quantiles, ref_len as u32);
-        let cond = |x: i32| conditional_cdf(cdf, cdf_max_arg, cdf_max_val, x);
-        for frag_start in 0..(ref_len - k as i32) {
-            let max_fw = ref_len - frag_start + 1;
-            let max_rc = frag_start;
-            let density_fw = cond(max_fw);
-            let density_rc = cond(max_rc);
-            if weight * density_fw > EPSILON {
-                pos5[lc].add_mass(frag_start, ref_len, (weight * density_fw).ln());
-            }
-            if weight * density_rc > EPSILON {
-                pos3[lc].add_mass(frag_start, ref_len, (weight * density_rc).ln());
-            }
-        }
+    use rayon::prelude::*;
+    type Partials = (Vec<SimplePosBias>, Vec<SimplePosBias>);
+    // Per-transcript contributions are independent, each an O(refLen) sweep;
+    // salmon parallelizes this expected-pos accumulation over transcripts and so
+    // do we. Per-thread partials use `new_empty` (masses at -inf, the `log_add`
+    // identity, carrying *no* pseudocount) so the fold/reduce merge via `combine`
+    // is associative; the single `log(1)` pseudocount salmon seeds each bin with
+    // is injected once at the end (combine into a `default()` model). `ref_len_of`
+    // must be `Sync` to share across threads. `num_targets` excludes decoys (the
+    // contiguous tail), which are never expressed and never contribute.
+    fn empty() -> Partials {
+        (
+            (0..NUM_LENGTH_CLASSES)
+                .map(|_| SimplePosBias::new_empty(NUM_POS_BINS))
+                .collect(),
+            (0..NUM_LENGTH_CLASSES)
+                .map(|_| SimplePosBias::new_empty(NUM_POS_BINS))
+                .collect(),
+        )
     }
-    for m in pos5.iter_mut().chain(pos3.iter_mut()) {
-        m.finalize();
+    let (sum5, sum3) = (0..num_targets)
+        .into_par_iter()
+        .fold(empty, |mut acc, tid| {
+            if alphas[tid] < MIN_ALPHA || eff_lens[tid] <= 0.0 {
+                return acc;
+            }
+            let ref_len = ref_len_of(tid) as i32;
+            if (ref_len as usize) <= k {
+                return acc;
+            }
+            let unprocessed = ref_len - eff_lens[tid] as i32;
+            if unprocessed <= 0 {
+                return acc;
+            }
+            let cdf_max_arg = (cdf.len() - 1).min(ref_len as usize);
+            let cdf_max_val = cdf[cdf_max_arg];
+            if cdf_max_val < MIN_CDF_MASS {
+                return acc;
+            }
+            let weight = alphas[tid] / eff_lens[tid];
+            let lc = length_class_index(quantiles, ref_len as u32);
+            let cond = |x: i32| conditional_cdf(cdf, cdf_max_arg, cdf_max_val, x);
+            for frag_start in 0..(ref_len - k as i32) {
+                let max_fw = ref_len - frag_start + 1;
+                let max_rc = frag_start;
+                let density_fw = cond(max_fw);
+                let density_rc = cond(max_rc);
+                if weight * density_fw > EPSILON {
+                    acc.0[lc].add_mass(frag_start, ref_len, (weight * density_fw).ln());
+                }
+                if weight * density_rc > EPSILON {
+                    acc.1[lc].add_mass(frag_start, ref_len, (weight * density_rc).ln());
+                }
+            }
+            acc
+        })
+        .reduce(empty, |mut a, b| {
+            for (x, y) in a.0.iter_mut().zip(&b.0) {
+                x.combine(y);
+            }
+            for (x, y) in a.1.iter_mut().zip(&b.1) {
+                x.combine(y);
+            }
+            a
+        });
+
+    // Inject the single per-bin `log(1)` pseudocount salmon seeds each bin with
+    // (`SimplePosBias::default`) by merging the raw observed log-sums into it,
+    // then finalize. An empty bin (sum at -inf) collapses to exactly `log(1)`,
+    // matching the serial accumulation.
+    let seed = |sums: Vec<SimplePosBias>| -> Vec<SimplePosBias> {
+        sums.into_iter()
+            .map(|s| {
+                let mut m = SimplePosBias::default();
+                m.combine(&s);
+                m.finalize();
+                m
+            })
+            .collect()
+    };
+    (seed(sum5), seed(sum3))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::posbias::compute_length_quantiles;
+    use crate::seqbias::fld_cdf_and_bounds;
+
+    type PosModels = (Vec<SimplePosBias>, Vec<SimplePosBias>);
+
+    fn mass_diff(a: &PosModels, b: &PosModels) -> f64 {
+        a.0.iter()
+            .chain(a.1.iter())
+            .zip(b.0.iter().chain(b.1.iter()))
+            .map(|(pa, pb)| {
+                pa.masses()
+                    .iter()
+                    .zip(pb.masses())
+                    .map(|(x, y)| (x - y).abs())
+                    .sum::<f64>()
+            })
+            .sum()
     }
-    (pos5, pos3)
+
+    #[test]
+    fn build_expected_pos_respects_num_targets_bound() {
+        // Five 200 nt transcripts plus a 400 nt "decoy". The decoy must change the
+        // expected positional model only when `num_targets` includes it; a zeroed
+        // alpha must skip it either way.
+        let lens = [200usize, 200, 200, 200, 200, 400];
+        let num_refs = lens.len();
+        let alphas = vec![1.0; num_refs];
+        let eff_lens = vec![150.0; num_refs];
+        let mut pmf = vec![0.0; 200];
+        pmf[100] = 1.0;
+        let (cdf, _lo, _hi) = fld_cdf_and_bounds(&pmf);
+        let qlens: Vec<u32> = lens.iter().map(|&l| l as u32).collect();
+        let quantiles = compute_length_quantiles(&qlens, NUM_LENGTH_CLASSES);
+        let k = 1usize;
+
+        let exclude = build_expected_pos(5, |t| lens[t], &alphas, &eff_lens, &cdf, &quantiles, k);
+        let include = build_expected_pos(6, |t| lens[t], &alphas, &eff_lens, &cdf, &quantiles, k);
+        assert!(exclude
+            .0
+            .iter()
+            .chain(exclude.1.iter())
+            .all(|p| p.masses().iter().all(|v| v.is_finite())));
+        let diff = mass_diff(&exclude, &include);
+        assert!(
+            diff > 1e-9,
+            "a target beyond num_targets must not contribute (diff={diff})"
+        );
+
+        let mut alphas0 = alphas.clone();
+        alphas0[5] = 0.0;
+        let include0 = build_expected_pos(6, |t| lens[t], &alphas0, &eff_lens, &cdf, &quantiles, k);
+        let diff2 = mass_diff(&exclude, &include0);
+        assert!(
+            diff2 < 1e-9,
+            "zero-alpha target must not contribute (diff={diff2})"
+        );
+    }
 }

--- a/crates/salmon-model/src/gcbias.rs
+++ b/crates/salmon-model/src/gcbias.rs
@@ -496,7 +496,7 @@ impl GcContext {
 /// fragment lengths ([`GC_SAMP_STRIDE`]).
 #[allow(clippy::too_many_arguments)]
 pub fn build_expected_gc<'a, FS, FP>(
-    num_refs: usize,
+    num_targets: usize,
     seq_of: FS,
     view_of: FP,
     alphas: &[f64],
@@ -559,7 +559,7 @@ where
         }
         Some(model)
     };
-    (0..num_refs)
+    (0..num_targets)
         .into_par_iter()
         .fold(
             || GcFragModel::new(cond_bins, gc_bins),

--- a/crates/salmon-model/src/posbias.rs
+++ b/crates/salmon-model/src/posbias.rs
@@ -66,6 +66,21 @@ impl SimplePosBias {
         }
     }
 
+    /// A model with masses at `log(0) = -inf` — the true [`log_add`] identity, so
+    /// it carries *no* pseudocount. Used as the per-thread accumulator when
+    /// building an expected model in parallel: partials accumulate pure observed
+    /// log-mass and merge associatively via [`combine`](Self::combine); the single
+    /// `log(1)` pseudocount is then injected once by combining into a [`new`](Self::new)
+    /// (or [`default`](Self::default)) model.
+    pub fn new_empty(num_bins: usize) -> Self {
+        Self {
+            num_bins,
+            masses: vec![f64::NEG_INFINITY; num_bins],
+            finalized: false,
+            spline: None,
+        }
+    }
+
     /// Add `mass` (log space) to bin `bin`.
     #[inline]
     pub fn add_mass_bin(&mut self, bin: usize, mass: f64) {

--- a/crates/salmon-model/src/seqbias.rs
+++ b/crates/salmon-model/src/seqbias.rs
@@ -244,46 +244,76 @@ pub(crate) fn conditional_cdf(cdf: &[f64], cdf_max_arg: usize, cdf_max_val: f64,
 /// mass that can start there (`conditionalCDF(maxFragLen)`), matching salmon's
 /// expected-model construction in `updateEffectiveLengths`.
 pub fn build_expected<'a, F>(
-    num_refs: usize,
+    num_targets: usize,
     seq_of: F,
     alphas: &[f64],
     eff_lens: &[f64],
     cdf: &[f64],
 ) -> (SBModel, SBModel)
 where
-    F: Fn(usize) -> &'a [u8],
+    F: Fn(usize) -> &'a [u8] + Sync,
 {
+    use rayon::prelude::*;
     let k = CONTEXT_LENGTH;
     let cu = CONTEXT_LEFT as i32;
-    let mut exp_fw = SBModel::new();
-    let mut exp_rc = SBModel::new();
-    for tid in 0..num_refs {
+    // Each expressed transcript contributes independently to the expected
+    // forward/RC context counts, an O(refLen) sweep per transcript. salmon
+    // parallelizes this over transcripts; do the same with rayon (per-thread
+    // `SBModel` partials reduced via `combine_counts`). `seq_of` must be `Sync`
+    // to share across threads (it is: a closure over the index). `num_targets`
+    // excludes decoys (the contiguous tail): decoys are never expressed and so
+    // contribute nothing, but skipping them outright guarantees no O(refLen)
+    // decoy sweep can ever run.
+    let per_tid = |tid: usize| -> Option<(SBModel, SBModel)> {
         if alphas[tid] < MIN_ALPHA || eff_lens[tid] <= 0.0 {
-            continue;
+            return None;
         }
         let seq = seq_of(tid);
         let ref_len = seq.len();
         if ref_len < k {
-            continue;
+            return None;
         }
         let cdf_max_arg = (cdf.len() - 1).min(ref_len);
         let cdf_max_val = cdf[cdf_max_arg];
         if cdf_max_val < MIN_CDF_MASS {
-            continue;
+            return None;
         }
         let weight = alphas[tid] / eff_lens[tid];
         let rc = revcomp_bytes(seq);
+        let mut fw = SBModel::new();
+        let mut rc_m = SBModel::new();
         // fragStartPos in 0..(refLen - K) (salmon's loop bound)
         for frag_start in 0..(ref_len - k) {
             let max_frag_len = ref_len as i32 - (frag_start as i32 + cu);
             if max_frag_len >= 0 && (max_frag_len as usize) < ref_len {
                 let cdensity = conditional_cdf(cdf, cdf_max_arg, cdf_max_val, max_frag_len);
                 let w = weight * cdensity;
-                exp_fw.add_context(&seq[frag_start..frag_start + k], false, w);
-                exp_rc.add_context(&rc[frag_start..frag_start + k], false, w);
+                fw.add_context(&seq[frag_start..frag_start + k], false, w);
+                rc_m.add_context(&rc[frag_start..frag_start + k], false, w);
             }
         }
-    }
+        Some((fw, rc_m))
+    };
+    let (mut exp_fw, mut exp_rc) = (0..num_targets)
+        .into_par_iter()
+        .fold(
+            || (SBModel::new(), SBModel::new()),
+            |mut acc, tid| {
+                if let Some((fw, rc_m)) = per_tid(tid) {
+                    acc.0.combine_counts(&fw);
+                    acc.1.combine_counts(&rc_m);
+                }
+                acc
+            },
+        )
+        .reduce(
+            || (SBModel::new(), SBModel::new()),
+            |mut a, b| {
+                a.0.combine_counts(&b.0);
+                a.1.combine_counts(&b.1);
+                a
+            },
+        );
     exp_fw.normalize();
     exp_rc.normalize();
     (exp_fw, exp_rc)
@@ -489,5 +519,60 @@ mod tests {
             })
             .collect();
         assert_eq!(SBModel::encode(&ctx, true), SBModel::encode(&rc, false));
+    }
+
+    #[test]
+    fn build_expected_respects_num_targets_bound() {
+        // Five real transcripts plus a sixth "decoy" with a very distinctive
+        // composition (poly-AC). The decoy must influence the expected model only
+        // when `num_targets` includes it, and must be skipped (cheaply) when its
+        // alpha is zero — the two ways decoys are kept out of the bias models.
+        let bases = b"ACGTACGTAGGCCTTAACCGGTTACGTACGT";
+        let mut refs: Vec<Vec<u8>> = (0..5)
+            .map(|s| (0..200).map(|i| bases[(i + s) % bases.len()]).collect())
+            .collect();
+        refs.push(
+            (0..400)
+                .map(|i| if i % 2 == 0 { b'A' } else { b'C' })
+                .collect(),
+        );
+        let num_refs = refs.len();
+        let alphas = vec![1.0; num_refs];
+        let eff_lens = vec![150.0; num_refs];
+        let mut pmf = vec![0.0; 200];
+        pmf[100] = 1.0;
+        let (cdf, _lo, _hi) = fld_cdf_and_bounds(&pmf);
+
+        // Exclude the decoy (num_targets = 5) vs include it (num_targets = 6).
+        let (a_fw, _) = build_expected(5, |t| refs[t].as_slice(), &alphas, &eff_lens, &cdf);
+        let (b_fw, _) = build_expected(6, |t| refs[t].as_slice(), &alphas, &eff_lens, &cdf);
+        assert!(a_fw.is_trained() && b_fw.is_trained());
+        assert!(a_fw.dump().iter().all(|v| v.is_finite()));
+        let diff: f64 = a_fw
+            .dump()
+            .iter()
+            .zip(b_fw.dump())
+            .map(|(x, y)| (x - y).abs())
+            .sum();
+        assert!(
+            diff > 1e-6,
+            "a target beyond num_targets must not contribute (diff={diff})"
+        );
+
+        // With the decoy's alpha zeroed the MIN_ALPHA guard skips it, so including
+        // it (num_targets = 6) must match excluding it (num_targets = 5).
+        let mut alphas0 = alphas.clone();
+        alphas0[5] = 0.0;
+        let (c_fw, _) = build_expected(6, |t| refs[t].as_slice(), &alphas0, &eff_lens, &cdf);
+        let diff2: f64 = a_fw
+            .dump()
+            .iter()
+            .zip(c_fw.dump())
+            .map(|(x, y)| (x - y).abs())
+            .sum();
+        assert!(
+            diff2 < 1e-9,
+            "zero-alpha target must not contribute (diff={diff2})"
+        );
     }
 }

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -543,6 +543,11 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     let mut bias_dump = BiasDump::default();
     if bias_on && !opts.skip_quant {
         use rayon::prelude::*;
+        // Expected-bias models are built only over quantification targets: decoys
+        // (the contiguous tail at `first_decoy_index`) are never expressed and so
+        // contribute nothing, but a decoy chromosome would otherwise hand one
+        // rayon worker an O(ref_len) sweep over hundreds of Mbp. See issue #1019.
+        let num_targets = salmon.info().first_decoy_index.unwrap_or(num_refs);
         let pmf_lin: Vec<f64> = log_pmf.iter().map(|lp| lp.exp()).collect();
         let (fld_cdf, fld_low, fld_high) = salmon_model::seqbias::fld_cdf_and_bounds(&pmf_lin);
         // K excludes the leading sequence context only when seq-correcting.
@@ -558,7 +563,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             obs_fw.normalize();
             obs_rc.normalize();
             let (exp_fw, exp_rc) = salmon_model::build_expected(
-                num_refs,
+                num_targets,
                 |t| salmon.ref_seq(t as u32),
                 &em.alphas,
                 &eff_lengths,
@@ -578,7 +583,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         let gc_ratio_model = if let Some(m) = gcbias_obs {
             let mut obs = m.into_inner().unwrap();
             let mut exp = salmon_model::build_expected_gc(
-                num_refs,
+                num_targets,
                 |t| salmon.ref_seq(t as u32),
                 |t| store.unwrap().view(t),
                 &em.alphas,
@@ -613,7 +618,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
                 x.finalize();
             }
             let (exp_fw, exp_rc) = salmon_model::build_expected_pos(
-                num_refs,
+                num_targets,
                 |t| salmon.ref_len(t) as usize,
                 &em.alphas,
                 &eff_lengths,


### PR DESCRIPTION
## Summary

Fixes #1019: with `--seqBias` and/or `--gcBias`, the `estimating abundances` phase pinned a single core and never completed on large indexes. For comparison, the reporter measured C++ salmon 1.12.0 completing their original sample (a private ~36.6M fragment-pair dataset) with the same flags in ~2.75 min; that figure is from the issue and is a different dataset than the public reproducer below, which was not separately timed for 1.12.0.

## Root cause

Bias correction builds three "expected" background models from the burn-in abundance estimate. Only one of the three was parallelized:

| function | status before |
| --- | --- |
| `build_expected` (seqBias) | single-threaded `for tid in 0..num_refs` |
| `build_expected_pos` (posBias) | single-threaded `for tid in 0..num_refs` |
| `build_expected_gc` (gcBias) | already parallel |

Each is an O(total transcriptome length) sweep, so the serial ones dominate the abundance phase on a large target set. The reporter confirmed the stall reproduces even on a decoy-free transcriptome (~250k targets), which isolates single-threadedness (not decoy handling) as the load-bearing bug. Separately, building the expected models over `0..num_refs` includes decoy references; decoys are never expressed (the burn-in EM drives their alpha to 0, and the `MIN_ALPHA` guard already skips them), but a decoy chromosome slipping through would hand one rayon worker an O(ref_len) sweep over hundreds of Mbp.

## Fix

Three commits, one per change:

1. **perf(model): parallelize expected sequence-bias model construction** - rayon `fold`/`reduce` over transcripts with per-thread `SBModel` partials merged via the existing `combine_counts` (associative with `SBModel::new()` as identity), mirroring `build_expected_gc`.
2. **perf(model): parallelize expected positional-bias model construction** - same pattern. Positional masses are log-space, where `log_add`'s identity is `-inf` rather than `log(1)`, so per-thread partials use a new `SimplePosBias::new_empty` (no pseudocount) and the single per-bin pseudocount is injected once at the end. This reproduces the serial accumulation exactly (an empty bin still collapses to `log(1)`).
3. **fix(quant): exclude decoy references from expected bias models** - bound all three builds to quantification targets via `num_targets = first_decoy_index` (decoys are always the contiguous tail). Parity-preserving, since a decoy's weight `alpha/effLen` is ~0.

The global rayon pool is already sized by `-p`, so the parallel sweeps scale with the requested thread count automatically.

## Tests

- New unit tests in `seqbias.rs` and `bias.rs` assert the `num_targets` bound is respected (a target beyond it does not contribute) and that a zero-alpha target is skipped either way.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --release` all pass on the pinned toolchain (1.91.1).

## Verification on the issue's public reproducer

The Ensembl r115 decoy-aware index + Himes airway `SRR1039508`, run with `-p 12 --seqBias --gcBias`, should now complete (write `quant.sf`) and use all threads during `estimating abundances`, where it previously hung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)