### PR TITLE
feat(quant): opt-in --deterministic two-pass inference (full -p N reproducibility)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tracing",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -568,6 +568,13 @@ struct QuantArgs {
     /// salmon's default is 1000000, this port's is 5000.)
     #[arg(long = "numPreAuxModelSamples", default_value_t = 5000)]
     num_pre_aux_model_samples: u64,
+    /// Produce byte-for-byte identical `quant.sf` regardless of thread count
+    /// (`-p`). Splits quantification into a parallel mapping pass and a
+    /// single-threaded, key-sorted inference pass, so every order-dependent
+    /// accumulation is reproducible. Costs some memory (mapped fragments are held
+    /// between passes) and serializes the inference phase; off by default.
+    #[arg(long = "deterministic")]
+    deterministic: bool,
     /// [accepted; not yet implemented] disable fragment-length-distribution
     /// concordance in the per-fragment probability.
     #[arg(long = "noFragLengthDist")]
@@ -893,6 +900,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.cond_gc_bins = args.conditional_gc_bins;
     opts.skip_quant = args.skip_quant;
     opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples;
+    opts.deterministic = args.deterministic;
     opts.map_config.seed_mode = seed_mode(args.unimems, args.refmems, args.sparse_seeds);
     // alignment scoring (selective alignment)
     opts.map_config.align.match_score = args.ma as i8;

--- a/crates/salmon-eqclass/src/lib.rs
+++ b/crates/salmon-eqclass/src/lib.rs
@@ -12,6 +12,8 @@
 //! into a flat [`CollapsedEqClasses`] for inference.
 
 use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 use xxhash_rust::xxh3::Xxh3;
 
 /// The label of an equivalence class: the sorted set of transcript ids a
@@ -211,12 +213,38 @@ impl TGValue {
     }
 }
 
-/// Concurrent equivalence-class builder backed by `scc::HashMap`.
+/// One fragment's contribution to an equivalence class, retained with a stable
+/// per-fragment key so the per-class weight sum is reduced in a deterministic,
+/// thread-count-independent order (see [`EquivalenceClassBuilder::finish`]).
+pub struct Contribution {
+    /// stable per-fragment sort key (e.g. a hash of the read name); ties on the
+    /// transcript label are broken by this key so the reduction order is fixed.
+    pub key: u128,
+    pub group: TranscriptGroup,
+    pub weights: Vec<f64>,
+    pub count: u64,
+}
+
+/// Number of buffer shards (a power of two) the builder spreads contributions
+/// across to bound lock contention during the concurrent mapping phase.
+const SHARDS: usize = 64;
+
+/// Concurrent equivalence-class builder.
 ///
-/// Worker threads call [`add_group`](Self::add_group) with `&self` while
-/// mapping reads; insertion is lock-free per bucket.
+/// Worker threads call [`add_group_keyed`](Self::add_group_keyed) with `&self`
+/// while mapping reads; each fragment's contribution is appended to a key-sharded
+/// buffer (low contention) rather than summed in place. [`finish`](Self::finish)
+/// then groups the contributions by class and **sums each class's weights in a
+/// fixed order** (sorted by the transcript label, ties broken by the per-fragment
+/// key), so the result is byte-identical regardless of how fragments were
+/// distributed across threads. (Summing floats in arrival order — the previous
+/// `DashMap` accumulation — is not associative and drifted run-to-run for
+/// multimapping classes.)
 pub struct EquivalenceClassBuilder {
-    map: dashmap::DashMap<TranscriptGroup, TGValue, IdentityBuildHasher>,
+    shards: Vec<Mutex<Vec<Contribution>>>,
+    /// fallback monotonic key source for [`add_group`](Self::add_group) callers
+    /// that have no stable per-fragment key (single-threaded / alignment mode).
+    next_seq: AtomicU64,
 }
 
 impl Default for EquivalenceClassBuilder {
@@ -228,36 +256,72 @@ impl Default for EquivalenceClassBuilder {
 impl EquivalenceClassBuilder {
     pub fn new() -> Self {
         Self {
-            map: dashmap::DashMap::with_hasher(IdentityBuildHasher),
+            shards: (0..SHARDS).map(|_| Mutex::new(Vec::new())).collect(),
+            next_seq: AtomicU64::new(0),
         }
     }
 
-    /// Add one fragment's worth of evidence: the transcript group, its
-    /// per-transcript weights, and a count (usually 1). Thread-safe.
-    pub fn add_group(&self, group: TranscriptGroup, weights: Vec<f64>, count: u64) {
+    /// Add one fragment's evidence with a **stable per-fragment key** (e.g. a
+    /// hash of the read name). The key fixes the per-class weight-summation order
+    /// in [`finish`](Self::finish), making the result thread-count-independent.
+    pub fn add_group_keyed(
+        &self,
+        key: u128,
+        group: TranscriptGroup,
+        weights: Vec<f64>,
+        count: u64,
+    ) {
         debug_assert_eq!(group.txps.len(), weights.len());
-        self.map
-            .entry(group)
-            .and_modify(|v| v.accumulate(&weights, count))
-            .or_insert_with(|| TGValue::new(weights, count));
+        let shard = (key as usize) & (SHARDS - 1);
+        self.shards[shard].lock().unwrap().push(Contribution {
+            key,
+            group,
+            weights,
+            count,
+        });
     }
 
-    /// Number of distinct equivalence classes accumulated so far.
+    /// Add one fragment's evidence without a stable key (single-threaded callers
+    /// and alignment mode); a monotonic sequence number is used as the key.
+    pub fn add_group(&self, group: TranscriptGroup, weights: Vec<f64>, count: u64) {
+        let key = self.next_seq.fetch_add(1, Ordering::Relaxed) as u128;
+        self.add_group_keyed(key, group, weights, count);
+    }
+
+    /// Number of buffered contributions so far (not distinct classes).
     pub fn len(&self) -> usize {
-        self.map.len()
+        self.shards.iter().map(|s| s.lock().unwrap().len()).sum()
     }
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        self.shards.iter().all(|s| s.lock().unwrap().is_empty())
     }
 
-    /// Finalize into a flat, index-stable collection for inference. Classes are
-    /// sorted by their transcript label for determinism.
+    /// Finalize into a flat, index-stable collection for inference. Contributions
+    /// are sorted by `(txps, bins, key)` and consecutive same-class contributions
+    /// are summed in that fixed order, so both the class ordering and the summed
+    /// weights are deterministic.
     pub fn finish(self) -> CollapsedEqClasses {
-        let mut classes: Vec<(TranscriptGroup, TGValue)> = Vec::with_capacity(self.map.len());
-        self.map
-            .iter()
-            .for_each(|e| classes.push((e.key().clone(), e.value().clone())));
-        classes.sort_by(|a, b| a.0.txps.cmp(&b.0.txps));
+        let mut contribs: Vec<Contribution> = Vec::new();
+        for shard in self.shards {
+            contribs.extend(shard.into_inner().unwrap());
+        }
+        contribs.sort_by(|a, b| {
+            a.group
+                .txps
+                .cmp(&b.group.txps)
+                .then_with(|| a.group.bins.cmp(&b.group.bins))
+                .then_with(|| a.key.cmp(&b.key))
+        });
+        let mut classes: Vec<(TranscriptGroup, TGValue)> = Vec::new();
+        for c in contribs {
+            if let Some((g, v)) = classes.last_mut() {
+                if g.txps == c.group.txps && g.bins == c.group.bins {
+                    v.accumulate(&c.weights, c.count);
+                    continue;
+                }
+            }
+            classes.push((c.group, TGValue::new(c.weights, c.count)));
+        }
         let total_count = classes.iter().map(|(_, v)| v.count).sum();
         CollapsedEqClasses {
             classes,
@@ -334,9 +398,9 @@ mod tests {
         b.add_group(TranscriptGroup::new(vec![1, 2]), vec![0.5, 0.5], 1);
         b.add_group(TranscriptGroup::new(vec![2, 1]), vec![0.5, 0.5], 1);
         b.add_group(TranscriptGroup::new(vec![3]), vec![1.0], 1);
-        assert_eq!(b.len(), 2);
 
         let collapsed = b.finish();
+        assert_eq!(collapsed.classes.len(), 2, "two distinct classes");
         assert_eq!(collapsed.total_count, 3);
         // sorted: [1,2] then [3]
         let (g0, v0) = &collapsed.classes[0];
@@ -346,6 +410,38 @@ mod tests {
         let (g1, v1) = &collapsed.classes[1];
         assert_eq!(g1.txps, vec![3]);
         assert_eq!(v1.count, 1);
+    }
+
+    #[test]
+    fn weight_sum_is_insertion_order_independent() {
+        // The per-class weight sum must be byte-identical regardless of the order
+        // fragments were added (how threads interleaved). Plain f64 addition is
+        // not associative, so this fails for arrival-order accumulation and holds
+        // only because `finish` reduces in a fixed key-sorted order.
+        let make = |order: &[usize]| -> Vec<u64> {
+            let b = EquivalenceClassBuilder::new();
+            for &i in order {
+                let key = (i as u128).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+                let w = vec![
+                    1.0 / 3.0 + (i as f64) * 1e-12,
+                    2.0 / 3.0 - (i as f64) * 1e-12,
+                ];
+                b.add_group_keyed(key, TranscriptGroup::new(vec![0, 1]), w, 1);
+            }
+            let c = b.finish();
+            c.classes[0].1.weights.iter().map(|x| x.to_bits()).collect()
+        };
+        let fwd: Vec<usize> = (0..200).collect();
+        let mut rev = fwd.clone();
+        rev.reverse();
+        // 137 is coprime to 200, so this is a permutation.
+        let shuf: Vec<usize> = (0..200).map(|i| (i * 137) % 200).collect();
+        assert_eq!(make(&fwd), make(&rev), "weight sum differs by order (rev)");
+        assert_eq!(
+            make(&fwd),
+            make(&shuf),
+            "weight sum differs by order (shuf)"
+        );
     }
 
     #[test]
@@ -374,7 +470,7 @@ mod tests {
         // a third fragment matching g1's shape merges with it
         let g3 = TranscriptGroup::with_bins(txps, range_factorize_bins(&[0.92, 0.08], 4));
         b.add_group(g3, vec![0.92, 0.08], 1);
-        assert_eq!(b.len(), 2, "expected 2 factorized classes");
+        assert_eq!(b.finish().len(), 2, "expected 2 factorized classes");
     }
 
     #[test]

--- a/crates/salmon-model/src/fld.rs
+++ b/crates/salmon-model/src/fld.rs
@@ -12,7 +12,7 @@
 use salmon_core::atomic::AtomicF64;
 use salmon_core::math::{log_add, LOG_0, LOG_EPSILON};
 use statrs::distribution::{Binomial, ContinuousCDF, Discrete, Normal};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 /// Tracks the observed distribution of fragment lengths.
@@ -24,12 +24,24 @@ pub struct FragmentLengthDistribution {
     hist: Vec<AtomicF64>,
     /// logged total observed mass (including pseudo-counts)
     tot_mass: AtomicF64,
-    /// logged sum of length*mass, for fast mean computation
-    sum: AtomicF64,
     /// minimum observed length (bin units)
     min: AtomicUsize,
     /// internal bin size
     bin_size: usize,
+
+    /// Order-independent observation counter (one per length bin). [`add_val`]
+    /// increments this in addition to spreading the kernel into `hist`. Because
+    /// every observation contributes the *same* kernel (`add_val(len, 0.0)`), the
+    /// trained histogram is exactly `prior + Σ_bin counts[bin]·kernel`, which the
+    /// deterministic reads-mode paths ([`refresh_online`](Self::refresh_online),
+    /// [`cache`](Self::cache), [`mean`](Self::mean)) rebuild from these counts in a
+    /// fixed bin order — independent of how observations were interleaved across
+    /// worker threads. The live `hist`/`tot_mass`/`sum` accumulation is retained
+    /// for the alignment-mode live `pmf` reads, which do not require determinism.
+    counts: Vec<AtomicU64>,
+    /// linear-space prior mass per bin (the initial `hist` before any
+    /// observation), captured once at construction for the deterministic rebuild.
+    prior_lin: Vec<f64>,
 
     /// cached normalized PMF, valid once [`cache`](Self::cache) is called
     cached_pmf: Vec<f64>,
@@ -89,7 +101,6 @@ impl FragmentLengthDistribution {
 
         let tot = alpha.ln();
         let hist: Vec<AtomicF64>;
-        let mut sum = LOG_0;
         let mut tot_mass;
 
         if prior_mu > 0.0 {
@@ -108,7 +119,6 @@ impl FragmentLengthDistribution {
                     LOG_EPSILON
                 };
                 slot.store(mass);
-                sum = log_add(sum, (i as f64).ln() + mass);
                 tot_mass = log_add(tot_mass, mass);
             }
         } else {
@@ -116,8 +126,6 @@ impl FragmentLengthDistribution {
             let per = tot - (max_val as f64).ln();
             hist = (0..=max_val).map(|_| AtomicF64::new(per)).collect();
             hist[0].store(LOG_0);
-            let h1 = hist.get(1).map(|a| a.load()).unwrap_or(per);
-            sum = h1 + ((max_val * (max_val + 1)) as f64).ln() - 2.0_f64.ln();
             tot_mass = tot;
         }
 
@@ -125,13 +133,19 @@ impl FragmentLengthDistribution {
         let binom = Binomial::new(kernel_p, kernel_n as u64).expect("valid binomial kernel");
         let kernel: Vec<f64> = (0..=kernel_n).map(|i| binom.pmf(i as u64).ln()).collect();
 
+        // Linear-space prior (the initial histogram) and a zeroed observation
+        // counter per bin, for the deterministic rebuild.
+        let prior_lin: Vec<f64> = hist.iter().map(|a| a.load().exp()).collect();
+        let counts: Vec<AtomicU64> = (0..hist.len()).map(|_| AtomicU64::new(0)).collect();
+
         Self {
             kernel,
             hist,
             tot_mass: AtomicF64::new(tot_mass),
-            sum: AtomicF64::new(sum),
             min: AtomicUsize::new(max_val),
             bin_size,
+            counts,
+            prior_lin,
             cached_pmf: Vec::new(),
             cached_cmf: Vec::new(),
             have_cache: false,
@@ -170,6 +184,11 @@ impl FragmentLengthDistribution {
         }
         self.min.fetch_min(len, Ordering::Relaxed);
 
+        // Order-independent count for the deterministic rebuild. Every quant/align
+        // observation is a unit count (`mass == 0.0`); the rebuild assumes that.
+        debug_assert_eq!(mass, 0.0, "deterministic rebuild assumes unit observations");
+        self.counts[len].fetch_add(1, Ordering::Relaxed);
+
         let half = self.kernel.len() / 2;
         // offset can go negative conceptually; use isize math then bound-check.
         let mut offset = len as isize - half as isize;
@@ -178,11 +197,44 @@ impl FragmentLengthDistribution {
                 let o = offset as usize;
                 let k_mass = mass + k;
                 self.hist[o].log_add_assign(k_mass);
-                self.sum.log_add_assign((o as f64).ln() + k_mass);
                 self.tot_mass.log_add_assign(k_mass);
             }
             offset += 1;
         }
+    }
+
+    /// Deterministically rebuild the linear-space histogram from the prior plus
+    /// the order-independent observation counts: `lin[o] = prior_lin[o] +
+    /// Σ_bin counts[bin]·kernel_lin[o − bin + half]`, accumulated in a fixed bin
+    /// order so the result does not depend on thread interleaving. Returns the
+    /// per-bin log-mass and the log total. Used by the reads-mode snapshot /
+    /// cache / mean paths so their outputs are byte-identical across thread
+    /// counts.
+    fn counts_hist(&self) -> (Vec<f64>, f64) {
+        let n = self.hist.len();
+        let mut lin = self.prior_lin.clone();
+        let kernel_lin: Vec<f64> = self.kernel.iter().map(|k| k.exp()).collect();
+        let half = self.kernel.len() / 2;
+        for bin in 0..n {
+            let c = self.counts[bin].load(Ordering::Relaxed);
+            if c == 0 {
+                continue;
+            }
+            let cf = c as f64;
+            for (kidx, &kl) in kernel_lin.iter().enumerate() {
+                let offset = bin as isize - half as isize + kidx as isize;
+                if offset > 0 && (offset as usize) < n {
+                    lin[offset as usize] += cf * kl;
+                }
+            }
+        }
+        let log_hist: Vec<f64> = lin
+            .iter()
+            .map(|&m| if m > 0.0 { m.ln() } else { LOG_0 })
+            .collect();
+        let tot: f64 = lin.iter().sum();
+        let log_tot = if tot > 0.0 { tot.ln() } else { LOG_0 };
+        (log_hist, log_tot)
     }
 
     /// Logged probability of observing a fragment of length `len`.
@@ -213,22 +265,25 @@ impl FragmentLengthDistribution {
         }
         let max_raw = self.max_val();
         let max_v = max_raw / self.bin_size;
-        let tot = self.tot_mass.load();
+        // Rebuild from the order-independent counts (not the live `hist`), so the
+        // snapshot a fragment reads is byte-identical regardless of how
+        // observations were interleaved across worker threads.
+        let (log_hist, tot) = self.counts_hist();
         // Per-bin cumulative mass (matches `cmf()`), so the snapshot CMF at raw
         // index `raw` equals `cmf(raw)`. Built first, then both the PMF and CMF
-        // snapshots are expanded over raw indices from the same `tot` read so
-        // they are mutually consistent.
+        // snapshots are expanded over raw indices from the same `tot` so they are
+        // mutually consistent.
         let mut bin_cum = Vec::with_capacity(max_v + 1);
         let mut cum = LOG_0;
         for b in 0..=max_v {
-            cum = log_add(cum, self.hist[b].load() - tot);
+            cum = log_add(cum, log_hist[b] - tot);
             bin_cum.push(cum);
         }
         let mut v = Vec::with_capacity(max_raw + 1);
         let mut c = Vec::with_capacity(max_raw + 1);
         for raw in 0..=max_raw {
             let l = (raw / self.bin_size).min(max_v);
-            v.push(self.hist[l].load() - tot);
+            v.push(log_hist[l] - tot);
             c.push(bin_cum[l]);
         }
         *self.online_pmf.write().unwrap() = Arc::new(v);
@@ -279,9 +334,21 @@ impl FragmentLengthDistribution {
         self.tot_mass.load()
     }
 
-    /// Mean observed length.
+    /// Mean observed length (in bin units, matching the historical
+    /// `sum/tot_mass` ratio). Computed from the order-independent counts so the
+    /// reported `frag_len_mean` is byte-identical across thread counts.
     pub fn mean(&self) -> f64 {
-        (self.sum.load() - self.tot_mass.load()).exp()
+        let (log_hist, log_tot) = self.counts_hist();
+        let mut s = 0.0;
+        for (bin, &lh) in log_hist.iter().enumerate() {
+            s += (bin as f64) * lh.exp();
+        }
+        let tot = log_tot.exp();
+        if tot > 0.0 {
+            s / tot
+        } else {
+            0.0
+        }
     }
 
     /// Standard deviation of the observed length distribution, computed from the
@@ -310,11 +377,16 @@ impl FragmentLengthDistribution {
             return;
         }
         let max_v = self.max_val();
-        // normalized PMF over [0, max_v]
+        // Build from the order-independent counts (not the live `hist`) so the
+        // cached PMF/CMF — and therefore the effective lengths derived from it —
+        // are byte-identical regardless of thread count.
+        let (log_hist, log_tot) = self.counts_hist();
+        let max_bin = log_hist.len() - 1;
+        // un-normalized log-PMF over [0, max_v] (raw indices, binned like `pmf`)
         let mut pmf = Vec::with_capacity(max_v + 1);
         let mut tot = LOG_0;
         for i in 0..=max_v {
-            let p = self.pmf(i);
+            let p = log_hist[(i / self.bin_size).min(max_bin)] - log_tot;
             pmf.push(p);
             tot = log_add(tot, p);
         }
@@ -448,6 +520,48 @@ mod tests {
         let fld = FragmentLengthDistribution::new(1000.0, 1000, 250.0, 25.0, 4, 0.5, 1);
         let m = fld.mean();
         assert!((m - 250.0).abs() < 5.0, "mean {m} not near 250");
+    }
+
+    #[test]
+    fn accumulation_is_order_independent() {
+        // The trained distribution must be byte-identical regardless of the order
+        // in which observations arrive (i.e. how they were interleaved across
+        // worker threads). Same multiset of lengths, two different orders.
+        let lengths_fwd: Vec<usize> = (0..2000).map(|i| 150 + (i * 7) % 500).collect();
+        let mut lengths_rev = lengths_fwd.clone();
+        lengths_rev.reverse();
+        let mut lengths_shuf = lengths_fwd.clone();
+        // deterministic shuffle (no Math.random; index-driven swaps)
+        for i in 0..lengths_shuf.len() {
+            let j = (i.wrapping_mul(2654435761)) % lengths_shuf.len();
+            lengths_shuf.swap(i, j);
+        }
+
+        let build = |order: &[usize]| {
+            let mut fld = FragmentLengthDistribution::new(1.0, 1000, 0.0, 0.0, 4, 0.5, 1);
+            for &l in order {
+                fld.add_val(l, 0.0);
+            }
+            // exercise the online snapshot path too
+            fld.refresh_online();
+            let snap = fld.online_snapshot().as_ref().clone();
+            let mean = fld.mean();
+            fld.cache();
+            (fld.log_pmf().to_vec(), fld.cached_cmf.clone(), snap, mean)
+        };
+
+        let (pmf_f, cmf_f, snap_f, mean_f) = build(&lengths_fwd);
+        let (pmf_r, cmf_r, snap_r, mean_r) = build(&lengths_rev);
+        let (pmf_s, cmf_s, snap_s, mean_s) = build(&lengths_shuf);
+
+        assert_eq!(pmf_f, pmf_r, "cached PMF differs by insertion order (rev)");
+        assert_eq!(pmf_f, pmf_s, "cached PMF differs by insertion order (shuf)");
+        assert_eq!(cmf_f, cmf_r, "cached CMF differs by insertion order (rev)");
+        assert_eq!(cmf_f, cmf_s, "cached CMF differs by insertion order (shuf)");
+        assert_eq!(snap_f, snap_r, "online snapshot differs by insertion order");
+        assert_eq!(snap_f, snap_s, "online snapshot differs by insertion order");
+        assert_eq!(mean_f.to_bits(), mean_r.to_bits(), "mean differs by order");
+        assert_eq!(mean_f.to_bits(), mean_s.to_bits(), "mean differs by order");
     }
 
     #[test]

--- a/crates/salmon-quant/Cargo.toml
+++ b/crates/salmon-quant/Cargo.toml
@@ -17,6 +17,7 @@ salmon-eqclass = { workspace = true }
 salmon-infer = { workspace = true }
 piscem-rs = { workspace = true }
 paraseq = "0.4"
+xxhash-rust = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -145,6 +145,12 @@ pub struct QuantOptions {
     /// online posterior (salmon's `--numPreAuxModelSamples`; salmon's default is
     /// 1,000,000, this port's prior hardcoded value is 5,000)
     pub num_pre_aux_model_samples: u64,
+    /// opt-in byte-for-byte reproducibility (`--deterministic`). When `true`,
+    /// quantification splits into a parallel mapping pass and a single-threaded,
+    /// key-sorted inference pass so `quant.sf` is byte-identical regardless of
+    /// `-p N`. Default `false` keeps the historical inline, fully-parallel path
+    /// (no fragment store, no extra overhead).
+    pub deterministic: bool,
     /// Optional shared progress counters. When `Some`, [`quantify`] reports
     /// processed/mapped fragment counts here as it runs so the caller can drive
     /// a live progress display. `None` (the default) disables sharing.
@@ -194,6 +200,7 @@ impl QuantOptions {
             cond_gc_bins: salmon_model::gcbias::DEFAULT_COND_BINS,
             skip_quant: false,
             num_pre_aux_model_samples: processor::NUM_PRE_BURNIN,
+            deterministic: false,
             progress: None,
         }
     }
@@ -401,8 +408,10 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     };
 
     // ---- parallel mapping pass (borrows the accumulators) -------------------
-    // Pass 1 maps reads in parallel and buffers each mapped fragment here; pass 2
-    // (`run_inference_serial`) replays the inference deterministically.
+    // The default path runs inference inline during this pass. With
+    // `--deterministic`, pass 1 instead buffers each mapped fragment into
+    // `frag_sink` and pass 2 (`run_inference_serial`) replays the inference in a
+    // fixed key-sorted order; the sink stays empty otherwise.
     let frag_sink: std::sync::Mutex<Vec<(u128, Vec<salmon_map::ScoredMapping>)>> =
         std::sync::Mutex::new(Vec::new());
     {
@@ -444,6 +453,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             num_below_threshold_vm: &num_below_threshold_vm,
             unmapped_names: unmapped_collector.as_ref(),
             sam: sam_writer.as_ref(),
+            deterministic: opts.deterministic,
             frag_sink: &frag_sink,
         };
         let mut proc = QuantProcessor::new(shared);
@@ -462,8 +472,12 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         }
         drop(proc);
         // ---- deterministic inference pass (single-threaded, key-sorted) ------
-        let frags = std::mem::take(&mut *frag_sink.lock().unwrap());
-        run_inference_serial(&shared, frags, INFERENCE_BATCH);
+        // Only with `--deterministic`; the default path already ran the inference
+        // inline during the parallel mapping pass.
+        if opts.deterministic {
+            let frags = std::mem::take(&mut *frag_sink.lock().unwrap());
+            run_inference_serial(&shared, frags, INFERENCE_BATCH);
+        }
     }
     {
         let p = num_processed.load(Ordering::Relaxed);

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -31,7 +31,11 @@ use salmon_map::MapConfig;
 use salmon_model::dumps::BiasDump;
 use salmon_model::{FragmentLengthDistribution, LibraryTypeDetector, SBModel};
 
-use processor::{QuantProcessor, Shared};
+use processor::{run_inference_serial, QuantProcessor, Shared};
+
+/// Mini-batch size for the deterministic inference pass (forgetting-mass
+/// schedule + FLD-snapshot refresh granularity).
+const INFERENCE_BATCH: usize = 5000;
 
 pub use output::write_outputs;
 
@@ -397,6 +401,10 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     };
 
     // ---- parallel mapping pass (borrows the accumulators) -------------------
+    // Pass 1 maps reads in parallel and buffers each mapped fragment here; pass 2
+    // (`run_inference_serial`) replays the inference deterministically.
+    let frag_sink: std::sync::Mutex<Vec<(Vec<u8>, Vec<salmon_map::ScoredMapping>)>> =
+        std::sync::Mutex::new(Vec::new());
     {
         let shared = Shared {
             salmon: &salmon,
@@ -436,6 +444,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             num_below_threshold_vm: &num_below_threshold_vm,
             unmapped_names: unmapped_collector.as_ref(),
             sam: sam_writer.as_ref(),
+            frag_sink: &frag_sink,
         };
         let mut proc = QuantProcessor::new(shared);
         tracing::info!(
@@ -451,6 +460,10 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         } else {
             run_single(&opts.unmated, &mut proc, nthreads)?;
         }
+        drop(proc);
+        // ---- deterministic inference pass (single-threaded, key-sorted) ------
+        let frags = std::mem::take(&mut *frag_sink.lock().unwrap());
+        run_inference_serial(&shared, frags, INFERENCE_BATCH);
     }
     {
         let p = num_processed.load(Ordering::Relaxed);

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -403,7 +403,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     // ---- parallel mapping pass (borrows the accumulators) -------------------
     // Pass 1 maps reads in parallel and buffers each mapped fragment here; pass 2
     // (`run_inference_serial`) replays the inference deterministically.
-    let frag_sink: std::sync::Mutex<Vec<(Vec<u8>, Vec<salmon_map::ScoredMapping>)>> =
+    let frag_sink: std::sync::Mutex<Vec<(u128, Vec<salmon_map::ScoredMapping>)>> =
         std::sync::Mutex::new(Vec::new());
     {
         let shared = Shared {

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -236,22 +236,45 @@ fn frag_log_prob(
     }
 }
 
-thread_local! {
-    /// Per-thread PRNG state for stochastic FLD-sample acceptance (mirrors
-    /// salmon's per-thread RNG used when training the fragment-length model).
-    static FLD_RNG: std::cell::Cell<u64> = const { std::cell::Cell::new(0x2545_F491_4F6C_DD1D) };
+/// Deterministic per-fragment acceptance sampler for stochastic FLD training.
+///
+/// salmon trains the fragment-length distribution online by accepting each
+/// concordant mapping's length with probability equal to its abundance-aware
+/// posterior. The previous port drew that acceptance coin from a *thread-local*
+/// PRNG, so which fragments trained the FLD depended on how the reads happened to
+/// be distributed across worker threads — the documented source of multi-threaded
+/// run-to-run wobble. Seeding instead from the read's own identity makes the
+/// acceptance decision a pure function of `(read_id, mapping_index, posterior)`,
+/// so the *set* of fragments training the FLD is identical regardless of thread
+/// count or fragment-arrival order. The draw for mapping `i` is derived directly
+/// from `(seed, i)` (not from a sequential stream), so it is independent of how
+/// many earlier mappings of the same fragment were concordant.
+#[derive(Clone, Copy)]
+struct FldSampler {
+    seed: u64,
 }
 
-/// Draw a pseudo-random value in `[0, 1)` from the per-thread xorshift state.
-fn fld_rng_u01() -> f64 {
-    FLD_RNG.with(|s| {
-        let mut x = s.get();
-        x ^= x << 13;
-        x ^= x >> 7;
-        x ^= x << 17;
-        s.set(x);
-        ((x >> 11) as f64) * (1.0 / ((1u64 << 53) as f64))
-    })
+impl FldSampler {
+    /// Seed from the stable fragment name (the full read id bytes). xxh3 is the
+    /// workspace hash already used for eq-class labels. The `| 1` keeps the seed
+    /// nonzero for any input (including an empty id).
+    fn for_read(read_id: &[u8]) -> Self {
+        FldSampler {
+            seed: xxhash_rust::xxh3::xxh3_64(read_id) | 1,
+        }
+    }
+
+    /// A pseudo-random value in `[0, 1)` for compatible-mapping index `i`,
+    /// derived statelessly from `(seed, i)` via the splitmix64 finalizer.
+    fn u01(&self, i: usize) -> f64 {
+        let mut z = self
+            .seed
+            .wrapping_add((i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        ((z >> 11) as f64) * (1.0 / ((1u64 << 53) as f64))
+    }
 }
 
 /// Collect the orientation-aware 5'/3' sequence-bias contexts for one mapping,
@@ -355,6 +378,7 @@ fn collect_pos(
 /// inference is active).
 fn record(
     sh: &Shared,
+    read_id: &[u8],
     maps: &[ScoredMapping],
     log_fm: f64,
     seqbias: Option<&mut (SBModel, SBModel)>,
@@ -577,11 +601,17 @@ fn record(
     // pair at full weight, which overdisperses it). Frozen after the training
     // window (`online_post` is `None`).
     if let Some(post) = &online_post {
+        // Seed the acceptance sampler from the fragment's own identity, so the
+        // set of fragments that train the FLD is independent of which worker
+        // thread processed this fragment (the documented source of multi-threaded
+        // run-to-run wobble). Computed once per fragment, only inside the
+        // training window.
+        let sampler = FldSampler::for_read(read_id);
         for (i, (m, _)) in compat.iter().enumerate() {
             let conc = m.status == MateStatus::PairedEndPaired
                 && m.fragment_len > 0
                 && expected.is_none_or(|exp| is_compatible(exp, m.format, m.is_fw, m.status));
-            if conc && fld_rng_u01() < post[i] {
+            if conc && sampler.u01(i) < post[i] {
                 sh.fld.add_val(m.fragment_len as usize, 0.0);
             }
         }
@@ -753,6 +783,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             }
             record(
                 &sh,
+                r1.id(),
                 &maps,
                 log_fm,
                 seqbias.as_mut(),
@@ -843,6 +874,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             }
             record(
                 &sh,
+                rec.id(),
                 &maps,
                 log_fm,
                 seqbias.as_mut(),
@@ -876,6 +908,80 @@ fn flush_sam(proc: &mut QuantProcessor) {
         if !proc.sam_buf.is_empty() {
             let _ = sw.write_block(&proc.sam_buf);
             proc.sam_buf.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reproduce the FLD-acceptance rule exactly: accept mapping `i` iff
+    /// `u01(i) < post[i]`, evaluating the indices in the given `order`.
+    fn accepts(read_id: &[u8], posts: &[f64], order: &[usize]) -> Vec<bool> {
+        let s = FldSampler::for_read(read_id);
+        let mut out = vec![false; posts.len()];
+        for &i in order {
+            out[i] = s.u01(i) < posts[i];
+        }
+        out
+    }
+
+    #[test]
+    fn fld_acceptance_is_order_and_thread_independent() {
+        let read_id = b"SRR1039508.frag_0042";
+        // Mix certain-accept (1.0), certain-reject (0.0), and middling probs so
+        // the decision actually depends on the draws.
+        let posts = [1.0, 0.0, 0.5, 0.5, 0.0, 1.0, 0.3, 0.7, 0.9, 0.1];
+
+        let forward: Vec<usize> = (0..posts.len()).collect();
+        let mut reversed = forward.clone();
+        reversed.reverse();
+        let shuffled = [3usize, 7, 0, 9, 1, 5, 8, 2, 6, 4];
+
+        let a = accepts(read_id, &posts, &forward);
+        let b = accepts(read_id, &posts, &reversed);
+        let c = accepts(read_id, &posts, &shuffled);
+
+        // The accept decision for index i is a pure function of (read_id, i,
+        // post[i]); permuting evaluation order (i.e. thread scheduling) must not
+        // change any decision.
+        assert_eq!(a, b, "acceptance must not depend on evaluation order");
+        assert_eq!(a, c, "acceptance must not depend on evaluation order");
+
+        // post == 1.0 always accepts, post == 0.0 never accepts (u01 in [0,1)).
+        assert!(a[0] && a[5]);
+        assert!(!a[1] && !a[4]);
+    }
+
+    #[test]
+    fn fld_sampler_is_deterministic_and_seed_robust() {
+        // Same id -> identical draws (run-to-run determinism).
+        let s1 = FldSampler::for_read(b"frag_x");
+        let s2 = FldSampler::for_read(b"frag_x");
+        for i in 0..16 {
+            assert_eq!(s1.u01(i), s2.u01(i));
+        }
+        // Different ids -> different seeds (no collapse onto a global constant).
+        assert_ne!(
+            FldSampler::for_read(b"frag_a").seed,
+            FldSampler::for_read(b"frag_b").seed
+        );
+        // Empty id is still a usable, nonzero-seeded, in-range stream.
+        let se = FldSampler::for_read(b"");
+        assert_ne!(se.seed, 0);
+        for i in 0..16 {
+            let u = se.u01(i);
+            assert!((0.0..1.0).contains(&u));
+        }
+    }
+
+    #[test]
+    fn fld_u01_in_unit_interval() {
+        let s = FldSampler::for_read(b"range_check");
+        for i in 0..10_000 {
+            let u = s.u01(i);
+            assert!((0.0..1.0).contains(&u), "u01({i}) = {u} out of [0,1)");
         }
     }
 }

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -637,7 +637,12 @@ fn record(
     } else {
         TranscriptGroup::from_sorted(tids)
     };
-    sh.eq.add_group(group, weights, 1);
+    // Key the contribution by the fragment's identity so the per-class weight sum
+    // is reduced in a fixed, thread-count-independent order (determinism).
+    // Key the contribution by the fragment's identity so the per-class weight sum
+    // is reduced in a fixed, thread-count-independent order (determinism).
+    let eq_key = xxhash_rust::xxh3::xxh3_128(read_id);
+    sh.eq.add_group_keyed(eq_key, group, weights, 1);
 }
 
 /// Fold the most recent fragment's selective-alignment [`MapStats`] into the

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -1,11 +1,13 @@
-//! paraseq parallel processor that maps reads and accumulates equivalence
-//! classes, fragment lengths, observed library formats, and (for `--seqBias`)
-//! observed sequence-bias contexts.
+//! Two-pass reads-mode quantification core.
 //!
-//! Shared `&'a` references hold the index and thread-safe accumulators; the
-//! per-thread scratch (a [`HitSearcher`] and, when bias-correcting, observed
-//! sequence-bias models) is rebuilt on `Clone` (paraseq clones the processor
-//! per worker) and merged into shared state in `on_thread_complete`.
+//! **Pass 1** (parallel, paraseq): each worker maps its reads, samples the
+//! library format, writes SAM/`--writeMappings`, and buffers every mapped
+//! fragment's `(read_id, mappings)` into [`Shared::frag_sink`]. No inference runs
+//! here. **Pass 2** ([`run_inference_serial`]): the buffered fragments are sorted
+//! by a stable per-fragment key and the online posterior, FLD training, bias
+//! collection, and equivalence-class accumulation are replayed single-threaded in
+//! that fixed order. Every order-dependent accumulation is therefore
+//! byte-identical regardless of how many threads mapped the reads.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -108,6 +110,12 @@ pub(crate) struct Shared<'a> {
     pub unmapped_names: Option<&'a Mutex<Vec<String>>>,
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
+    /// Mapping-phase fragment sink. The parallel pass maps each fragment and
+    /// appends `(read_id, mappings)` here; the inference (online posterior, FLD
+    /// training, bias collection, eq-class accumulation) then runs in a
+    /// deterministic, key-sorted, single-threaded second pass, so the result is
+    /// byte-identical regardless of thread count (see [`run_inference_serial`]).
+    pub frag_sink: &'a Mutex<Vec<(Vec<u8>, Vec<ScoredMapping>)>>,
 }
 
 /// Per-thread mapping processor.
@@ -116,45 +124,24 @@ pub(crate) struct QuantProcessor<'a> {
     pub hs: Option<HitSearcher<'a>>,
     /// per-thread reusable sketch caches (avoids per-read MappingCache allocs)
     pub sketch_scratch: Option<salmon_map::SketchScratch>,
-    /// per-thread observed (fw, rc) sequence-bias models (when collecting)
-    pub seqbias: Option<(SBModel, SBModel)>,
-    /// per-thread observed fragment-GC model (when collecting)
-    pub gcbias: Option<GcFragModel>,
-    /// per-thread observed (5', 3') positional-bias models, per length class
-    pub posbias: Option<(Vec<SimplePosBias>, Vec<SimplePosBias>)>,
     /// per-thread collected unmapped-fragment names (merged in on_thread_complete)
     pub unmapped: Vec<String>,
     /// per-thread SAM record buffer (flushed to the shared writer per batch)
     pub sam_buf: String,
+    /// per-thread buffer of mapped fragments `(read_id, mappings)`, drained into
+    /// `Shared::frag_sink` at thread completion for the deterministic second pass.
+    pub frag_buf: Vec<(Vec<u8>, Vec<ScoredMapping>)>,
 }
 
 impl<'a> QuantProcessor<'a> {
     pub fn new(shared: Shared<'a>) -> Self {
-        let seqbias = shared
-            .collect_seqbias
-            .then(|| (SBModel::new(), SBModel::new()));
-        let gcbias = shared
-            .collect_gcbias
-            .then(|| GcFragModel::new(shared.cond_gc_bins, shared.gc_bins));
-        let posbias = shared.collect_posbias.then(|| {
-            (
-                (0..NUM_LENGTH_CLASSES)
-                    .map(|_| SimplePosBias::default())
-                    .collect(),
-                (0..NUM_LENGTH_CLASSES)
-                    .map(|_| SimplePosBias::default())
-                    .collect(),
-            )
-        });
         Self {
             shared,
             hs: None,
             sketch_scratch: None,
-            seqbias,
-            gcbias,
-            posbias,
             unmapped: Vec::new(),
             sam_buf: String::new(),
+            frag_buf: Vec::new(),
         }
     }
 }
@@ -385,7 +372,8 @@ fn record(
     gcbias: Option<&mut GcFragModel>,
     posbias: Option<&mut (Vec<SimplePosBias>, Vec<SimplePosBias>)>,
 ) {
-    sh.num_processed.fetch_add(1, Ordering::Relaxed);
+    // `num_processed` is counted during the mapping pass; pass 2 only receives
+    // mapped fragments.
     if maps.is_empty() {
         return;
     }
@@ -545,7 +533,10 @@ fn record(
     // differs and coarsening the range-factorized classes. The FLD term is only
     // applied once the auxiliary model is trained (after `pre_burnin` fragments),
     // matching salmon's `numPreAuxModelSamples` gating.
-    let use_aux = sh.num_processed.load(Ordering::Relaxed) >= sh.pre_burnin;
+    // Gate on the online inference's own progressive count (equal to the
+    // fragments processed so far in the deterministic pass), not the pre-counted
+    // total `num_processed`, so the burn-in window is honored in pass 2.
+    let use_aux = sh.online.map_or(0, |o| o.num_assigned()) >= sh.pre_burnin;
     // Per-mapping FLD log-probability via the shared `frag_log_prob` term — the
     // same one the online posterior uses, reading the same per-fragment snapshot
     // pair captured above (so the two paths share one consistent FLD view, as
@@ -685,17 +676,66 @@ fn merge_unmapped(proc: &mut QuantProcessor) {
     }
 }
 
-fn merge_bias(proc: &QuantProcessor) {
-    if let (Some(local), Some(shared_mtx)) = (proc.seqbias.as_ref(), proc.shared.seqbias_obs) {
+/// Run the per-fragment inference over the mapped fragments in a deterministic,
+/// key-sorted, single-threaded order. The parallel mapping pass only maps and
+/// buffers fragments; this pass replays the online posterior, FLD training, bias
+/// collection, and eq-class accumulation in a fixed order (sorted by a stable
+/// per-fragment key), so every order-dependent accumulation — the online masses,
+/// the FLD, and the observed bias models — is byte-identical regardless of how
+/// many threads mapped the reads. `batch_size` sets the mini-batch granularity
+/// for the forgetting-mass schedule and the FLD-snapshot refresh.
+pub(crate) fn run_inference_serial(
+    sh: &Shared,
+    mut frags: Vec<(Vec<u8>, Vec<ScoredMapping>)>,
+    batch_size: usize,
+) {
+    frags.sort_by_key(|(id, _)| xxhash_rust::xxh3::xxh3_128(id));
+
+    let mut seqbias = sh.collect_seqbias.then(|| (SBModel::new(), SBModel::new()));
+    let mut gcbias = sh
+        .collect_gcbias
+        .then(|| GcFragModel::new(sh.cond_gc_bins, sh.gc_bins));
+    let mut posbias = sh.collect_posbias.then(|| {
+        (
+            (0..NUM_LENGTH_CLASSES)
+                .map(|_| SimplePosBias::default())
+                .collect::<Vec<_>>(),
+            (0..NUM_LENGTH_CLASSES)
+                .map(|_| SimplePosBias::default())
+                .collect::<Vec<_>>(),
+        )
+    });
+
+    let bs = batch_size.max(1);
+    for chunk in frags.chunks(bs) {
+        // one forgetting-mass timestep per minibatch (online inference)
+        let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
+        for (read_id, maps) in chunk {
+            record(
+                sh,
+                read_id,
+                maps,
+                log_fm,
+                seqbias.as_mut(),
+                gcbias.as_mut(),
+                posbias.as_mut(),
+            );
+        }
+        // refresh the FLD snapshot at the minibatch boundary (mirrors salmon)
+        sh.fld.refresh_online();
+    }
+
+    // Merge the collected bias models into the shared accumulators that the
+    // effective-length step reads.
+    if let (Some(local), Some(shared_mtx)) = (seqbias.as_ref(), sh.seqbias_obs) {
         let mut g = shared_mtx.lock().unwrap();
         g.0.combine_counts(&local.0);
         g.1.combine_counts(&local.1);
     }
-    if let (Some(local), Some(shared_mtx)) = (proc.gcbias.as_ref(), proc.shared.gcbias_obs) {
-        let mut g = shared_mtx.lock().unwrap();
-        g.combine_counts(local);
+    if let (Some(local), Some(shared_mtx)) = (gcbias.as_ref(), sh.gcbias_obs) {
+        shared_mtx.lock().unwrap().combine_counts(local);
     }
-    if let (Some(local), Some(shared_mtx)) = (proc.posbias.as_ref(), proc.shared.posbias_obs) {
+    if let (Some(local), Some(shared_mtx)) = (posbias.as_ref(), sh.posbias_obs) {
         let mut g = shared_mtx.lock().unwrap();
         for (a, b) in g.0.iter_mut().zip(&local.0) {
             a.combine(b);
@@ -715,11 +755,10 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             shared,
             hs,
             sketch_scratch,
-            seqbias,
-            gcbias,
-            posbias,
             unmapped,
             sam_buf,
+            frag_buf,
+            ..
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -730,8 +769,6 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         if sh.sketch && sketch_scratch.is_none() {
             *sketch_scratch = Some(salmon_map::SketchScratch::new(idx.k()));
         }
-        // one forgetting-mass timestep per minibatch (online inference)
-        let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
         for (r1, r2) in pairs {
             let s1 = r1.seq();
             let s2 = r2.seq();
@@ -786,30 +823,29 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     &maps,
                 );
             }
-            record(
-                &sh,
-                r1.id(),
-                &maps,
-                log_fm,
-                seqbias.as_mut(),
-                gcbias.as_mut(),
-                posbias.as_mut(),
-            );
+            // Pass 1 only maps + buffers; the inference runs deterministically in
+            // pass 2 (see `run_inference_serial`).
+            sh.num_processed.fetch_add(1, Ordering::Relaxed);
+            if !maps.is_empty() {
+                frag_buf.push((r1.id().to_vec(), maps));
+            }
         }
         Ok(())
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Refresh the FLD online PMF snapshot at the mini-batch boundary so the
-        // next batch's per-fragment reads are stable (see `record`). No-op once the
-        // final FLD cache is taken; amortized over the whole batch.
-        self.shared.fld.refresh_online();
+        // Pass 1 only maps; the FLD is trained in the deterministic pass 2.
         flush_sam(self);
         Ok(())
     }
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
-        merge_bias(self);
+        // Hand this worker's mapped fragments to the shared sink for the
+        // deterministic inference pass (bias models are collected there, not here).
+        if !self.frag_buf.is_empty() {
+            let mut sink = self.shared.frag_sink.lock().unwrap();
+            sink.append(&mut self.frag_buf);
+        }
         merge_unmapped(self);
         flush_sam(self);
         Ok(())
@@ -825,11 +861,10 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             shared,
             hs,
             sketch_scratch,
-            seqbias,
-            gcbias,
-            posbias,
             unmapped,
             sam_buf,
+            frag_buf,
+            ..
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -840,7 +875,6 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         if sh.sketch && sketch_scratch.is_none() {
             *sketch_scratch = Some(salmon_map::SketchScratch::new(idx.k()));
         }
-        let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
         for rec in records {
             let s = rec.seq();
             let mut maps = if sh.sketch {
@@ -877,30 +911,27 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             if sh.sam.is_some() && !maps.is_empty() {
                 crate::sam::write_fragment(sam_buf, sh.salmon, rec.id(), s.as_ref(), None, &maps);
             }
-            record(
-                &sh,
-                rec.id(),
-                &maps,
-                log_fm,
-                seqbias.as_mut(),
-                gcbias.as_mut(),
-                posbias.as_mut(),
-            );
+            sh.num_processed.fetch_add(1, Ordering::Relaxed);
+            if !maps.is_empty() {
+                frag_buf.push((rec.id().to_vec(), maps));
+            }
         }
         Ok(())
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Refresh the FLD online PMF snapshot at the mini-batch boundary so the
-        // next batch's per-fragment reads are stable (see `record`). No-op once the
-        // final FLD cache is taken; amortized over the whole batch.
-        self.shared.fld.refresh_online();
+        // Pass 1 only maps; the FLD is trained in the deterministic pass 2.
         flush_sam(self);
         Ok(())
     }
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
-        merge_bias(self);
+        // Hand this worker's mapped fragments to the shared sink for the
+        // deterministic inference pass (bias models are collected there, not here).
+        if !self.frag_buf.is_empty() {
+            let mut sink = self.shared.frag_sink.lock().unwrap();
+            sink.append(&mut self.frag_buf);
+        }
         merge_unmapped(self);
         flush_sam(self);
         Ok(())

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -2,7 +2,7 @@
 //!
 //! **Pass 1** (parallel, paraseq): each worker maps its reads, samples the
 //! library format, writes SAM/`--writeMappings`, and buffers every mapped
-//! fragment's `(read_id, mappings)` into [`Shared::frag_sink`]. No inference runs
+//! fragment's `(key, mappings)` into [`Shared::frag_sink`]. No inference runs
 //! here. **Pass 2** ([`run_inference_serial`]): the buffered fragments are sorted
 //! by a stable per-fragment key and the online posterior, FLD training, bias
 //! collection, and equivalence-class accumulation are replayed single-threaded in
@@ -111,11 +111,11 @@ pub(crate) struct Shared<'a> {
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
     /// Mapping-phase fragment sink. The parallel pass maps each fragment and
-    /// appends `(read_id, mappings)` here; the inference (online posterior, FLD
+    /// appends `(key, mappings)` here; the inference (online posterior, FLD
     /// training, bias collection, eq-class accumulation) then runs in a
     /// deterministic, key-sorted, single-threaded second pass, so the result is
     /// byte-identical regardless of thread count (see [`run_inference_serial`]).
-    pub frag_sink: &'a Mutex<Vec<(Vec<u8>, Vec<ScoredMapping>)>>,
+    pub frag_sink: &'a Mutex<Vec<(u128, Vec<ScoredMapping>)>>,
 }
 
 /// Per-thread mapping processor.
@@ -128,9 +128,9 @@ pub(crate) struct QuantProcessor<'a> {
     pub unmapped: Vec<String>,
     /// per-thread SAM record buffer (flushed to the shared writer per batch)
     pub sam_buf: String,
-    /// per-thread buffer of mapped fragments `(read_id, mappings)`, drained into
+    /// per-thread buffer of mapped fragments `(key, mappings)`, drained into
     /// `Shared::frag_sink` at thread completion for the deterministic second pass.
-    pub frag_buf: Vec<(Vec<u8>, Vec<ScoredMapping>)>,
+    pub frag_buf: Vec<(u128, Vec<ScoredMapping>)>,
 }
 
 impl<'a> QuantProcessor<'a> {
@@ -242,12 +242,11 @@ struct FldSampler {
 }
 
 impl FldSampler {
-    /// Seed from the stable fragment name (the full read id bytes). xxh3 is the
-    /// workspace hash already used for eq-class labels. The `| 1` keeps the seed
-    /// nonzero for any input (including an empty id).
-    fn for_read(read_id: &[u8]) -> Self {
+    /// Seed from the fragment's precomputed key (`xxh3_128(read_id)`); the low 64
+    /// bits give a stable per-fragment seed. `| 1` keeps it nonzero.
+    fn from_key(key: u128) -> Self {
         FldSampler {
-            seed: xxhash_rust::xxh3::xxh3_64(read_id) | 1,
+            seed: (key as u64) | 1,
         }
     }
 
@@ -365,7 +364,7 @@ fn collect_pos(
 /// inference is active).
 fn record(
     sh: &Shared,
-    read_id: &[u8],
+    key: u128,
     maps: &[ScoredMapping],
     log_fm: f64,
     seqbias: Option<&mut (SBModel, SBModel)>,
@@ -597,7 +596,7 @@ fn record(
         // thread processed this fragment (the documented source of multi-threaded
         // run-to-run wobble). Computed once per fragment, only inside the
         // training window.
-        let sampler = FldSampler::for_read(read_id);
+        let sampler = FldSampler::from_key(key);
         for (i, (m, _)) in compat.iter().enumerate() {
             let conc = m.status == MateStatus::PairedEndPaired
                 && m.fragment_len > 0
@@ -628,12 +627,8 @@ fn record(
     } else {
         TranscriptGroup::from_sorted(tids)
     };
-    // Key the contribution by the fragment's identity so the per-class weight sum
-    // is reduced in a fixed, thread-count-independent order (determinism).
-    // Key the contribution by the fragment's identity so the per-class weight sum
-    // is reduced in a fixed, thread-count-independent order (determinism).
-    let eq_key = xxhash_rust::xxh3::xxh3_128(read_id);
-    sh.eq.add_group_keyed(eq_key, group, weights, 1);
+    // The fragment's key fixes the per-class weight-summation order (determinism).
+    sh.eq.add_group_keyed(key, group, weights, 1);
 }
 
 /// Fold the most recent fragment's selective-alignment [`MapStats`] into the
@@ -686,10 +681,10 @@ fn merge_unmapped(proc: &mut QuantProcessor) {
 /// for the forgetting-mass schedule and the FLD-snapshot refresh.
 pub(crate) fn run_inference_serial(
     sh: &Shared,
-    mut frags: Vec<(Vec<u8>, Vec<ScoredMapping>)>,
+    mut frags: Vec<(u128, Vec<ScoredMapping>)>,
     batch_size: usize,
 ) {
-    frags.sort_by_key(|(id, _)| xxhash_rust::xxh3::xxh3_128(id));
+    frags.sort_by_key(|(key, _)| *key);
 
     let mut seqbias = sh.collect_seqbias.then(|| (SBModel::new(), SBModel::new()));
     let mut gcbias = sh
@@ -710,10 +705,10 @@ pub(crate) fn run_inference_serial(
     for chunk in frags.chunks(bs) {
         // one forgetting-mass timestep per minibatch (online inference)
         let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
-        for (read_id, maps) in chunk {
+        for (key, maps) in chunk {
             record(
                 sh,
-                read_id,
+                *key,
                 maps,
                 log_fm,
                 seqbias.as_mut(),
@@ -827,7 +822,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             // pass 2 (see `run_inference_serial`).
             sh.num_processed.fetch_add(1, Ordering::Relaxed);
             if !maps.is_empty() {
-                frag_buf.push((r1.id().to_vec(), maps));
+                frag_buf.push((xxhash_rust::xxh3::xxh3_128(r1.id()), maps));
             }
         }
         Ok(())
@@ -913,7 +908,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             }
             sh.num_processed.fetch_add(1, Ordering::Relaxed);
             if !maps.is_empty() {
-                frag_buf.push((rec.id().to_vec(), maps));
+                frag_buf.push((xxhash_rust::xxh3::xxh3_128(rec.id()), maps));
             }
         }
         Ok(())
@@ -954,8 +949,8 @@ mod tests {
 
     /// Reproduce the FLD-acceptance rule exactly: accept mapping `i` iff
     /// `u01(i) < post[i]`, evaluating the indices in the given `order`.
-    fn accepts(read_id: &[u8], posts: &[f64], order: &[usize]) -> Vec<bool> {
-        let s = FldSampler::for_read(read_id);
+    fn accepts(key: u128, posts: &[f64], order: &[usize]) -> Vec<bool> {
+        let s = FldSampler::from_key(key);
         let mut out = vec![false; posts.len()];
         for &i in order {
             out[i] = s.u01(i) < posts[i];
@@ -965,7 +960,7 @@ mod tests {
 
     #[test]
     fn fld_acceptance_is_order_and_thread_independent() {
-        let read_id = b"SRR1039508.frag_0042";
+        let key: u128 = 0x1234_5678_9ABC_DEF0_0FED_CBA9_8765_4321;
         // Mix certain-accept (1.0), certain-reject (0.0), and middling probs so
         // the decision actually depends on the draws.
         let posts = [1.0, 0.0, 0.5, 0.5, 0.0, 1.0, 0.3, 0.7, 0.9, 0.1];
@@ -975,13 +970,13 @@ mod tests {
         reversed.reverse();
         let shuffled = [3usize, 7, 0, 9, 1, 5, 8, 2, 6, 4];
 
-        let a = accepts(read_id, &posts, &forward);
-        let b = accepts(read_id, &posts, &reversed);
-        let c = accepts(read_id, &posts, &shuffled);
+        let a = accepts(key, &posts, &forward);
+        let b = accepts(key, &posts, &reversed);
+        let c = accepts(key, &posts, &shuffled);
 
-        // The accept decision for index i is a pure function of (read_id, i,
-        // post[i]); permuting evaluation order (i.e. thread scheduling) must not
-        // change any decision.
+        // The accept decision for index i is a pure function of (key, i, post[i]);
+        // permuting evaluation order (i.e. thread scheduling) must not change any
+        // decision.
         assert_eq!(a, b, "acceptance must not depend on evaluation order");
         assert_eq!(a, c, "acceptance must not depend on evaluation order");
 
@@ -992,19 +987,16 @@ mod tests {
 
     #[test]
     fn fld_sampler_is_deterministic_and_seed_robust() {
-        // Same id -> identical draws (run-to-run determinism).
-        let s1 = FldSampler::for_read(b"frag_x");
-        let s2 = FldSampler::for_read(b"frag_x");
+        // Same key -> identical draws (run-to-run determinism).
+        let s1 = FldSampler::from_key(0xAAAA_BBBB_CCCC_DDDD);
+        let s2 = FldSampler::from_key(0xAAAA_BBBB_CCCC_DDDD);
         for i in 0..16 {
             assert_eq!(s1.u01(i), s2.u01(i));
         }
-        // Different ids -> different seeds (no collapse onto a global constant).
-        assert_ne!(
-            FldSampler::for_read(b"frag_a").seed,
-            FldSampler::for_read(b"frag_b").seed
-        );
-        // Empty id is still a usable, nonzero-seeded, in-range stream.
-        let se = FldSampler::for_read(b"");
+        // Different keys -> different seeds (no collapse onto a global constant).
+        assert_ne!(FldSampler::from_key(1).seed, FldSampler::from_key(2).seed);
+        // A zero key still yields a usable, nonzero-seeded, in-range stream.
+        let se = FldSampler::from_key(0);
         assert_ne!(se.seed, 0);
         for i in 0..16 {
             let u = se.u01(i);
@@ -1014,7 +1006,7 @@ mod tests {
 
     #[test]
     fn fld_u01_in_unit_interval() {
-        let s = FldSampler::for_read(b"range_check");
+        let s = FldSampler::from_key(0xDEAD_BEEF_F00D);
         for i in 0..10_000 {
             let u = s.u01(i);
             assert!((0.0..1.0).contains(&u), "u01({i}) = {u} out of [0,1)");

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -1,13 +1,20 @@
-//! Two-pass reads-mode quantification core.
+//! Reads-mode quantification core, with two inference strategies.
 //!
-//! **Pass 1** (parallel, paraseq): each worker maps its reads, samples the
-//! library format, writes SAM/`--writeMappings`, and buffers every mapped
-//! fragment's `(key, mappings)` into [`Shared::frag_sink`]. No inference runs
-//! here. **Pass 2** ([`run_inference_serial`]): the buffered fragments are sorted
-//! by a stable per-fragment key and the online posterior, FLD training, bias
-//! collection, and equivalence-class accumulation are replayed single-threaded in
-//! that fixed order. Every order-dependent accumulation is therefore
-//! byte-identical regardless of how many threads mapped the reads.
+//! **Default (inline, fully parallel):** each worker maps its reads and runs the
+//! per-fragment inference ([`record`]) immediately, accumulating the online
+//! posterior, FLD training, bias models, and equivalence classes concurrently.
+//! This is the historical behaviour: fast, no fragment store, but the
+//! accumulation order (hence the last ULPs of `quant.sf`) depends on thread
+//! scheduling.
+//!
+//! **`--deterministic` (opt-in, two-pass):** pass 1 maps in parallel and only
+//! buffers every mapped fragment's `(key, mappings)` into [`Shared::frag_sink`];
+//! pass 2 ([`run_inference_serial`]) sorts the buffered fragments by a stable
+//! per-fragment key and replays the inference single-threaded in that fixed order.
+//! Every order-dependent accumulation is then byte-identical regardless of how
+//! many threads mapped the reads, at the cost of holding the mappings between
+//! passes and a single-threaded inference phase. Selected by
+//! [`Shared::deterministic`].
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -110,11 +117,17 @@ pub(crate) struct Shared<'a> {
     pub unmapped_names: Option<&'a Mutex<Vec<String>>>,
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
-    /// Mapping-phase fragment sink. The parallel pass maps each fragment and
-    /// appends `(key, mappings)` here; the inference (online posterior, FLD
-    /// training, bias collection, eq-class accumulation) then runs in a
-    /// deterministic, key-sorted, single-threaded second pass, so the result is
-    /// byte-identical regardless of thread count (see [`run_inference_serial`]).
+    /// opt-in byte-for-byte reproducibility (`--deterministic`). When `true`, the
+    /// mapping pass only buffers fragments into `frag_sink` and the inference runs
+    /// in a deterministic key-sorted second pass ([`run_inference_serial`]); when
+    /// `false` (default) the inference runs inline during the parallel mapping pass
+    /// (no fragment store, no extra overhead), as before.
+    pub deterministic: bool,
+    /// Mapping-phase fragment sink for the deterministic second pass; appended to
+    /// only when `deterministic` is set. The parallel pass maps each fragment and
+    /// appends `(key, mappings)`; [`run_inference_serial`] then replays the
+    /// inference key-sorted and single-threaded, byte-identical across thread
+    /// counts.
     pub frag_sink: &'a Mutex<Vec<(u128, Vec<ScoredMapping>)>>,
 }
 
@@ -124,21 +137,54 @@ pub(crate) struct QuantProcessor<'a> {
     pub hs: Option<HitSearcher<'a>>,
     /// per-thread reusable sketch caches (avoids per-read MappingCache allocs)
     pub sketch_scratch: Option<salmon_map::SketchScratch>,
+    /// per-thread observed (fw, rc) sequence-bias models (inline path only)
+    pub seqbias: Option<(SBModel, SBModel)>,
+    /// per-thread observed fragment-GC model (inline path only)
+    pub gcbias: Option<GcFragModel>,
+    /// per-thread observed (5', 3') positional-bias models (inline path only)
+    pub posbias: Option<(Vec<SimplePosBias>, Vec<SimplePosBias>)>,
     /// per-thread collected unmapped-fragment names (merged in on_thread_complete)
     pub unmapped: Vec<String>,
     /// per-thread SAM record buffer (flushed to the shared writer per batch)
     pub sam_buf: String,
     /// per-thread buffer of mapped fragments `(key, mappings)`, drained into
-    /// `Shared::frag_sink` at thread completion for the deterministic second pass.
+    /// `Shared::frag_sink` at thread completion for the deterministic second pass
+    /// (used only when `Shared::deterministic`).
     pub frag_buf: Vec<(u128, Vec<ScoredMapping>)>,
 }
 
 impl<'a> QuantProcessor<'a> {
     pub fn new(shared: Shared<'a>) -> Self {
+        // Per-thread bias models for the inline (non-deterministic) path; the
+        // deterministic path collects bias in `run_inference_serial` instead.
+        let (seqbias, gcbias, posbias) = if shared.deterministic {
+            (None, None, None)
+        } else {
+            let seqbias = shared
+                .collect_seqbias
+                .then(|| (SBModel::new(), SBModel::new()));
+            let gcbias = shared
+                .collect_gcbias
+                .then(|| GcFragModel::new(shared.cond_gc_bins, shared.gc_bins));
+            let posbias = shared.collect_posbias.then(|| {
+                (
+                    (0..NUM_LENGTH_CLASSES)
+                        .map(|_| SimplePosBias::default())
+                        .collect(),
+                    (0..NUM_LENGTH_CLASSES)
+                        .map(|_| SimplePosBias::default())
+                        .collect(),
+                )
+            });
+            (seqbias, gcbias, posbias)
+        };
         Self {
             shared,
             hs: None,
             sketch_scratch: None,
+            seqbias,
+            gcbias,
+            posbias,
             unmapped: Vec::new(),
             sam_buf: String::new(),
             frag_buf: Vec::new(),
@@ -532,10 +578,17 @@ fn record(
     // differs and coarsening the range-factorized classes. The FLD term is only
     // applied once the auxiliary model is trained (after `pre_burnin` fragments),
     // matching salmon's `numPreAuxModelSamples` gating.
-    // Gate on the online inference's own progressive count (equal to the
-    // fragments processed so far in the deterministic pass), not the pre-counted
-    // total `num_processed`, so the burn-in window is honored in pass 2.
-    let use_aux = sh.online.map_or(0, |o| o.num_assigned()) >= sh.pre_burnin;
+    // Burn-in gate. The inline (default) path reads the shared `num_processed`
+    // counter as it did before, matching the non-deterministic behaviour. The
+    // deterministic pass instead gates on the online inference's own progressive
+    // count (the fragments replayed so far in key-sorted order), so the burn-in
+    // window is honored in that fixed order rather than against the pre-counted
+    // total.
+    let use_aux = if sh.deterministic {
+        sh.online.map_or(0, |o| o.num_assigned())
+    } else {
+        sh.num_processed.load(Ordering::Relaxed)
+    } >= sh.pre_burnin;
     // Per-mapping FLD log-probability via the shared `frag_log_prob` term — the
     // same one the online posterior uses, reading the same per-fragment snapshot
     // pair captured above (so the two paths share one consistent FLD view, as
@@ -671,6 +724,30 @@ fn merge_unmapped(proc: &mut QuantProcessor) {
     }
 }
 
+/// Merge this thread's observed bias models (sequence, GC, positional) into the
+/// shared accumulators. Inline (non-deterministic) path only; the deterministic
+/// pass collects bias directly into shared models in [`run_inference_serial`].
+fn merge_bias(proc: &QuantProcessor) {
+    if let (Some(local), Some(shared_mtx)) = (proc.seqbias.as_ref(), proc.shared.seqbias_obs) {
+        let mut g = shared_mtx.lock().unwrap();
+        g.0.combine_counts(&local.0);
+        g.1.combine_counts(&local.1);
+    }
+    if let (Some(local), Some(shared_mtx)) = (proc.gcbias.as_ref(), proc.shared.gcbias_obs) {
+        let mut g = shared_mtx.lock().unwrap();
+        g.combine_counts(local);
+    }
+    if let (Some(local), Some(shared_mtx)) = (proc.posbias.as_ref(), proc.shared.posbias_obs) {
+        let mut g = shared_mtx.lock().unwrap();
+        for (a, b) in g.0.iter_mut().zip(&local.0) {
+            a.combine(b);
+        }
+        for (a, b) in g.1.iter_mut().zip(&local.1) {
+            a.combine(b);
+        }
+    }
+}
+
 /// Run the per-fragment inference over the mapped fragments in a deterministic,
 /// key-sorted, single-threaded order. The parallel mapping pass only maps and
 /// buffers fragments; this pass replays the online posterior, FLD training, bias
@@ -750,10 +827,12 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             shared,
             hs,
             sketch_scratch,
+            seqbias,
+            gcbias,
+            posbias,
             unmapped,
             sam_buf,
             frag_buf,
-            ..
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -764,6 +843,14 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         if sh.sketch && sketch_scratch.is_none() {
             *sketch_scratch = Some(salmon_map::SketchScratch::new(idx.k()));
         }
+        // One forgetting-mass timestep per mapped batch for the inline online
+        // posterior; the deterministic pass advances it per mini-batch in pass 2
+        // instead, so leave the schedule untouched here when buffering.
+        let log_fm = if sh.deterministic {
+            0.0
+        } else {
+            sh.online.map_or(0.0, |o| o.next_log_fm())
+        };
         for (r1, r2) in pairs {
             let s1 = r1.seq();
             let s2 = r2.seq();
@@ -818,28 +905,51 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     &maps,
                 );
             }
-            // Pass 1 only maps + buffers; the inference runs deterministically in
-            // pass 2 (see `run_inference_serial`).
             sh.num_processed.fetch_add(1, Ordering::Relaxed);
-            if !maps.is_empty() {
-                frag_buf.push((xxhash_rust::xxh3::xxh3_128(r1.id()), maps));
+            if maps.is_empty() {
+                continue;
+            }
+            let key = xxhash_rust::xxh3::xxh3_128(r1.id());
+            if sh.deterministic {
+                // Pass 1 only maps + buffers; the inference runs deterministically
+                // in pass 2 (see `run_inference_serial`).
+                frag_buf.push((key, maps));
+            } else {
+                // Inline (default): run the per-fragment inference now, in parallel.
+                record(
+                    &sh,
+                    key,
+                    &maps,
+                    log_fm,
+                    seqbias.as_mut(),
+                    gcbias.as_mut(),
+                    posbias.as_mut(),
+                );
             }
         }
         Ok(())
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Pass 1 only maps; the FLD is trained in the deterministic pass 2.
+        // Inline path refreshes the FLD online snapshot at the mini-batch boundary
+        // (see `record`); the deterministic pass trains the FLD in pass 2 instead.
+        if !self.shared.deterministic {
+            self.shared.fld.refresh_online();
+        }
         flush_sam(self);
         Ok(())
     }
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
-        // Hand this worker's mapped fragments to the shared sink for the
-        // deterministic inference pass (bias models are collected there, not here).
-        if !self.frag_buf.is_empty() {
-            let mut sink = self.shared.frag_sink.lock().unwrap();
-            sink.append(&mut self.frag_buf);
+        if self.shared.deterministic {
+            // Hand this worker's mapped fragments to the shared sink for the
+            // deterministic inference pass (bias models are collected there).
+            if !self.frag_buf.is_empty() {
+                let mut sink = self.shared.frag_sink.lock().unwrap();
+                sink.append(&mut self.frag_buf);
+            }
+        } else {
+            merge_bias(self);
         }
         merge_unmapped(self);
         flush_sam(self);
@@ -856,10 +966,12 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             shared,
             hs,
             sketch_scratch,
+            seqbias,
+            gcbias,
+            posbias,
             unmapped,
             sam_buf,
             frag_buf,
-            ..
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -870,6 +982,11 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         if sh.sketch && sketch_scratch.is_none() {
             *sketch_scratch = Some(salmon_map::SketchScratch::new(idx.k()));
         }
+        let log_fm = if sh.deterministic {
+            0.0
+        } else {
+            sh.online.map_or(0.0, |o| o.next_log_fm())
+        };
         for rec in records {
             let s = rec.seq();
             let mut maps = if sh.sketch {
@@ -907,25 +1024,43 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                 crate::sam::write_fragment(sam_buf, sh.salmon, rec.id(), s.as_ref(), None, &maps);
             }
             sh.num_processed.fetch_add(1, Ordering::Relaxed);
-            if !maps.is_empty() {
-                frag_buf.push((xxhash_rust::xxh3::xxh3_128(rec.id()), maps));
+            if maps.is_empty() {
+                continue;
+            }
+            let key = xxhash_rust::xxh3::xxh3_128(rec.id());
+            if sh.deterministic {
+                frag_buf.push((key, maps));
+            } else {
+                record(
+                    &sh,
+                    key,
+                    &maps,
+                    log_fm,
+                    seqbias.as_mut(),
+                    gcbias.as_mut(),
+                    posbias.as_mut(),
+                );
             }
         }
         Ok(())
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Pass 1 only maps; the FLD is trained in the deterministic pass 2.
+        if !self.shared.deterministic {
+            self.shared.fld.refresh_online();
+        }
         flush_sam(self);
         Ok(())
     }
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
-        // Hand this worker's mapped fragments to the shared sink for the
-        // deterministic inference pass (bias models are collected there, not here).
-        if !self.frag_buf.is_empty() {
-            let mut sink = self.shared.frag_sink.lock().unwrap();
-            sink.append(&mut self.frag_buf);
+        if self.shared.deterministic {
+            if !self.frag_buf.is_empty() {
+                let mut sink = self.shared.frag_sink.lock().unwrap();
+                sink.append(&mut self.frag_buf);
+            }
+        } else {
+            merge_bias(self);
         }
         merge_unmapped(self);
         flush_sam(self);

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -210,6 +210,105 @@ fn quant_is_byte_identical_across_thread_counts() {
     assert_eq!(p1, p4a, "-p 1 and -p 4 differ");
 }
 
+fn simulate_multimapping(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let backbone = gen_seq(1500, 99);
+    let snp = |seed: u64, n: usize| {
+        let mut s = backbone.clone();
+        let mut x = seed;
+        for _ in 0..n {
+            x = x
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let pos = (x >> 33) as usize % s.len();
+            s[pos] = match s[pos] {
+                b'A' => b'C',
+                b'C' => b'G',
+                b'G' => b'T',
+                _ => b'A',
+            };
+        }
+        s
+    };
+    let txs = [
+        ("d0", backbone.clone()),
+        ("d1", snp(1, 6)),
+        ("d2", snp(2, 6)),
+    ];
+    let fasta = dir.join("multi.fa");
+    let mut fa = std::fs::File::create(&fasta).unwrap();
+    for (name, seq) in &txs {
+        writeln!(fa, ">{name}").unwrap();
+        fa.write_all(seq).unwrap();
+        writeln!(fa).unwrap();
+    }
+    drop(fa);
+    let r1p = dir.join("m1.fq");
+    let r2p = dir.join("m2.fq");
+    let mut w = FastqWriters {
+        r1: std::io::BufWriter::new(std::fs::File::create(&r1p).unwrap()),
+        r2: std::io::BufWriter::new(std::fs::File::create(&r2p).unwrap()),
+    };
+    let mut rng = 0x0BEE_F00Du64;
+    let mut next = || {
+        rng = rng
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        rng >> 33
+    };
+    // Enough fragments to span multiple paraseq batches / worker threads (so the
+    // multi-threaded path is actually exercised).
+    for id in 0..20000 {
+        let frag = 200 + (next() % 100) as usize;
+        let max_start = backbone.len() - frag;
+        let pos = (next() as usize) % (max_start + 1);
+        let s1 = backbone[pos..pos + READ_LEN].to_vec();
+        let s2 = revcomp(&backbone[pos + frag - READ_LEN..pos + frag]);
+        w.write_pair(id, &s1, &s2);
+    }
+    w.r1.flush().unwrap();
+    w.r2.flush().unwrap();
+    (fasta, r1p, r2p)
+}
+
+/// Strongest end-to-end determinism guard: compares the **full-precision** `f64`
+/// abundances (`res.counts`, not the truncated `quant.sf` text) across thread
+/// counts, under the hardest conditions for thread-order sensitivity — many
+/// multimapping fragments (near-duplicate transcripts -> fractional eq-class
+/// weights), `--seqBias --gcBias` on (online masses + bias models), and the
+/// after-burn-in FLD path forced on. With stages 1 (#1027), 2a (#1028) and 2b
+/// (#1030) this is bit-identical; the residual online-mass differences are far
+/// too small to flip the per-fragment-seeded FLD acceptance or the binned bias
+/// models.
+#[test]
+fn multimapping_counts_bit_identical_across_threads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = simulate_multimapping(tmp.path());
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let run = |threads: usize| -> Vec<u64> {
+        let out = tmp.path().join(format!("mm_{threads}"));
+        let mut opts = QuantOptions::new(idx_dir.clone(), out);
+        opts.mates1 = vec![r1.clone()];
+        opts.mates2 = vec![r2.clone()];
+        opts.lib_type = "IU".to_string();
+        opts.num_threads = threads;
+        opts.seq_bias = true;
+        opts.gc_bias = true;
+        // force the after-burn-in FLD path on small data
+        opts.num_pre_aux_model_samples = 50;
+        let res = quantify(&opts).expect("quantify");
+        res.counts.iter().map(|c| c.to_bits()).collect()
+    };
+    let p1 = run(1);
+    let p8a = run(8);
+    let p8b = run(8);
+    assert_eq!(p8a, p8b, "two -p 8 runs differ (full precision)");
+    assert_eq!(p1, p8a, "-p 1 and -p 8 differ (full precision)");
+}
+
 #[test]
 fn pseudoalignment_quantification_tracks_truth() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -196,6 +196,7 @@ fn quant_is_byte_identical_across_thread_counts() {
         opts.mates2 = vec![r2.clone()];
         opts.lib_type = "IU".to_string();
         opts.num_threads = threads;
+        opts.deterministic = true;
         quantify(&opts).expect("quantify");
         std::fs::read_to_string(out.join("quant.sf")).unwrap()
     };
@@ -299,6 +300,9 @@ fn multimapping_counts_bit_identical_across_threads() {
         opts.gc_bias = true;
         // force the after-burn-in FLD path on small data
         opts.num_pre_aux_model_samples = 50;
+        // byte-for-byte reproducibility is opt-in (#1031 review): the two-pass,
+        // key-sorted inference path is what makes this bit-identical across `-p`.
+        opts.deterministic = true;
         let res = quantify(&opts).expect("quantify");
         res.counts.iter().map(|c| c.to_bits()).collect()
     };

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -180,6 +180,37 @@ fn selective_alignment_quantification_tracks_truth() {
 }
 
 #[test]
+fn quant_is_byte_identical_across_thread_counts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2, _truth) = simulate(tmp.path());
+
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let run = |threads: usize, tag: &str| {
+        let out = tmp.path().join(format!("quant_{tag}"));
+        let mut opts = QuantOptions::new(idx_dir.clone(), out.clone());
+        opts.mates1 = vec![r1.clone()];
+        opts.mates2 = vec![r2.clone()];
+        opts.lib_type = "IU".to_string();
+        opts.num_threads = threads;
+        quantify(&opts).expect("quantify");
+        std::fs::read_to_string(out.join("quant.sf")).unwrap()
+    };
+
+    let p1 = run(1, "p1");
+    let p4a = run(4, "p4a");
+    let p4b = run(4, "p4b");
+
+    // Multi-threaded runs must be byte-identical to each other and to the
+    // single-threaded run (no thread-scheduling-dependent drift).
+    assert_eq!(p4a, p4b, "two -p 4 runs differ");
+    assert_eq!(p1, p4a, "-p 1 and -p 4 differ");
+}
+
+#[test]
 fn pseudoalignment_quantification_tracks_truth() {
     let tmp = tempfile::tempdir().unwrap();
     let (fasta, r1, r2, truth) = simulate(tmp.path());


### PR DESCRIPTION
## What

Add an **opt-in** `--deterministic` mode that makes `salmon quant` produce **byte-identical `quant.sf` regardless of `-p N`**, including bias-corrected and large (after-burn-in) runs. Off by default: the default path is the historical inline, fully-parallel inference, unchanged.

> Stacks on #1027 / #1028 / #1030. Reworked from "deterministic by default" to opt-in per @rob-p's review.

## Why

Stages 1 (#1027), 2a (#1028) and 2b (#1030) made the FLD acceptance, FLD accumulation, and eq-class weight reduction order-independent. The remaining sources all trace to the **online masses**, accumulated via lock-free CAS during the parallel loop: the FLD-acceptance threshold, the after-burn-in FLD snapshot a fragment reads, and the bias-model weights (hence effective lengths) all depend on them. Those are only deterministic if fragments go through the online phase in a fixed order, which is what the opt-in pass provides.

## Change

A new `--deterministic` flag (`QuantOptions::deterministic`, default `false`) selects between two inference strategies:

- **Default (inline, parallel):** each worker maps and runs the per-fragment inference (`record`) immediately, accumulating the online posterior, FLD, bias models, and eq-classes concurrently. No fragment store, no serial phase, no added overhead. This is the existing behaviour, restored unchanged.
- **`--deterministic` (two-pass):** pass 1 maps in parallel and only buffers `(key, mappings)` (`key = xxh3_128(read_id)`) into a shared sink; pass 2 (`run_inference_serial`, single-threaded) sorts by key and replays the online posterior, FLD training, bias collection, and eq-class accumulation in that fixed order. The online masses, FLD, bias models, and eq-class weights become a pure function of the input.

The burn-in gate reads the shared `num_processed` counter inline (as before) and the online inference's progressive count in the deterministic pass, so `numPreAuxModelSamples` is honored in either path.

## Trade-offs

- **Default unchanged:** with the flag off there is no fragment store and no serial phase. The cost is paid only when the flag is set.
- **`--deterministic` perf:** the serial inference pass is a small slice of wall time on real data, where the (still-parallel) mapping pass dominates; the ~20% seen on trivial synthetic reads is an artifact of their near-instant mapping.
- **`--deterministic` memory:** the inter-pass buffer holds `(u128 key, mappings)` per mapped fragment (the `read_id` bytes are not retained). This is inherent to a by-construction determinism guarantee, and the natural next step (see discussion) is a RAD-backed on-disk store so very large inputs stream from disk in pass 2.

## Testing

- Accuracy unchanged: `selective_alignment_quantification_tracks_truth` / `pseudoalignment_…` (default inline path) still recover the true fractions.
- Determinism (opt-in): `quant_is_byte_identical_across_thread_counts` and the full-precision `multimapping_counts_bit_identical_across_threads` (20k multimapping fragments, `--seqBias --gcBias`, after-burn-in forced, `-p 1` vs `-p 8`) set `deterministic = true` and pass, guaranteed **by construction**.
- `cargo test --workspace`: 158 passing. `cargo fmt --all --check`: clean. `cargo clippy`: no findings in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
