### PR TITLE
feat(model): order-independent FLD accumulation (parallel determinism, stage 2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tracing",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/crates/salmon-model/src/fld.rs
+++ b/crates/salmon-model/src/fld.rs
@@ -12,7 +12,7 @@
 use salmon_core::atomic::AtomicF64;
 use salmon_core::math::{log_add, LOG_0, LOG_EPSILON};
 use statrs::distribution::{Binomial, ContinuousCDF, Discrete, Normal};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 /// Tracks the observed distribution of fragment lengths.
@@ -24,12 +24,24 @@ pub struct FragmentLengthDistribution {
     hist: Vec<AtomicF64>,
     /// logged total observed mass (including pseudo-counts)
     tot_mass: AtomicF64,
-    /// logged sum of length*mass, for fast mean computation
-    sum: AtomicF64,
     /// minimum observed length (bin units)
     min: AtomicUsize,
     /// internal bin size
     bin_size: usize,
+
+    /// Order-independent observation counter (one per length bin). [`add_val`]
+    /// increments this in addition to spreading the kernel into `hist`. Because
+    /// every observation contributes the *same* kernel (`add_val(len, 0.0)`), the
+    /// trained histogram is exactly `prior + Σ_bin counts[bin]·kernel`, which the
+    /// deterministic reads-mode paths ([`refresh_online`](Self::refresh_online),
+    /// [`cache`](Self::cache), [`mean`](Self::mean)) rebuild from these counts in a
+    /// fixed bin order — independent of how observations were interleaved across
+    /// worker threads. The live `hist`/`tot_mass`/`sum` accumulation is retained
+    /// for the alignment-mode live `pmf` reads, which do not require determinism.
+    counts: Vec<AtomicU64>,
+    /// linear-space prior mass per bin (the initial `hist` before any
+    /// observation), captured once at construction for the deterministic rebuild.
+    prior_lin: Vec<f64>,
 
     /// cached normalized PMF, valid once [`cache`](Self::cache) is called
     cached_pmf: Vec<f64>,
@@ -89,7 +101,6 @@ impl FragmentLengthDistribution {
 
         let tot = alpha.ln();
         let hist: Vec<AtomicF64>;
-        let mut sum = LOG_0;
         let mut tot_mass;
 
         if prior_mu > 0.0 {
@@ -108,7 +119,6 @@ impl FragmentLengthDistribution {
                     LOG_EPSILON
                 };
                 slot.store(mass);
-                sum = log_add(sum, (i as f64).ln() + mass);
                 tot_mass = log_add(tot_mass, mass);
             }
         } else {
@@ -116,8 +126,6 @@ impl FragmentLengthDistribution {
             let per = tot - (max_val as f64).ln();
             hist = (0..=max_val).map(|_| AtomicF64::new(per)).collect();
             hist[0].store(LOG_0);
-            let h1 = hist.get(1).map(|a| a.load()).unwrap_or(per);
-            sum = h1 + ((max_val * (max_val + 1)) as f64).ln() - 2.0_f64.ln();
             tot_mass = tot;
         }
 
@@ -125,13 +133,19 @@ impl FragmentLengthDistribution {
         let binom = Binomial::new(kernel_p, kernel_n as u64).expect("valid binomial kernel");
         let kernel: Vec<f64> = (0..=kernel_n).map(|i| binom.pmf(i as u64).ln()).collect();
 
+        // Linear-space prior (the initial histogram) and a zeroed observation
+        // counter per bin, for the deterministic rebuild.
+        let prior_lin: Vec<f64> = hist.iter().map(|a| a.load().exp()).collect();
+        let counts: Vec<AtomicU64> = (0..hist.len()).map(|_| AtomicU64::new(0)).collect();
+
         Self {
             kernel,
             hist,
             tot_mass: AtomicF64::new(tot_mass),
-            sum: AtomicF64::new(sum),
             min: AtomicUsize::new(max_val),
             bin_size,
+            counts,
+            prior_lin,
             cached_pmf: Vec::new(),
             cached_cmf: Vec::new(),
             have_cache: false,
@@ -170,6 +184,11 @@ impl FragmentLengthDistribution {
         }
         self.min.fetch_min(len, Ordering::Relaxed);
 
+        // Order-independent count for the deterministic rebuild. Every quant/align
+        // observation is a unit count (`mass == 0.0`); the rebuild assumes that.
+        debug_assert_eq!(mass, 0.0, "deterministic rebuild assumes unit observations");
+        self.counts[len].fetch_add(1, Ordering::Relaxed);
+
         let half = self.kernel.len() / 2;
         // offset can go negative conceptually; use isize math then bound-check.
         let mut offset = len as isize - half as isize;
@@ -178,11 +197,44 @@ impl FragmentLengthDistribution {
                 let o = offset as usize;
                 let k_mass = mass + k;
                 self.hist[o].log_add_assign(k_mass);
-                self.sum.log_add_assign((o as f64).ln() + k_mass);
                 self.tot_mass.log_add_assign(k_mass);
             }
             offset += 1;
         }
+    }
+
+    /// Deterministically rebuild the linear-space histogram from the prior plus
+    /// the order-independent observation counts: `lin[o] = prior_lin[o] +
+    /// Σ_bin counts[bin]·kernel_lin[o − bin + half]`, accumulated in a fixed bin
+    /// order so the result does not depend on thread interleaving. Returns the
+    /// per-bin log-mass and the log total. Used by the reads-mode snapshot /
+    /// cache / mean paths so their outputs are byte-identical across thread
+    /// counts.
+    fn counts_hist(&self) -> (Vec<f64>, f64) {
+        let n = self.hist.len();
+        let mut lin = self.prior_lin.clone();
+        let kernel_lin: Vec<f64> = self.kernel.iter().map(|k| k.exp()).collect();
+        let half = self.kernel.len() / 2;
+        for bin in 0..n {
+            let c = self.counts[bin].load(Ordering::Relaxed);
+            if c == 0 {
+                continue;
+            }
+            let cf = c as f64;
+            for (kidx, &kl) in kernel_lin.iter().enumerate() {
+                let offset = bin as isize - half as isize + kidx as isize;
+                if offset > 0 && (offset as usize) < n {
+                    lin[offset as usize] += cf * kl;
+                }
+            }
+        }
+        let log_hist: Vec<f64> = lin
+            .iter()
+            .map(|&m| if m > 0.0 { m.ln() } else { LOG_0 })
+            .collect();
+        let tot: f64 = lin.iter().sum();
+        let log_tot = if tot > 0.0 { tot.ln() } else { LOG_0 };
+        (log_hist, log_tot)
     }
 
     /// Logged probability of observing a fragment of length `len`.
@@ -213,22 +265,25 @@ impl FragmentLengthDistribution {
         }
         let max_raw = self.max_val();
         let max_v = max_raw / self.bin_size;
-        let tot = self.tot_mass.load();
+        // Rebuild from the order-independent counts (not the live `hist`), so the
+        // snapshot a fragment reads is byte-identical regardless of how
+        // observations were interleaved across worker threads.
+        let (log_hist, tot) = self.counts_hist();
         // Per-bin cumulative mass (matches `cmf()`), so the snapshot CMF at raw
         // index `raw` equals `cmf(raw)`. Built first, then both the PMF and CMF
-        // snapshots are expanded over raw indices from the same `tot` read so
-        // they are mutually consistent.
+        // snapshots are expanded over raw indices from the same `tot` so they are
+        // mutually consistent.
         let mut bin_cum = Vec::with_capacity(max_v + 1);
         let mut cum = LOG_0;
         for b in 0..=max_v {
-            cum = log_add(cum, self.hist[b].load() - tot);
+            cum = log_add(cum, log_hist[b] - tot);
             bin_cum.push(cum);
         }
         let mut v = Vec::with_capacity(max_raw + 1);
         let mut c = Vec::with_capacity(max_raw + 1);
         for raw in 0..=max_raw {
             let l = (raw / self.bin_size).min(max_v);
-            v.push(self.hist[l].load() - tot);
+            v.push(log_hist[l] - tot);
             c.push(bin_cum[l]);
         }
         *self.online_pmf.write().unwrap() = Arc::new(v);
@@ -279,9 +334,21 @@ impl FragmentLengthDistribution {
         self.tot_mass.load()
     }
 
-    /// Mean observed length.
+    /// Mean observed length (in bin units, matching the historical
+    /// `sum/tot_mass` ratio). Computed from the order-independent counts so the
+    /// reported `frag_len_mean` is byte-identical across thread counts.
     pub fn mean(&self) -> f64 {
-        (self.sum.load() - self.tot_mass.load()).exp()
+        let (log_hist, log_tot) = self.counts_hist();
+        let mut s = 0.0;
+        for (bin, &lh) in log_hist.iter().enumerate() {
+            s += (bin as f64) * lh.exp();
+        }
+        let tot = log_tot.exp();
+        if tot > 0.0 {
+            s / tot
+        } else {
+            0.0
+        }
     }
 
     /// Standard deviation of the observed length distribution, computed from the
@@ -310,11 +377,16 @@ impl FragmentLengthDistribution {
             return;
         }
         let max_v = self.max_val();
-        // normalized PMF over [0, max_v]
+        // Build from the order-independent counts (not the live `hist`) so the
+        // cached PMF/CMF — and therefore the effective lengths derived from it —
+        // are byte-identical regardless of thread count.
+        let (log_hist, log_tot) = self.counts_hist();
+        let max_bin = log_hist.len() - 1;
+        // un-normalized log-PMF over [0, max_v] (raw indices, binned like `pmf`)
         let mut pmf = Vec::with_capacity(max_v + 1);
         let mut tot = LOG_0;
         for i in 0..=max_v {
-            let p = self.pmf(i);
+            let p = log_hist[(i / self.bin_size).min(max_bin)] - log_tot;
             pmf.push(p);
             tot = log_add(tot, p);
         }
@@ -448,6 +520,48 @@ mod tests {
         let fld = FragmentLengthDistribution::new(1000.0, 1000, 250.0, 25.0, 4, 0.5, 1);
         let m = fld.mean();
         assert!((m - 250.0).abs() < 5.0, "mean {m} not near 250");
+    }
+
+    #[test]
+    fn accumulation_is_order_independent() {
+        // The trained distribution must be byte-identical regardless of the order
+        // in which observations arrive (i.e. how they were interleaved across
+        // worker threads). Same multiset of lengths, two different orders.
+        let lengths_fwd: Vec<usize> = (0..2000).map(|i| 150 + (i * 7) % 500).collect();
+        let mut lengths_rev = lengths_fwd.clone();
+        lengths_rev.reverse();
+        let mut lengths_shuf = lengths_fwd.clone();
+        // deterministic shuffle (no Math.random; index-driven swaps)
+        for i in 0..lengths_shuf.len() {
+            let j = (i.wrapping_mul(2654435761)) % lengths_shuf.len();
+            lengths_shuf.swap(i, j);
+        }
+
+        let build = |order: &[usize]| {
+            let mut fld = FragmentLengthDistribution::new(1.0, 1000, 0.0, 0.0, 4, 0.5, 1);
+            for &l in order {
+                fld.add_val(l, 0.0);
+            }
+            // exercise the online snapshot path too
+            fld.refresh_online();
+            let snap = fld.online_snapshot().as_ref().clone();
+            let mean = fld.mean();
+            fld.cache();
+            (fld.log_pmf().to_vec(), fld.cached_cmf.clone(), snap, mean)
+        };
+
+        let (pmf_f, cmf_f, snap_f, mean_f) = build(&lengths_fwd);
+        let (pmf_r, cmf_r, snap_r, mean_r) = build(&lengths_rev);
+        let (pmf_s, cmf_s, snap_s, mean_s) = build(&lengths_shuf);
+
+        assert_eq!(pmf_f, pmf_r, "cached PMF differs by insertion order (rev)");
+        assert_eq!(pmf_f, pmf_s, "cached PMF differs by insertion order (shuf)");
+        assert_eq!(cmf_f, cmf_r, "cached CMF differs by insertion order (rev)");
+        assert_eq!(cmf_f, cmf_s, "cached CMF differs by insertion order (shuf)");
+        assert_eq!(snap_f, snap_r, "online snapshot differs by insertion order");
+        assert_eq!(snap_f, snap_s, "online snapshot differs by insertion order");
+        assert_eq!(mean_f.to_bits(), mean_r.to_bits(), "mean differs by order");
+        assert_eq!(mean_f.to_bits(), mean_s.to_bits(), "mean differs by order");
     }
 
     #[test]

--- a/crates/salmon-quant/Cargo.toml
+++ b/crates/salmon-quant/Cargo.toml
@@ -17,6 +17,7 @@ salmon-eqclass = { workspace = true }
 salmon-infer = { workspace = true }
 piscem-rs = { workspace = true }
 paraseq = "0.4"
+xxhash-rust = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -236,22 +236,45 @@ fn frag_log_prob(
     }
 }
 
-thread_local! {
-    /// Per-thread PRNG state for stochastic FLD-sample acceptance (mirrors
-    /// salmon's per-thread RNG used when training the fragment-length model).
-    static FLD_RNG: std::cell::Cell<u64> = const { std::cell::Cell::new(0x2545_F491_4F6C_DD1D) };
+/// Deterministic per-fragment acceptance sampler for stochastic FLD training.
+///
+/// salmon trains the fragment-length distribution online by accepting each
+/// concordant mapping's length with probability equal to its abundance-aware
+/// posterior. The previous port drew that acceptance coin from a *thread-local*
+/// PRNG, so which fragments trained the FLD depended on how the reads happened to
+/// be distributed across worker threads — the documented source of multi-threaded
+/// run-to-run wobble. Seeding instead from the read's own identity makes the
+/// acceptance decision a pure function of `(read_id, mapping_index, posterior)`,
+/// so the *set* of fragments training the FLD is identical regardless of thread
+/// count or fragment-arrival order. The draw for mapping `i` is derived directly
+/// from `(seed, i)` (not from a sequential stream), so it is independent of how
+/// many earlier mappings of the same fragment were concordant.
+#[derive(Clone, Copy)]
+struct FldSampler {
+    seed: u64,
 }
 
-/// Draw a pseudo-random value in `[0, 1)` from the per-thread xorshift state.
-fn fld_rng_u01() -> f64 {
-    FLD_RNG.with(|s| {
-        let mut x = s.get();
-        x ^= x << 13;
-        x ^= x >> 7;
-        x ^= x << 17;
-        s.set(x);
-        ((x >> 11) as f64) * (1.0 / ((1u64 << 53) as f64))
-    })
+impl FldSampler {
+    /// Seed from the stable fragment name (the full read id bytes). xxh3 is the
+    /// workspace hash already used for eq-class labels. The `| 1` keeps the seed
+    /// nonzero for any input (including an empty id).
+    fn for_read(read_id: &[u8]) -> Self {
+        FldSampler {
+            seed: xxhash_rust::xxh3::xxh3_64(read_id) | 1,
+        }
+    }
+
+    /// A pseudo-random value in `[0, 1)` for compatible-mapping index `i`,
+    /// derived statelessly from `(seed, i)` via the splitmix64 finalizer.
+    fn u01(&self, i: usize) -> f64 {
+        let mut z = self
+            .seed
+            .wrapping_add((i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        ((z >> 11) as f64) * (1.0 / ((1u64 << 53) as f64))
+    }
 }
 
 /// Collect the orientation-aware 5'/3' sequence-bias contexts for one mapping,
@@ -355,6 +378,7 @@ fn collect_pos(
 /// inference is active).
 fn record(
     sh: &Shared,
+    read_id: &[u8],
     maps: &[ScoredMapping],
     log_fm: f64,
     seqbias: Option<&mut (SBModel, SBModel)>,
@@ -577,11 +601,17 @@ fn record(
     // pair at full weight, which overdisperses it). Frozen after the training
     // window (`online_post` is `None`).
     if let Some(post) = &online_post {
+        // Seed the acceptance sampler from the fragment's own identity, so the
+        // set of fragments that train the FLD is independent of which worker
+        // thread processed this fragment (the documented source of multi-threaded
+        // run-to-run wobble). Computed once per fragment, only inside the
+        // training window.
+        let sampler = FldSampler::for_read(read_id);
         for (i, (m, _)) in compat.iter().enumerate() {
             let conc = m.status == MateStatus::PairedEndPaired
                 && m.fragment_len > 0
                 && expected.is_none_or(|exp| is_compatible(exp, m.format, m.is_fw, m.status));
-            if conc && fld_rng_u01() < post[i] {
+            if conc && sampler.u01(i) < post[i] {
                 sh.fld.add_val(m.fragment_len as usize, 0.0);
             }
         }
@@ -753,6 +783,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             }
             record(
                 &sh,
+                r1.id(),
                 &maps,
                 log_fm,
                 seqbias.as_mut(),
@@ -843,6 +874,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             }
             record(
                 &sh,
+                rec.id(),
                 &maps,
                 log_fm,
                 seqbias.as_mut(),
@@ -876,6 +908,80 @@ fn flush_sam(proc: &mut QuantProcessor) {
         if !proc.sam_buf.is_empty() {
             let _ = sw.write_block(&proc.sam_buf);
             proc.sam_buf.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reproduce the FLD-acceptance rule exactly: accept mapping `i` iff
+    /// `u01(i) < post[i]`, evaluating the indices in the given `order`.
+    fn accepts(read_id: &[u8], posts: &[f64], order: &[usize]) -> Vec<bool> {
+        let s = FldSampler::for_read(read_id);
+        let mut out = vec![false; posts.len()];
+        for &i in order {
+            out[i] = s.u01(i) < posts[i];
+        }
+        out
+    }
+
+    #[test]
+    fn fld_acceptance_is_order_and_thread_independent() {
+        let read_id = b"SRR1039508.frag_0042";
+        // Mix certain-accept (1.0), certain-reject (0.0), and middling probs so
+        // the decision actually depends on the draws.
+        let posts = [1.0, 0.0, 0.5, 0.5, 0.0, 1.0, 0.3, 0.7, 0.9, 0.1];
+
+        let forward: Vec<usize> = (0..posts.len()).collect();
+        let mut reversed = forward.clone();
+        reversed.reverse();
+        let shuffled = [3usize, 7, 0, 9, 1, 5, 8, 2, 6, 4];
+
+        let a = accepts(read_id, &posts, &forward);
+        let b = accepts(read_id, &posts, &reversed);
+        let c = accepts(read_id, &posts, &shuffled);
+
+        // The accept decision for index i is a pure function of (read_id, i,
+        // post[i]); permuting evaluation order (i.e. thread scheduling) must not
+        // change any decision.
+        assert_eq!(a, b, "acceptance must not depend on evaluation order");
+        assert_eq!(a, c, "acceptance must not depend on evaluation order");
+
+        // post == 1.0 always accepts, post == 0.0 never accepts (u01 in [0,1)).
+        assert!(a[0] && a[5]);
+        assert!(!a[1] && !a[4]);
+    }
+
+    #[test]
+    fn fld_sampler_is_deterministic_and_seed_robust() {
+        // Same id -> identical draws (run-to-run determinism).
+        let s1 = FldSampler::for_read(b"frag_x");
+        let s2 = FldSampler::for_read(b"frag_x");
+        for i in 0..16 {
+            assert_eq!(s1.u01(i), s2.u01(i));
+        }
+        // Different ids -> different seeds (no collapse onto a global constant).
+        assert_ne!(
+            FldSampler::for_read(b"frag_a").seed,
+            FldSampler::for_read(b"frag_b").seed
+        );
+        // Empty id is still a usable, nonzero-seeded, in-range stream.
+        let se = FldSampler::for_read(b"");
+        assert_ne!(se.seed, 0);
+        for i in 0..16 {
+            let u = se.u01(i);
+            assert!((0.0..1.0).contains(&u));
+        }
+    }
+
+    #[test]
+    fn fld_u01_in_unit_interval() {
+        let s = FldSampler::for_read(b"range_check");
+        for i in 0..10_000 {
+            let u = s.u01(i);
+            assert!((0.0..1.0).contains(&u), "u01({i}) = {u} out of [0,1)");
         }
     }
 }

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -180,6 +180,37 @@ fn selective_alignment_quantification_tracks_truth() {
 }
 
 #[test]
+fn quant_is_byte_identical_across_thread_counts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2, _truth) = simulate(tmp.path());
+
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let run = |threads: usize, tag: &str| {
+        let out = tmp.path().join(format!("quant_{tag}"));
+        let mut opts = QuantOptions::new(idx_dir.clone(), out.clone());
+        opts.mates1 = vec![r1.clone()];
+        opts.mates2 = vec![r2.clone()];
+        opts.lib_type = "IU".to_string();
+        opts.num_threads = threads;
+        quantify(&opts).expect("quantify");
+        std::fs::read_to_string(out.join("quant.sf")).unwrap()
+    };
+
+    let p1 = run(1, "p1");
+    let p4a = run(4, "p4a");
+    let p4b = run(4, "p4b");
+
+    // Multi-threaded runs must be byte-identical to each other and to the
+    // single-threaded run (no thread-scheduling-dependent drift).
+    assert_eq!(p4a, p4b, "two -p 4 runs differ");
+    assert_eq!(p1, p4a, "-p 1 and -p 4 differ");
+}
+
+#[test]
 fn pseudoalignment_quantification_tracks_truth() {
     let tmp = tempfile::tempdir().unwrap();
     let (fasta, r1, r2, truth) = simulate(tmp.path());


### PR DESCRIPTION
## What

Make the fragment-length-distribution (FLD) training **order-independent**, so the trained FLD, the effective lengths derived from it, and (with stage 1) the resulting `quant.sf` are byte-identical regardless of `-p N`. This is **stage 2a** of the parallel-determinism follow-up.

> Stacks on #1027 (stage 1). The first commit here is #1027's; it disappears once that merges.

## Why

The FLD was trained by spreading a binomial kernel into a shared log-space histogram with lock-free `log_add_assign` CAS loops. Log-space addition is not associative, so concurrent observations committed in a thread-scheduling-dependent order left the trained histogram (and the effective lengths / online snapshots derived from it) differing in the low bits run-to-run.

## Change

`crates/salmon-model/src/fld.rs`:
- Every observation contributes the *same* kernel (`add_val(len, 0.0)`), so the trained histogram is exactly `prior + Σ_bin counts[bin]·kernel`. Add an order-independent per-bin observation counter (`counts: Vec<AtomicU64>`) and a `counts_hist()` that rebuilds the histogram from `prior + counts` in a fixed bin order.
- The deterministic reads-mode paths (`refresh_online`, `cache`, `mean`) now derive from `counts_hist()` instead of the live histogram, so the per-fragment online snapshot, the cached PMF/CMF (hence effective lengths), and `frag_len_mean` are byte-identical regardless of observation interleaving.
- The live `hist`/`tot_mass` log accumulation is kept for the alignment-mode (`-a`) live `pmf` reads, which do not require determinism. The previously write-only `sum` field is dropped (mean now derives from the counts).

## Scope / honest claim

Combined with stage 1, this makes `-p N` `quant.sf` byte-identical for datasets within the auxiliary-model burn-in window (the common case; default `numPreAuxModelSamples` = 5M fragments), where eq-class weights are score-only. The remaining sources for *all* dataset sizes and for bias-corrected runs (after-burn-in eq-class-weight snapshot timing, fractional multimapping eq-class weight summation order, and the bias online-mass accumulation) are addressed by stage 2b (a fixed-order reduction).

Accuracy is unchanged: the trained distribution is identical, only its accumulation order is fixed.

## Testing

- `fld.rs` unit test `accumulation_is_order_independent`: the cached PMF/CMF, the online snapshot, and the mean are byte-identical when the same multiset of lengths is added in forward / reversed / shuffled order. (Fails before this change — `log_add_assign` is not associative.)
- `quant_end_to_end.rs` test `quant_is_byte_identical_across_thread_counts`: build an index, quantify the same reads at `-p 1` and `-p 4` (twice), assert `quant.sf` byte-identical.
- `cargo test -p salmon-model -p salmon-quant -p salmon-align`: green. `cargo fmt --all --check`: clean. `cargo clippy` on the changed crate: no new findings (one pre-existing `explicit_counter_loop` in `add_val`, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
