### PR TITLE
feat(quant): RAD-format input (--rad) and --writeRad (decouple map/quant)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222fb4925a15bea6a68075021910e03d6aa2d04951d71ff1d956190a551d738f"
 
 [[package]]
+name = "bio-types"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dcf54f8b7f51450207d54780bab09c05f30b8b0caa991545082842e466ad7e"
+dependencies = [
+ "derive-new",
+ "lazy_static",
+ "regex",
+ "strum_macros",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +759,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_setters"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1182,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1381,6 +1420,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libradicl"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4007c1723234af12a1cc779b5d9fccdeda516f8904bc2bb86051b050fc4490"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "bio-types",
+ "bytemuck",
+ "crossbeam-queue",
+ "dashmap",
+ "derivative",
+ "itertools 0.13.0",
+ "noodles",
+ "num",
+ "scroll",
+ "serde",
+ "smallvec",
+ "snap",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,6 +1663,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "noodles"
+version = "0.85.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ecd3b4ddb5792b0358e035fbd41543613e4234dc2d0f13c814e3d5e705d8c8"
+dependencies = [
+ "noodles-bam 0.70.0",
+ "noodles-sam 0.66.0",
+]
+
+[[package]]
+name = "noodles-bam"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57dbbc6b91efed384ceac16c1f4f764bc07d4941bacf7d5d7fdccfef48f52031"
+dependencies = [
+ "bstr",
+ "byteorder",
+ "bytes",
+ "indexmap",
+ "memchr",
+ "noodles-bgzf 0.33.0",
+ "noodles-core 0.15.0",
+ "noodles-csi 0.40.0",
+ "noodles-sam 0.66.0",
+]
+
+[[package]]
 name = "noodles-bam"
 version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,10 +1698,22 @@ dependencies = [
  "bstr",
  "indexmap",
  "memchr",
- "noodles-bgzf",
- "noodles-core",
- "noodles-csi",
- "noodles-sam",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+ "noodles-csi 0.56.0",
+ "noodles-sam 0.85.0",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b50aaa8f0a3c8a0b738b641a6d1a78d9fd30a899ab2d398779ee3c4eb80f1c1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
 ]
 
 [[package]]
@@ -1629,6 +1729,15 @@ dependencies = [
 
 [[package]]
 name = "noodles-core"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a8c6b020d1205abef2b0fab4463a6c5ecc3c8f4d561ca8b0d1a42323376200"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "noodles-core"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8dbac7c5f9a7de9fe45590f198a09697df631cd13d2060b4742cc48144555b0"
@@ -1638,15 +1747,45 @@ dependencies = [
 
 [[package]]
 name = "noodles-csi"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99fdf34a300b37bc15160afcbec76487750bf6e3d9a6ff69c8e4fd635bc66745"
+dependencies = [
+ "bit-vec 0.8.0",
+ "bstr",
+ "byteorder",
+ "indexmap",
+ "noodles-bgzf 0.33.0",
+ "noodles-core 0.15.0",
+]
+
+[[package]]
+name = "noodles-csi"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6832254d731cb022d46927ce64403221b280b17140516cafa21e43ee4140d633"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
  "bstr",
  "indexmap",
- "noodles-bgzf",
- "noodles-core",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+]
+
+[[package]]
+name = "noodles-sam"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26c31cfbb05b20fc8fb3cf1ac556efca0ff4b3455112705dd2ea81ae01e7d81"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "indexmap",
+ "lexical-core",
+ "memchr",
+ "noodles-bgzf 0.33.0",
+ "noodles-core 0.15.0",
+ "noodles-csi 0.40.0",
 ]
 
 [[package]]
@@ -1660,9 +1799,9 @@ dependencies = [
  "indexmap",
  "lexical-core",
  "memchr",
- "noodles-bgzf",
- "noodles-core",
- "noodles-csi",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+ "noodles-csi 0.56.0",
 ]
 
 [[package]]
@@ -1681,6 +1820,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -1718,6 +1871,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2325,9 +2489,9 @@ dependencies = [
  "crossbeam-channel",
  "flate2",
  "jiff",
- "noodles-bam",
- "noodles-bgzf",
- "noodles-sam",
+ "noodles-bam 0.90.0",
+ "noodles-bgzf 0.47.0",
+ "noodles-sam 0.85.0",
  "rayon",
  "salmon-core",
  "salmon-eqclass",
@@ -2439,6 +2603,7 @@ dependencies = [
  "anyhow",
  "flate2",
  "jiff",
+ "libradicl",
  "paraseq",
  "piscem-rs",
  "rayon",
@@ -2478,6 +2643,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 
 [[package]]
 name = "sdd"
@@ -2654,6 +2825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "sshash-lib"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2887,19 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "succinctly"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tracing",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ sha2 = "0.10"
 # COMBINE-lab dependencies, from crates.io.
 cf1-rs = "0.5"
 piscem-rs = "0.6.0"
+# RAD-format mapping store (deterministic two-pass path; the format used by
+# piscem / piscem-infer / alevin-fry, and the groundwork for RAD-format input).
+libradicl = "0.10"
 
 # dev / test helpers
 tempfile = "3"

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -575,6 +575,16 @@ struct QuantArgs {
     /// between passes) and serializes the inference phase; off by default.
     #[arg(long = "deterministic")]
     deterministic: bool,
+    /// Write the mapping store to this path (RAD format) and keep it. Implies the
+    /// deterministic store is produced; the result can later be re-quantified with
+    /// `--rad` (salmon map -> RAD -> salmon quant), avoiding re-mapping.
+    #[arg(long = "writeRad", value_name = "FILE")]
+    write_rad: Option<PathBuf>,
+    /// Quantify from a RAD mapping store (written by `--writeRad`) instead of
+    /// mapping FASTQ reads. The index (`-i`) still supplies reference
+    /// lengths/sequences for effective lengths and bias correction.
+    #[arg(long = "rad", value_name = "FILE")]
+    rad: Option<PathBuf>,
     /// [accepted; not yet implemented] disable fragment-length-distribution
     /// concordance in the per-fragment probability.
     #[arg(long = "noFragLengthDist")]
@@ -836,10 +846,14 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Reads (selective-alignment / pseudoalignment) mode.
+    // Reads (selective-alignment / pseudoalignment) mode, or RAD-store input.
     anyhow::ensure!(
-        !args.mates1.is_empty() || !args.unmated.is_empty(),
-        "no reads provided: pass -1/-2 (paired), -r (single-end), or -a (BAM)"
+        !args.mates1.is_empty() || !args.unmated.is_empty() || args.rad.is_some(),
+        "no input provided: pass -1/-2 (paired), -r (single-end), -a (BAM), or --rad (RAD store)"
+    );
+    anyhow::ensure!(
+        args.rad.is_none() || (args.mates1.is_empty() && args.unmated.is_empty()),
+        "--rad cannot be combined with read inputs (-1/-2/-r)"
     );
     anyhow::ensure!(
         args.mates1.len() == args.mates2.len(),
@@ -901,6 +915,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.skip_quant = args.skip_quant;
     opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples;
     opts.deterministic = args.deterministic;
+    opts.write_rad = args.write_rad.clone();
+    opts.rad_input = args.rad.clone();
     opts.map_config.seed_mode = seed_mode(args.unimems, args.refmems, args.sparse_seeds);
     // alignment scoring (selective alignment)
     opts.map_config.align.match_score = args.ma as i8;

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -568,6 +568,13 @@ struct QuantArgs {
     /// salmon's default is 1000000, this port's is 5000.)
     #[arg(long = "numPreAuxModelSamples", default_value_t = 5000)]
     num_pre_aux_model_samples: u64,
+    /// Produce byte-for-byte identical `quant.sf` regardless of thread count
+    /// (`-p`). Splits quantification into a parallel mapping pass and a
+    /// single-threaded, key-sorted inference pass, so every order-dependent
+    /// accumulation is reproducible. Costs some memory (mapped fragments are held
+    /// between passes) and serializes the inference phase; off by default.
+    #[arg(long = "deterministic")]
+    deterministic: bool,
     /// [accepted; not yet implemented] disable fragment-length-distribution
     /// concordance in the per-fragment probability.
     #[arg(long = "noFragLengthDist")]
@@ -893,6 +900,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.cond_gc_bins = args.conditional_gc_bins;
     opts.skip_quant = args.skip_quant;
     opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples;
+    opts.deterministic = args.deterministic;
     opts.map_config.seed_mode = seed_mode(args.unimems, args.refmems, args.sparse_seeds);
     // alignment scoring (selective alignment)
     opts.map_config.align.match_score = args.ma as i8;

--- a/crates/salmon-eqclass/src/lib.rs
+++ b/crates/salmon-eqclass/src/lib.rs
@@ -12,6 +12,8 @@
 //! into a flat [`CollapsedEqClasses`] for inference.
 
 use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 use xxhash_rust::xxh3::Xxh3;
 
 /// The label of an equivalence class: the sorted set of transcript ids a
@@ -211,12 +213,38 @@ impl TGValue {
     }
 }
 
-/// Concurrent equivalence-class builder backed by `scc::HashMap`.
+/// One fragment's contribution to an equivalence class, retained with a stable
+/// per-fragment key so the per-class weight sum is reduced in a deterministic,
+/// thread-count-independent order (see [`EquivalenceClassBuilder::finish`]).
+pub struct Contribution {
+    /// stable per-fragment sort key (e.g. a hash of the read name); ties on the
+    /// transcript label are broken by this key so the reduction order is fixed.
+    pub key: u128,
+    pub group: TranscriptGroup,
+    pub weights: Vec<f64>,
+    pub count: u64,
+}
+
+/// Number of buffer shards (a power of two) the builder spreads contributions
+/// across to bound lock contention during the concurrent mapping phase.
+const SHARDS: usize = 64;
+
+/// Concurrent equivalence-class builder.
 ///
-/// Worker threads call [`add_group`](Self::add_group) with `&self` while
-/// mapping reads; insertion is lock-free per bucket.
+/// Worker threads call [`add_group_keyed`](Self::add_group_keyed) with `&self`
+/// while mapping reads; each fragment's contribution is appended to a key-sharded
+/// buffer (low contention) rather than summed in place. [`finish`](Self::finish)
+/// then groups the contributions by class and **sums each class's weights in a
+/// fixed order** (sorted by the transcript label, ties broken by the per-fragment
+/// key), so the result is byte-identical regardless of how fragments were
+/// distributed across threads. (Summing floats in arrival order — the previous
+/// `DashMap` accumulation — is not associative and drifted run-to-run for
+/// multimapping classes.)
 pub struct EquivalenceClassBuilder {
-    map: dashmap::DashMap<TranscriptGroup, TGValue, IdentityBuildHasher>,
+    shards: Vec<Mutex<Vec<Contribution>>>,
+    /// fallback monotonic key source for [`add_group`](Self::add_group) callers
+    /// that have no stable per-fragment key (single-threaded / alignment mode).
+    next_seq: AtomicU64,
 }
 
 impl Default for EquivalenceClassBuilder {
@@ -228,36 +256,72 @@ impl Default for EquivalenceClassBuilder {
 impl EquivalenceClassBuilder {
     pub fn new() -> Self {
         Self {
-            map: dashmap::DashMap::with_hasher(IdentityBuildHasher),
+            shards: (0..SHARDS).map(|_| Mutex::new(Vec::new())).collect(),
+            next_seq: AtomicU64::new(0),
         }
     }
 
-    /// Add one fragment's worth of evidence: the transcript group, its
-    /// per-transcript weights, and a count (usually 1). Thread-safe.
-    pub fn add_group(&self, group: TranscriptGroup, weights: Vec<f64>, count: u64) {
+    /// Add one fragment's evidence with a **stable per-fragment key** (e.g. a
+    /// hash of the read name). The key fixes the per-class weight-summation order
+    /// in [`finish`](Self::finish), making the result thread-count-independent.
+    pub fn add_group_keyed(
+        &self,
+        key: u128,
+        group: TranscriptGroup,
+        weights: Vec<f64>,
+        count: u64,
+    ) {
         debug_assert_eq!(group.txps.len(), weights.len());
-        self.map
-            .entry(group)
-            .and_modify(|v| v.accumulate(&weights, count))
-            .or_insert_with(|| TGValue::new(weights, count));
+        let shard = (key as usize) & (SHARDS - 1);
+        self.shards[shard].lock().unwrap().push(Contribution {
+            key,
+            group,
+            weights,
+            count,
+        });
     }
 
-    /// Number of distinct equivalence classes accumulated so far.
+    /// Add one fragment's evidence without a stable key (single-threaded callers
+    /// and alignment mode); a monotonic sequence number is used as the key.
+    pub fn add_group(&self, group: TranscriptGroup, weights: Vec<f64>, count: u64) {
+        let key = self.next_seq.fetch_add(1, Ordering::Relaxed) as u128;
+        self.add_group_keyed(key, group, weights, count);
+    }
+
+    /// Number of buffered contributions so far (not distinct classes).
     pub fn len(&self) -> usize {
-        self.map.len()
+        self.shards.iter().map(|s| s.lock().unwrap().len()).sum()
     }
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        self.shards.iter().all(|s| s.lock().unwrap().is_empty())
     }
 
-    /// Finalize into a flat, index-stable collection for inference. Classes are
-    /// sorted by their transcript label for determinism.
+    /// Finalize into a flat, index-stable collection for inference. Contributions
+    /// are sorted by `(txps, bins, key)` and consecutive same-class contributions
+    /// are summed in that fixed order, so both the class ordering and the summed
+    /// weights are deterministic.
     pub fn finish(self) -> CollapsedEqClasses {
-        let mut classes: Vec<(TranscriptGroup, TGValue)> = Vec::with_capacity(self.map.len());
-        self.map
-            .iter()
-            .for_each(|e| classes.push((e.key().clone(), e.value().clone())));
-        classes.sort_by(|a, b| a.0.txps.cmp(&b.0.txps));
+        let mut contribs: Vec<Contribution> = Vec::new();
+        for shard in self.shards {
+            contribs.extend(shard.into_inner().unwrap());
+        }
+        contribs.sort_by(|a, b| {
+            a.group
+                .txps
+                .cmp(&b.group.txps)
+                .then_with(|| a.group.bins.cmp(&b.group.bins))
+                .then_with(|| a.key.cmp(&b.key))
+        });
+        let mut classes: Vec<(TranscriptGroup, TGValue)> = Vec::new();
+        for c in contribs {
+            if let Some((g, v)) = classes.last_mut() {
+                if g.txps == c.group.txps && g.bins == c.group.bins {
+                    v.accumulate(&c.weights, c.count);
+                    continue;
+                }
+            }
+            classes.push((c.group, TGValue::new(c.weights, c.count)));
+        }
         let total_count = classes.iter().map(|(_, v)| v.count).sum();
         CollapsedEqClasses {
             classes,
@@ -334,9 +398,9 @@ mod tests {
         b.add_group(TranscriptGroup::new(vec![1, 2]), vec![0.5, 0.5], 1);
         b.add_group(TranscriptGroup::new(vec![2, 1]), vec![0.5, 0.5], 1);
         b.add_group(TranscriptGroup::new(vec![3]), vec![1.0], 1);
-        assert_eq!(b.len(), 2);
 
         let collapsed = b.finish();
+        assert_eq!(collapsed.classes.len(), 2, "two distinct classes");
         assert_eq!(collapsed.total_count, 3);
         // sorted: [1,2] then [3]
         let (g0, v0) = &collapsed.classes[0];
@@ -346,6 +410,38 @@ mod tests {
         let (g1, v1) = &collapsed.classes[1];
         assert_eq!(g1.txps, vec![3]);
         assert_eq!(v1.count, 1);
+    }
+
+    #[test]
+    fn weight_sum_is_insertion_order_independent() {
+        // The per-class weight sum must be byte-identical regardless of the order
+        // fragments were added (how threads interleaved). Plain f64 addition is
+        // not associative, so this fails for arrival-order accumulation and holds
+        // only because `finish` reduces in a fixed key-sorted order.
+        let make = |order: &[usize]| -> Vec<u64> {
+            let b = EquivalenceClassBuilder::new();
+            for &i in order {
+                let key = (i as u128).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+                let w = vec![
+                    1.0 / 3.0 + (i as f64) * 1e-12,
+                    2.0 / 3.0 - (i as f64) * 1e-12,
+                ];
+                b.add_group_keyed(key, TranscriptGroup::new(vec![0, 1]), w, 1);
+            }
+            let c = b.finish();
+            c.classes[0].1.weights.iter().map(|x| x.to_bits()).collect()
+        };
+        let fwd: Vec<usize> = (0..200).collect();
+        let mut rev = fwd.clone();
+        rev.reverse();
+        // 137 is coprime to 200, so this is a permutation.
+        let shuf: Vec<usize> = (0..200).map(|i| (i * 137) % 200).collect();
+        assert_eq!(make(&fwd), make(&rev), "weight sum differs by order (rev)");
+        assert_eq!(
+            make(&fwd),
+            make(&shuf),
+            "weight sum differs by order (shuf)"
+        );
     }
 
     #[test]
@@ -374,7 +470,7 @@ mod tests {
         // a third fragment matching g1's shape merges with it
         let g3 = TranscriptGroup::with_bins(txps, range_factorize_bins(&[0.92, 0.08], 4));
         b.add_group(g3, vec![0.92, 0.08], 1);
-        assert_eq!(b.len(), 2, "expected 2 factorized classes");
+        assert_eq!(b.finish().len(), 2, "expected 2 factorized classes");
     }
 
     #[test]

--- a/crates/salmon-model/src/fld.rs
+++ b/crates/salmon-model/src/fld.rs
@@ -12,7 +12,7 @@
 use salmon_core::atomic::AtomicF64;
 use salmon_core::math::{log_add, LOG_0, LOG_EPSILON};
 use statrs::distribution::{Binomial, ContinuousCDF, Discrete, Normal};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 /// Tracks the observed distribution of fragment lengths.
@@ -24,12 +24,24 @@ pub struct FragmentLengthDistribution {
     hist: Vec<AtomicF64>,
     /// logged total observed mass (including pseudo-counts)
     tot_mass: AtomicF64,
-    /// logged sum of length*mass, for fast mean computation
-    sum: AtomicF64,
     /// minimum observed length (bin units)
     min: AtomicUsize,
     /// internal bin size
     bin_size: usize,
+
+    /// Order-independent observation counter (one per length bin). [`add_val`]
+    /// increments this in addition to spreading the kernel into `hist`. Because
+    /// every observation contributes the *same* kernel (`add_val(len, 0.0)`), the
+    /// trained histogram is exactly `prior + Σ_bin counts[bin]·kernel`, which the
+    /// deterministic reads-mode paths ([`refresh_online`](Self::refresh_online),
+    /// [`cache`](Self::cache), [`mean`](Self::mean)) rebuild from these counts in a
+    /// fixed bin order — independent of how observations were interleaved across
+    /// worker threads. The live `hist`/`tot_mass`/`sum` accumulation is retained
+    /// for the alignment-mode live `pmf` reads, which do not require determinism.
+    counts: Vec<AtomicU64>,
+    /// linear-space prior mass per bin (the initial `hist` before any
+    /// observation), captured once at construction for the deterministic rebuild.
+    prior_lin: Vec<f64>,
 
     /// cached normalized PMF, valid once [`cache`](Self::cache) is called
     cached_pmf: Vec<f64>,
@@ -89,7 +101,6 @@ impl FragmentLengthDistribution {
 
         let tot = alpha.ln();
         let hist: Vec<AtomicF64>;
-        let mut sum = LOG_0;
         let mut tot_mass;
 
         if prior_mu > 0.0 {
@@ -108,7 +119,6 @@ impl FragmentLengthDistribution {
                     LOG_EPSILON
                 };
                 slot.store(mass);
-                sum = log_add(sum, (i as f64).ln() + mass);
                 tot_mass = log_add(tot_mass, mass);
             }
         } else {
@@ -116,8 +126,6 @@ impl FragmentLengthDistribution {
             let per = tot - (max_val as f64).ln();
             hist = (0..=max_val).map(|_| AtomicF64::new(per)).collect();
             hist[0].store(LOG_0);
-            let h1 = hist.get(1).map(|a| a.load()).unwrap_or(per);
-            sum = h1 + ((max_val * (max_val + 1)) as f64).ln() - 2.0_f64.ln();
             tot_mass = tot;
         }
 
@@ -125,13 +133,19 @@ impl FragmentLengthDistribution {
         let binom = Binomial::new(kernel_p, kernel_n as u64).expect("valid binomial kernel");
         let kernel: Vec<f64> = (0..=kernel_n).map(|i| binom.pmf(i as u64).ln()).collect();
 
+        // Linear-space prior (the initial histogram) and a zeroed observation
+        // counter per bin, for the deterministic rebuild.
+        let prior_lin: Vec<f64> = hist.iter().map(|a| a.load().exp()).collect();
+        let counts: Vec<AtomicU64> = (0..hist.len()).map(|_| AtomicU64::new(0)).collect();
+
         Self {
             kernel,
             hist,
             tot_mass: AtomicF64::new(tot_mass),
-            sum: AtomicF64::new(sum),
             min: AtomicUsize::new(max_val),
             bin_size,
+            counts,
+            prior_lin,
             cached_pmf: Vec::new(),
             cached_cmf: Vec::new(),
             have_cache: false,
@@ -170,6 +184,11 @@ impl FragmentLengthDistribution {
         }
         self.min.fetch_min(len, Ordering::Relaxed);
 
+        // Order-independent count for the deterministic rebuild. Every quant/align
+        // observation is a unit count (`mass == 0.0`); the rebuild assumes that.
+        debug_assert_eq!(mass, 0.0, "deterministic rebuild assumes unit observations");
+        self.counts[len].fetch_add(1, Ordering::Relaxed);
+
         let half = self.kernel.len() / 2;
         // offset can go negative conceptually; use isize math then bound-check.
         let mut offset = len as isize - half as isize;
@@ -178,11 +197,44 @@ impl FragmentLengthDistribution {
                 let o = offset as usize;
                 let k_mass = mass + k;
                 self.hist[o].log_add_assign(k_mass);
-                self.sum.log_add_assign((o as f64).ln() + k_mass);
                 self.tot_mass.log_add_assign(k_mass);
             }
             offset += 1;
         }
+    }
+
+    /// Deterministically rebuild the linear-space histogram from the prior plus
+    /// the order-independent observation counts: `lin[o] = prior_lin[o] +
+    /// Σ_bin counts[bin]·kernel_lin[o − bin + half]`, accumulated in a fixed bin
+    /// order so the result does not depend on thread interleaving. Returns the
+    /// per-bin log-mass and the log total. Used by the reads-mode snapshot /
+    /// cache / mean paths so their outputs are byte-identical across thread
+    /// counts.
+    fn counts_hist(&self) -> (Vec<f64>, f64) {
+        let n = self.hist.len();
+        let mut lin = self.prior_lin.clone();
+        let kernel_lin: Vec<f64> = self.kernel.iter().map(|k| k.exp()).collect();
+        let half = self.kernel.len() / 2;
+        for bin in 0..n {
+            let c = self.counts[bin].load(Ordering::Relaxed);
+            if c == 0 {
+                continue;
+            }
+            let cf = c as f64;
+            for (kidx, &kl) in kernel_lin.iter().enumerate() {
+                let offset = bin as isize - half as isize + kidx as isize;
+                if offset > 0 && (offset as usize) < n {
+                    lin[offset as usize] += cf * kl;
+                }
+            }
+        }
+        let log_hist: Vec<f64> = lin
+            .iter()
+            .map(|&m| if m > 0.0 { m.ln() } else { LOG_0 })
+            .collect();
+        let tot: f64 = lin.iter().sum();
+        let log_tot = if tot > 0.0 { tot.ln() } else { LOG_0 };
+        (log_hist, log_tot)
     }
 
     /// Logged probability of observing a fragment of length `len`.
@@ -213,22 +265,25 @@ impl FragmentLengthDistribution {
         }
         let max_raw = self.max_val();
         let max_v = max_raw / self.bin_size;
-        let tot = self.tot_mass.load();
+        // Rebuild from the order-independent counts (not the live `hist`), so the
+        // snapshot a fragment reads is byte-identical regardless of how
+        // observations were interleaved across worker threads.
+        let (log_hist, tot) = self.counts_hist();
         // Per-bin cumulative mass (matches `cmf()`), so the snapshot CMF at raw
         // index `raw` equals `cmf(raw)`. Built first, then both the PMF and CMF
-        // snapshots are expanded over raw indices from the same `tot` read so
-        // they are mutually consistent.
+        // snapshots are expanded over raw indices from the same `tot` so they are
+        // mutually consistent.
         let mut bin_cum = Vec::with_capacity(max_v + 1);
         let mut cum = LOG_0;
         for b in 0..=max_v {
-            cum = log_add(cum, self.hist[b].load() - tot);
+            cum = log_add(cum, log_hist[b] - tot);
             bin_cum.push(cum);
         }
         let mut v = Vec::with_capacity(max_raw + 1);
         let mut c = Vec::with_capacity(max_raw + 1);
         for raw in 0..=max_raw {
             let l = (raw / self.bin_size).min(max_v);
-            v.push(self.hist[l].load() - tot);
+            v.push(log_hist[l] - tot);
             c.push(bin_cum[l]);
         }
         *self.online_pmf.write().unwrap() = Arc::new(v);
@@ -279,9 +334,21 @@ impl FragmentLengthDistribution {
         self.tot_mass.load()
     }
 
-    /// Mean observed length.
+    /// Mean observed length (in bin units, matching the historical
+    /// `sum/tot_mass` ratio). Computed from the order-independent counts so the
+    /// reported `frag_len_mean` is byte-identical across thread counts.
     pub fn mean(&self) -> f64 {
-        (self.sum.load() - self.tot_mass.load()).exp()
+        let (log_hist, log_tot) = self.counts_hist();
+        let mut s = 0.0;
+        for (bin, &lh) in log_hist.iter().enumerate() {
+            s += (bin as f64) * lh.exp();
+        }
+        let tot = log_tot.exp();
+        if tot > 0.0 {
+            s / tot
+        } else {
+            0.0
+        }
     }
 
     /// Standard deviation of the observed length distribution, computed from the
@@ -310,11 +377,16 @@ impl FragmentLengthDistribution {
             return;
         }
         let max_v = self.max_val();
-        // normalized PMF over [0, max_v]
+        // Build from the order-independent counts (not the live `hist`) so the
+        // cached PMF/CMF — and therefore the effective lengths derived from it —
+        // are byte-identical regardless of thread count.
+        let (log_hist, log_tot) = self.counts_hist();
+        let max_bin = log_hist.len() - 1;
+        // un-normalized log-PMF over [0, max_v] (raw indices, binned like `pmf`)
         let mut pmf = Vec::with_capacity(max_v + 1);
         let mut tot = LOG_0;
         for i in 0..=max_v {
-            let p = self.pmf(i);
+            let p = log_hist[(i / self.bin_size).min(max_bin)] - log_tot;
             pmf.push(p);
             tot = log_add(tot, p);
         }
@@ -448,6 +520,48 @@ mod tests {
         let fld = FragmentLengthDistribution::new(1000.0, 1000, 250.0, 25.0, 4, 0.5, 1);
         let m = fld.mean();
         assert!((m - 250.0).abs() < 5.0, "mean {m} not near 250");
+    }
+
+    #[test]
+    fn accumulation_is_order_independent() {
+        // The trained distribution must be byte-identical regardless of the order
+        // in which observations arrive (i.e. how they were interleaved across
+        // worker threads). Same multiset of lengths, two different orders.
+        let lengths_fwd: Vec<usize> = (0..2000).map(|i| 150 + (i * 7) % 500).collect();
+        let mut lengths_rev = lengths_fwd.clone();
+        lengths_rev.reverse();
+        let mut lengths_shuf = lengths_fwd.clone();
+        // deterministic shuffle (no Math.random; index-driven swaps)
+        for i in 0..lengths_shuf.len() {
+            let j = (i.wrapping_mul(2654435761)) % lengths_shuf.len();
+            lengths_shuf.swap(i, j);
+        }
+
+        let build = |order: &[usize]| {
+            let mut fld = FragmentLengthDistribution::new(1.0, 1000, 0.0, 0.0, 4, 0.5, 1);
+            for &l in order {
+                fld.add_val(l, 0.0);
+            }
+            // exercise the online snapshot path too
+            fld.refresh_online();
+            let snap = fld.online_snapshot().as_ref().clone();
+            let mean = fld.mean();
+            fld.cache();
+            (fld.log_pmf().to_vec(), fld.cached_cmf.clone(), snap, mean)
+        };
+
+        let (pmf_f, cmf_f, snap_f, mean_f) = build(&lengths_fwd);
+        let (pmf_r, cmf_r, snap_r, mean_r) = build(&lengths_rev);
+        let (pmf_s, cmf_s, snap_s, mean_s) = build(&lengths_shuf);
+
+        assert_eq!(pmf_f, pmf_r, "cached PMF differs by insertion order (rev)");
+        assert_eq!(pmf_f, pmf_s, "cached PMF differs by insertion order (shuf)");
+        assert_eq!(cmf_f, cmf_r, "cached CMF differs by insertion order (rev)");
+        assert_eq!(cmf_f, cmf_s, "cached CMF differs by insertion order (shuf)");
+        assert_eq!(snap_f, snap_r, "online snapshot differs by insertion order");
+        assert_eq!(snap_f, snap_s, "online snapshot differs by insertion order");
+        assert_eq!(mean_f.to_bits(), mean_r.to_bits(), "mean differs by order");
+        assert_eq!(mean_f.to_bits(), mean_s.to_bits(), "mean differs by order");
     }
 
     #[test]

--- a/crates/salmon-quant/Cargo.toml
+++ b/crates/salmon-quant/Cargo.toml
@@ -16,6 +16,7 @@ salmon-model = { workspace = true }
 salmon-eqclass = { workspace = true }
 salmon-infer = { workspace = true }
 piscem-rs = { workspace = true }
+libradicl = { workspace = true }
 paraseq = "0.4"
 xxhash-rust = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/salmon-quant/Cargo.toml
+++ b/crates/salmon-quant/Cargo.toml
@@ -17,6 +17,7 @@ salmon-eqclass = { workspace = true }
 salmon-infer = { workspace = true }
 piscem-rs = { workspace = true }
 paraseq = "0.4"
+xxhash-rust = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -145,6 +145,12 @@ pub struct QuantOptions {
     /// online posterior (salmon's `--numPreAuxModelSamples`; salmon's default is
     /// 1,000,000, this port's prior hardcoded value is 5,000)
     pub num_pre_aux_model_samples: u64,
+    /// opt-in byte-for-byte reproducibility (`--deterministic`). When `true`,
+    /// quantification splits into a parallel mapping pass and a single-threaded,
+    /// key-sorted inference pass so `quant.sf` is byte-identical regardless of
+    /// `-p N`. Default `false` keeps the historical inline, fully-parallel path
+    /// (no fragment store, no extra overhead).
+    pub deterministic: bool,
     /// Optional shared progress counters. When `Some`, [`quantify`] reports
     /// processed/mapped fragment counts here as it runs so the caller can drive
     /// a live progress display. `None` (the default) disables sharing.
@@ -194,6 +200,7 @@ impl QuantOptions {
             cond_gc_bins: salmon_model::gcbias::DEFAULT_COND_BINS,
             skip_quant: false,
             num_pre_aux_model_samples: processor::NUM_PRE_BURNIN,
+            deterministic: false,
             progress: None,
         }
     }
@@ -401,8 +408,10 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     };
 
     // ---- parallel mapping pass (borrows the accumulators) -------------------
-    // Pass 1 maps reads in parallel and buffers each mapped fragment here; pass 2
-    // (`run_inference_serial`) replays the inference deterministically.
+    // The default path runs inference inline during this pass. With
+    // `--deterministic`, pass 1 instead buffers each mapped fragment into
+    // `frag_sink` and pass 2 (`run_inference_serial`) replays the inference in a
+    // fixed key-sorted order; the sink stays empty otherwise.
     let frag_sink: std::sync::Mutex<Vec<(u128, Vec<salmon_map::ScoredMapping>)>> =
         std::sync::Mutex::new(Vec::new());
     {
@@ -444,6 +453,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             num_below_threshold_vm: &num_below_threshold_vm,
             unmapped_names: unmapped_collector.as_ref(),
             sam: sam_writer.as_ref(),
+            deterministic: opts.deterministic,
             frag_sink: &frag_sink,
         };
         let mut proc = QuantProcessor::new(shared);
@@ -462,8 +472,12 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         }
         drop(proc);
         // ---- deterministic inference pass (single-threaded, key-sorted) ------
-        let frags = std::mem::take(&mut *frag_sink.lock().unwrap());
-        run_inference_serial(&shared, frags, INFERENCE_BATCH);
+        // Only with `--deterministic`; the default path already ran the inference
+        // inline during the parallel mapping pass.
+        if opts.deterministic {
+            let frags = std::mem::take(&mut *frag_sink.lock().unwrap());
+            run_inference_serial(&shared, frags, INFERENCE_BATCH);
+        }
     }
     {
         let p = num_processed.load(Ordering::Relaxed);

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -31,7 +31,11 @@ use salmon_map::MapConfig;
 use salmon_model::dumps::BiasDump;
 use salmon_model::{FragmentLengthDistribution, LibraryTypeDetector, SBModel};
 
-use processor::{QuantProcessor, Shared};
+use processor::{run_inference_serial, QuantProcessor, Shared};
+
+/// Mini-batch size for the deterministic inference pass (forgetting-mass
+/// schedule + FLD-snapshot refresh granularity).
+const INFERENCE_BATCH: usize = 5000;
 
 pub use output::write_outputs;
 
@@ -397,6 +401,10 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     };
 
     // ---- parallel mapping pass (borrows the accumulators) -------------------
+    // Pass 1 maps reads in parallel and buffers each mapped fragment here; pass 2
+    // (`run_inference_serial`) replays the inference deterministically.
+    let frag_sink: std::sync::Mutex<Vec<(Vec<u8>, Vec<salmon_map::ScoredMapping>)>> =
+        std::sync::Mutex::new(Vec::new());
     {
         let shared = Shared {
             salmon: &salmon,
@@ -436,6 +444,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             num_below_threshold_vm: &num_below_threshold_vm,
             unmapped_names: unmapped_collector.as_ref(),
             sam: sam_writer.as_ref(),
+            frag_sink: &frag_sink,
         };
         let mut proc = QuantProcessor::new(shared);
         tracing::info!(
@@ -451,6 +460,10 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         } else {
             run_single(&opts.unmated, &mut proc, nthreads)?;
         }
+        drop(proc);
+        // ---- deterministic inference pass (single-threaded, key-sorted) ------
+        let frags = std::mem::take(&mut *frag_sink.lock().unwrap());
+        run_inference_serial(&shared, frags, INFERENCE_BATCH);
     }
     {
         let p = num_processed.load(Ordering::Relaxed);

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -157,6 +157,15 @@ pub struct QuantOptions {
     /// more runs (exercising the k-way merge) at the cost of more, smaller run
     /// files; primarily a test knob.
     pub det_run_size: Option<usize>,
+    /// write the mapping store to this path and keep it (`--writeRad`). Implies
+    /// the deterministic store is produced (pass 1 streams mappings to RAD);
+    /// the result can later be quantified with [`Self::rad_input`].
+    pub write_rad: Option<PathBuf>,
+    /// quantify from this RAD mapping store instead of mapping FASTQ reads
+    /// (`--rad`). Must be a RAD written by salmon (see [`Self::write_rad`]); the
+    /// index still supplies reference lengths/sequences for effective lengths and
+    /// bias correction. Mutually exclusive with read inputs.
+    pub rad_input: Option<PathBuf>,
     /// Optional shared progress counters. When `Some`, [`quantify`] reports
     /// processed/mapped fragment counts here as it runs so the caller can drive
     /// a live progress display. `None` (the default) disables sharing.
@@ -208,6 +217,8 @@ impl QuantOptions {
             num_pre_aux_model_samples: processor::NUM_PRE_BURNIN,
             deterministic: false,
             det_run_size: None,
+            write_rad: None,
+            rad_input: None,
             progress: None,
         }
     }
@@ -328,9 +339,23 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         opts.num_threads
     };
 
+    // RAD-format input (`--rad`): quantify from a salmon-written mapping store
+    // instead of FASTQ reads. Validate the profile up front and take paired-vs-
+    // single from the RAD header (there are no FASTQ mates to infer it from).
+    let rad_input = opts.rad_input.as_ref();
+    if let Some(path) = rad_input {
+        rad::verify_salmon_profile(path)
+            .with_context(|| format!("validating RAD input {}", path.display()))?;
+    }
+    let is_paired = match rad_input {
+        Some(path) => rad::read_is_paired(path)
+            .with_context(|| format!("reading RAD header {}", path.display()))?,
+        None => opts.is_paired(),
+    };
+
     // Auto-detect the library type when requested (`-l A`).
     let auto_detect = LibraryFormat::is_auto(&opts.lib_type);
-    let read_type = if opts.is_paired() {
+    let read_type = if is_paired {
         ReadType::PairedEnd
     } else {
         ReadType::SingleEnd
@@ -414,18 +439,33 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         ))
     };
 
-    // ---- parallel mapping pass (borrows the accumulators) -------------------
-    // The default path runs inference inline during this pass. With
-    // `--deterministic`, pass 1 instead streams each mapped fragment to a RAD
-    // mapping store and pass 2 (`run_inference_serial`) reads it back, sorts by
-    // key, and replays the inference in that fixed order; the store is absent
-    // otherwise. It is written under `aux_info/` and removed after pass 2.
-    let rad_path = opts.output_dir.join("aux_info").join("det_mappings.rad");
-    let rad_writer = if opts.deterministic {
-        std::fs::create_dir_all(opts.output_dir.join("aux_info"))
-            .context("creating aux_info for the RAD mapping store")?;
+    // ---- mapping / inference pass (borrows the accumulators) ----------------
+    // Three configurations:
+    //   * `--rad`: skip mapping; run the deterministic key-sorted inference over
+    //     the input store directly.
+    //   * FASTQ + `--deterministic`/`--writeRad`: map in parallel streaming each
+    //     fragment to a RAD store, then run the deterministic pass over it.
+    //   * FASTQ (default): map in parallel and run inference inline.
+    let aux_dir = opts.output_dir.join("aux_info");
+    let store_path = opts
+        .write_rad
+        .clone()
+        .unwrap_or_else(|| aux_dir.join("det_mappings.rad"));
+    // A store is produced when mapping AND (deterministic or keeping the RAD).
+    let make_store = rad_input.is_none() && (opts.deterministic || opts.write_rad.is_some());
+    // The serial key-sorted inference runs for a produced store or a RAD input.
+    let det_inference = make_store || rad_input.is_some();
+    if make_store || det_inference {
+        std::fs::create_dir_all(&aux_dir).context("creating aux_info")?;
+    }
+    if let Some(parent) = store_path.parent() {
+        if make_store {
+            std::fs::create_dir_all(parent).context("creating --writeRad directory")?;
+        }
+    }
+    let rad_writer = if make_store {
         Some(
-            rad::RadChunkWriter::create(&rad_path, &salmon, opts.is_paired())
+            rad::RadChunkWriter::create(&store_path, &salmon, is_paired)
                 .context("creating RAD mapping store")?,
         )
     } else {
@@ -458,7 +498,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             length_class: length_class.as_deref(),
             posbias_obs: posbias_obs.as_ref(),
             online: online.as_ref(),
-            paired_lib: opts.is_paired(),
+            paired_lib: is_paired,
             model_single_frag_prob: opts.model_single_frag_prob,
             no_frag_length_dist: opts.no_frag_length_dist,
             num_processed,
@@ -470,47 +510,54 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             num_below_threshold_vm: &num_below_threshold_vm,
             unmapped_names: unmapped_collector.as_ref(),
             sam: sam_writer.as_ref(),
-            deterministic: opts.deterministic,
+            deterministic: det_inference,
             rad: rad_writer.as_ref(),
         };
-        let mut proc = QuantProcessor::new(shared);
-        tracing::info!(
-            "mapping reads ({} mode, {nthreads} threads)",
-            if opts.sketch {
-                "sketch"
-            } else {
-                "selective-alignment"
-            }
-        );
-        if opts.is_paired() {
-            run_paired(&opts.mates1, &opts.mates2, &mut proc, nthreads)?;
-        } else {
-            run_single(&opts.unmated, &mut proc, nthreads)?;
-        }
-        drop(proc);
-        // ---- deterministic inference pass (single-threaded, key-sorted) ------
-        // Only with `--deterministic`; the default path already ran the inference
-        // inline during the parallel mapping pass. Flush the store, read it back,
-        // and replay the inference in key-sorted order.
-        if opts.deterministic {
-            if let Some(w) = &rad_writer {
-                w.flush()?;
-            }
-            // External merge sort over the store: stream fragments in key order
-            // without loading the whole store into memory. Run files live next to
-            // the store and are cleaned up when the sorter drops.
-            let aux_dir = opts.output_dir.join("aux_info");
-            let run_size = opts.det_run_size.unwrap_or(rad::RUN_SIZE);
-            let sorter = rad::ExternalSort::new(&rad_path, run_size, &aux_dir)
-                .context("sorting RAD mapping store")?;
+        let run_size = opts.det_run_size.unwrap_or(rad::RUN_SIZE);
+        if let Some(rad_path) = rad_input {
+            // ---- RAD input: quantify from the store, no mapping --------------
+            tracing::info!("quantifying from RAD store {}", rad_path.display());
+            let sorter = rad::ExternalSort::new(rad_path, run_size, &aux_dir)
+                .context("sorting RAD input")?;
             run_inference_serial(&shared, sorter, INFERENCE_BATCH)
-                .context("deterministic inference pass")?;
+                .context("RAD-input inference")?;
+            // the store carries only mapped fragments; report processed == mapped
+            num_processed.store(num_mapped.load(Ordering::Relaxed), Ordering::Relaxed);
+        } else {
+            let mut proc = QuantProcessor::new(shared);
+            tracing::info!(
+                "mapping reads ({} mode, {nthreads} threads)",
+                if opts.sketch {
+                    "sketch"
+                } else {
+                    "selective-alignment"
+                }
+            );
+            if is_paired {
+                run_paired(&opts.mates1, &opts.mates2, &mut proc, nthreads)?;
+            } else {
+                run_single(&opts.unmated, &mut proc, nthreads)?;
+            }
+            drop(proc);
+            // ---- deterministic inference pass (single-threaded, key-sorted) --
+            // The default (inline) path already ran the inference during mapping;
+            // here we flush the store and replay it in key-sorted order.
+            if det_inference {
+                if let Some(w) = &rad_writer {
+                    w.flush()?;
+                }
+                let sorter = rad::ExternalSort::new(&store_path, run_size, &aux_dir)
+                    .context("sorting RAD mapping store")?;
+                run_inference_serial(&shared, sorter, INFERENCE_BATCH)
+                    .context("deterministic inference pass")?;
+            }
         }
     }
-    // Drop the writer (closing the file handle), then remove the transient store.
+    // Drop the writer (closing the file handle), then remove the store unless the
+    // user asked to keep it (`--writeRad`). A `--rad` input is never removed.
     drop(rad_writer);
-    if opts.deterministic {
-        let _ = std::fs::remove_file(&rad_path);
+    if make_store && opts.write_rad.is_none() {
+        let _ = std::fs::remove_file(&store_path);
     }
     {
         let p = num_processed.load(Ordering::Relaxed);

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -403,7 +403,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     // ---- parallel mapping pass (borrows the accumulators) -------------------
     // Pass 1 maps reads in parallel and buffers each mapped fragment here; pass 2
     // (`run_inference_serial`) replays the inference deterministically.
-    let frag_sink: std::sync::Mutex<Vec<(Vec<u8>, Vec<salmon_map::ScoredMapping>)>> =
+    let frag_sink: std::sync::Mutex<Vec<(u128, Vec<salmon_map::ScoredMapping>)>> =
         std::sync::Mutex::new(Vec::new());
     {
         let shared = Shared {

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -152,6 +152,11 @@ pub struct QuantOptions {
     /// `-p N`. Default `false` keeps the historical inline, fully-parallel path
     /// (no fragment store, no extra overhead).
     pub deterministic: bool,
+    /// fragments per external-sort run in the deterministic pass-2 store
+    /// ([`rad::ExternalSort`]); `None` uses [`rad::RUN_SIZE`]. Lower values force
+    /// more runs (exercising the k-way merge) at the cost of more, smaller run
+    /// files; primarily a test knob.
+    pub det_run_size: Option<usize>,
     /// Optional shared progress counters. When `Some`, [`quantify`] reports
     /// processed/mapped fragment counts here as it runs so the caller can drive
     /// a live progress display. `None` (the default) disables sharing.
@@ -202,6 +207,7 @@ impl QuantOptions {
             skip_quant: false,
             num_pre_aux_model_samples: processor::NUM_PRE_BURNIN,
             deterministic: false,
+            det_run_size: None,
             progress: None,
         }
     }
@@ -490,8 +496,15 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             if let Some(w) = &rad_writer {
                 w.flush()?;
             }
-            let frags = rad::read_rad(&rad_path).context("reading RAD mapping store")?;
-            run_inference_serial(&shared, frags, INFERENCE_BATCH);
+            // External merge sort over the store: stream fragments in key order
+            // without loading the whole store into memory. Run files live next to
+            // the store and are cleaned up when the sorter drops.
+            let aux_dir = opts.output_dir.join("aux_info");
+            let run_size = opts.det_run_size.unwrap_or(rad::RUN_SIZE);
+            let sorter = rad::ExternalSort::new(&rad_path, run_size, &aux_dir)
+                .context("sorting RAD mapping store")?;
+            run_inference_serial(&shared, sorter, INFERENCE_BATCH)
+                .context("deterministic inference pass")?;
         }
     }
     // Drop the writer (closing the file handle), then remove the transient store.

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -410,11 +410,21 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
 
     // ---- parallel mapping pass (borrows the accumulators) -------------------
     // The default path runs inference inline during this pass. With
-    // `--deterministic`, pass 1 instead buffers each mapped fragment into
-    // `frag_sink` and pass 2 (`run_inference_serial`) replays the inference in a
-    // fixed key-sorted order; the sink stays empty otherwise.
-    let frag_sink: std::sync::Mutex<Vec<(u128, Vec<salmon_map::ScoredMapping>)>> =
-        std::sync::Mutex::new(Vec::new());
+    // `--deterministic`, pass 1 instead streams each mapped fragment to a RAD
+    // mapping store and pass 2 (`run_inference_serial`) reads it back, sorts by
+    // key, and replays the inference in that fixed order; the store is absent
+    // otherwise. It is written under `aux_info/` and removed after pass 2.
+    let rad_path = opts.output_dir.join("aux_info").join("det_mappings.rad");
+    let rad_writer = if opts.deterministic {
+        std::fs::create_dir_all(opts.output_dir.join("aux_info"))
+            .context("creating aux_info for the RAD mapping store")?;
+        Some(
+            rad::RadChunkWriter::create(&rad_path, &salmon, opts.is_paired())
+                .context("creating RAD mapping store")?,
+        )
+    } else {
+        None
+    };
     {
         let shared = Shared {
             salmon: &salmon,
@@ -455,7 +465,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             unmapped_names: unmapped_collector.as_ref(),
             sam: sam_writer.as_ref(),
             deterministic: opts.deterministic,
-            frag_sink: &frag_sink,
+            rad: rad_writer.as_ref(),
         };
         let mut proc = QuantProcessor::new(shared);
         tracing::info!(
@@ -474,11 +484,20 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         drop(proc);
         // ---- deterministic inference pass (single-threaded, key-sorted) ------
         // Only with `--deterministic`; the default path already ran the inference
-        // inline during the parallel mapping pass.
+        // inline during the parallel mapping pass. Flush the store, read it back,
+        // and replay the inference in key-sorted order.
         if opts.deterministic {
-            let frags = std::mem::take(&mut *frag_sink.lock().unwrap());
+            if let Some(w) = &rad_writer {
+                w.flush()?;
+            }
+            let frags = rad::read_rad(&rad_path).context("reading RAD mapping store")?;
             run_inference_serial(&shared, frags, INFERENCE_BATCH);
         }
+    }
+    // Drop the writer (closing the file handle), then remove the transient store.
+    drop(rad_writer);
+    if opts.deterministic {
+        let _ = std::fs::remove_file(&rad_path);
     }
     {
         let p = num_processed.load(Ordering::Relaxed);

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod output;
 mod processor;
+pub mod rad;
 mod sam;
 
 use std::path::{Path, PathBuf};

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -750,19 +750,25 @@ fn merge_bias(proc: &QuantProcessor) {
 
 /// Run the per-fragment inference over the mapped fragments in a deterministic,
 /// key-sorted, single-threaded order. The parallel mapping pass only maps and
-/// buffers fragments; this pass replays the online posterior, FLD training, bias
-/// collection, and eq-class accumulation in a fixed order (sorted by a stable
-/// per-fragment key), so every order-dependent accumulation — the online masses,
-/// the FLD, and the observed bias models — is byte-identical regardless of how
-/// many threads mapped the reads. `batch_size` sets the mini-batch granularity
-/// for the forgetting-mass schedule and the FLD-snapshot refresh.
-pub(crate) fn run_inference_serial(
+/// stores fragments; this pass replays the online posterior, FLD training, bias
+/// collection, and eq-class accumulation in a fixed order, so every
+/// order-dependent accumulation — the online masses, the FLD, and the observed
+/// bias models — is byte-identical regardless of how many threads mapped the
+/// reads.
+///
+/// `frags` must already yield fragments in ascending key order (the RAD store is
+/// externally sorted by [`crate::rad::ExternalSort`], so the whole input never
+/// has to reside in memory at once). Each item is a `Result` so a read error in
+/// the streamed/merged store propagates out. `batch_size` sets the mini-batch
+/// granularity for the forgetting-mass schedule and the FLD-snapshot refresh.
+pub(crate) fn run_inference_serial<I>(
     sh: &Shared,
-    mut frags: Vec<(u128, Vec<ScoredMapping>)>,
+    frags: I,
     batch_size: usize,
-) {
-    frags.sort_by_key(|(key, _)| *key);
-
+) -> anyhow::Result<()>
+where
+    I: IntoIterator<Item = anyhow::Result<(u128, Vec<ScoredMapping>)>>,
+{
     let mut seqbias = sh.collect_seqbias.then(|| (SBModel::new(), SBModel::new()));
     let mut gcbias = sh
         .collect_gcbias
@@ -779,10 +785,24 @@ pub(crate) fn run_inference_serial(
     });
 
     let bs = batch_size.max(1);
-    for chunk in frags.chunks(bs) {
+    let mut iter = frags.into_iter();
+    // Pull the already-sorted stream one mini-batch at a time: holding only one
+    // batch keeps pass-2 memory bounded even for very large stores.
+    loop {
+        let mut batch: Vec<(u128, Vec<ScoredMapping>)> = Vec::with_capacity(bs);
+        for _ in 0..bs {
+            match iter.next() {
+                Some(item) => batch.push(item?),
+                None => break,
+            }
+        }
+        if batch.is_empty() {
+            break;
+        }
+        let last = batch.len() < bs;
         // one forgetting-mass timestep per minibatch (online inference)
         let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
-        for (key, maps) in chunk {
+        for (key, maps) in &batch {
             record(
                 sh,
                 *key,
@@ -795,6 +815,9 @@ pub(crate) fn run_inference_serial(
         }
         // refresh the FLD snapshot at the minibatch boundary (mirrors salmon)
         sh.fld.refresh_online();
+        if last {
+            break;
+        }
     }
 
     // Merge the collected bias models into the shared accumulators that the
@@ -816,6 +839,7 @@ pub(crate) fn run_inference_serial(
             a.combine(b);
         }
     }
+    Ok(())
 }
 
 impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -236,22 +236,45 @@ fn frag_log_prob(
     }
 }
 
-thread_local! {
-    /// Per-thread PRNG state for stochastic FLD-sample acceptance (mirrors
-    /// salmon's per-thread RNG used when training the fragment-length model).
-    static FLD_RNG: std::cell::Cell<u64> = const { std::cell::Cell::new(0x2545_F491_4F6C_DD1D) };
+/// Deterministic per-fragment acceptance sampler for stochastic FLD training.
+///
+/// salmon trains the fragment-length distribution online by accepting each
+/// concordant mapping's length with probability equal to its abundance-aware
+/// posterior. The previous port drew that acceptance coin from a *thread-local*
+/// PRNG, so which fragments trained the FLD depended on how the reads happened to
+/// be distributed across worker threads — the documented source of multi-threaded
+/// run-to-run wobble. Seeding instead from the read's own identity makes the
+/// acceptance decision a pure function of `(read_id, mapping_index, posterior)`,
+/// so the *set* of fragments training the FLD is identical regardless of thread
+/// count or fragment-arrival order. The draw for mapping `i` is derived directly
+/// from `(seed, i)` (not from a sequential stream), so it is independent of how
+/// many earlier mappings of the same fragment were concordant.
+#[derive(Clone, Copy)]
+struct FldSampler {
+    seed: u64,
 }
 
-/// Draw a pseudo-random value in `[0, 1)` from the per-thread xorshift state.
-fn fld_rng_u01() -> f64 {
-    FLD_RNG.with(|s| {
-        let mut x = s.get();
-        x ^= x << 13;
-        x ^= x >> 7;
-        x ^= x << 17;
-        s.set(x);
-        ((x >> 11) as f64) * (1.0 / ((1u64 << 53) as f64))
-    })
+impl FldSampler {
+    /// Seed from the stable fragment name (the full read id bytes). xxh3 is the
+    /// workspace hash already used for eq-class labels. The `| 1` keeps the seed
+    /// nonzero for any input (including an empty id).
+    fn for_read(read_id: &[u8]) -> Self {
+        FldSampler {
+            seed: xxhash_rust::xxh3::xxh3_64(read_id) | 1,
+        }
+    }
+
+    /// A pseudo-random value in `[0, 1)` for compatible-mapping index `i`,
+    /// derived statelessly from `(seed, i)` via the splitmix64 finalizer.
+    fn u01(&self, i: usize) -> f64 {
+        let mut z = self
+            .seed
+            .wrapping_add((i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        ((z >> 11) as f64) * (1.0 / ((1u64 << 53) as f64))
+    }
 }
 
 /// Collect the orientation-aware 5'/3' sequence-bias contexts for one mapping,
@@ -355,6 +378,7 @@ fn collect_pos(
 /// inference is active).
 fn record(
     sh: &Shared,
+    read_id: &[u8],
     maps: &[ScoredMapping],
     log_fm: f64,
     seqbias: Option<&mut (SBModel, SBModel)>,
@@ -577,11 +601,17 @@ fn record(
     // pair at full weight, which overdisperses it). Frozen after the training
     // window (`online_post` is `None`).
     if let Some(post) = &online_post {
+        // Seed the acceptance sampler from the fragment's own identity, so the
+        // set of fragments that train the FLD is independent of which worker
+        // thread processed this fragment (the documented source of multi-threaded
+        // run-to-run wobble). Computed once per fragment, only inside the
+        // training window.
+        let sampler = FldSampler::for_read(read_id);
         for (i, (m, _)) in compat.iter().enumerate() {
             let conc = m.status == MateStatus::PairedEndPaired
                 && m.fragment_len > 0
                 && expected.is_none_or(|exp| is_compatible(exp, m.format, m.is_fw, m.status));
-            if conc && fld_rng_u01() < post[i] {
+            if conc && sampler.u01(i) < post[i] {
                 sh.fld.add_val(m.fragment_len as usize, 0.0);
             }
         }
@@ -753,6 +783,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             }
             record(
                 &sh,
+                r1.id(),
                 &maps,
                 log_fm,
                 seqbias.as_mut(),
@@ -843,6 +874,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             }
             record(
                 &sh,
+                rec.id(),
                 &maps,
                 log_fm,
                 seqbias.as_mut(),
@@ -876,6 +908,80 @@ fn flush_sam(proc: &mut QuantProcessor) {
         if !proc.sam_buf.is_empty() {
             let _ = sw.write_block(&proc.sam_buf);
             proc.sam_buf.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reproduce the FLD-acceptance rule exactly: accept mapping `i` iff
+    /// `u01(i) < post[i]`, evaluating the indices in the given `order`.
+    fn accepts(read_id: &[u8], posts: &[f64], order: &[usize]) -> Vec<bool> {
+        let s = FldSampler::for_read(read_id);
+        let mut out = vec![false; posts.len()];
+        for &i in order {
+            out[i] = s.u01(i) < posts[i];
+        }
+        out
+    }
+
+    #[test]
+    fn fld_acceptance_is_order_and_thread_independent() {
+        let read_id = b"SRR1039508.frag_0042";
+        // Mix certain-accept (1.0), certain-reject (0.0), and middling probs so
+        // the decision actually depends on the draws.
+        let posts = [1.0, 0.0, 0.5, 0.5, 0.0, 1.0, 0.3, 0.7, 0.9, 0.1];
+
+        let forward: Vec<usize> = (0..posts.len()).collect();
+        let mut reversed = forward.clone();
+        reversed.reverse();
+        let shuffled = [3usize, 7, 0, 9, 1, 5, 8, 2, 6, 4];
+
+        let a = accepts(read_id, &posts, &forward);
+        let b = accepts(read_id, &posts, &reversed);
+        let c = accepts(read_id, &posts, &shuffled);
+
+        // The accept decision for index i is a pure function of (read_id, i,
+        // post[i]); permuting evaluation order (i.e. thread scheduling) must not
+        // change any decision.
+        assert_eq!(a, b, "acceptance must not depend on evaluation order");
+        assert_eq!(a, c, "acceptance must not depend on evaluation order");
+
+        // post == 1.0 always accepts, post == 0.0 never accepts (u01 in [0,1)).
+        assert!(a[0] && a[5]);
+        assert!(!a[1] && !a[4]);
+    }
+
+    #[test]
+    fn fld_sampler_is_deterministic_and_seed_robust() {
+        // Same id -> identical draws (run-to-run determinism).
+        let s1 = FldSampler::for_read(b"frag_x");
+        let s2 = FldSampler::for_read(b"frag_x");
+        for i in 0..16 {
+            assert_eq!(s1.u01(i), s2.u01(i));
+        }
+        // Different ids -> different seeds (no collapse onto a global constant).
+        assert_ne!(
+            FldSampler::for_read(b"frag_a").seed,
+            FldSampler::for_read(b"frag_b").seed
+        );
+        // Empty id is still a usable, nonzero-seeded, in-range stream.
+        let se = FldSampler::for_read(b"");
+        assert_ne!(se.seed, 0);
+        for i in 0..16 {
+            let u = se.u01(i);
+            assert!((0.0..1.0).contains(&u));
+        }
+    }
+
+    #[test]
+    fn fld_u01_in_unit_interval() {
+        let s = FldSampler::for_read(b"range_check");
+        for i in 0..10_000 {
+            let u = s.u01(i);
+            assert!((0.0..1.0).contains(&u), "u01({i}) = {u} out of [0,1)");
         }
     }
 }

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -637,7 +637,12 @@ fn record(
     } else {
         TranscriptGroup::from_sorted(tids)
     };
-    sh.eq.add_group(group, weights, 1);
+    // Key the contribution by the fragment's identity so the per-class weight sum
+    // is reduced in a fixed, thread-count-independent order (determinism).
+    // Key the contribution by the fragment's identity so the per-class weight sum
+    // is reduced in a fixed, thread-count-independent order (determinism).
+    let eq_key = xxhash_rust::xxh3::xxh3_128(read_id);
+    sh.eq.add_group_keyed(eq_key, group, weights, 1);
 }
 
 /// Fold the most recent fragment's selective-alignment [`MapStats`] into the

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -118,17 +118,16 @@ pub(crate) struct Shared<'a> {
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
     /// opt-in byte-for-byte reproducibility (`--deterministic`). When `true`, the
-    /// mapping pass only buffers fragments into `frag_sink` and the inference runs
-    /// in a deterministic key-sorted second pass ([`run_inference_serial`]); when
-    /// `false` (default) the inference runs inline during the parallel mapping pass
-    /// (no fragment store, no extra overhead), as before.
+    /// mapping pass only writes fragments to the RAD store (`rad`) and the
+    /// inference runs in a deterministic key-sorted second pass
+    /// ([`run_inference_serial`]); when `false` (default) the inference runs inline
+    /// during the parallel mapping pass (no store, no extra overhead), as before.
     pub deterministic: bool,
-    /// Mapping-phase fragment sink for the deterministic second pass; appended to
-    /// only when `deterministic` is set. The parallel pass maps each fragment and
-    /// appends `(key, mappings)`; [`run_inference_serial`] then replays the
-    /// inference key-sorted and single-threaded, byte-identical across thread
-    /// counts.
-    pub frag_sink: &'a Mutex<Vec<(u128, Vec<ScoredMapping>)>>,
+    /// RAD-format mapping store for the deterministic second pass; `Some` only
+    /// when `deterministic` is set. Each worker appends its mapped fragments
+    /// `(key, mappings)` as a chunk; pass 2 reads the file back, sorts by key, and
+    /// replays the inference single-threaded, byte-identical across thread counts.
+    pub rad: Option<&'a crate::rad::RadChunkWriter>,
 }
 
 /// Per-thread mapping processor.
@@ -147,9 +146,10 @@ pub(crate) struct QuantProcessor<'a> {
     pub unmapped: Vec<String>,
     /// per-thread SAM record buffer (flushed to the shared writer per batch)
     pub sam_buf: String,
-    /// per-thread buffer of mapped fragments `(key, mappings)`, drained into
-    /// `Shared::frag_sink` at thread completion for the deterministic second pass
-    /// (used only when `Shared::deterministic`).
+    /// per-thread buffer of mapped fragments `(key, mappings)`, written to the RAD
+    /// store (`Shared::rad`) as a chunk at each batch boundary and at thread
+    /// completion for the deterministic second pass (used only when
+    /// `Shared::deterministic`).
     pub frag_buf: Vec<(u128, Vec<ScoredMapping>)>,
 }
 
@@ -931,9 +931,12 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Inline path refreshes the FLD online snapshot at the mini-batch boundary
-        // (see `record`); the deterministic pass trains the FLD in pass 2 instead.
-        if !self.shared.deterministic {
+        if self.shared.deterministic {
+            // Stream this batch's mapped fragments to the RAD store.
+            flush_rad(self);
+        } else {
+            // Inline path refreshes the FLD online snapshot at the mini-batch
+            // boundary (see `record`); the deterministic pass trains it in pass 2.
             self.shared.fld.refresh_online();
         }
         flush_sam(self);
@@ -942,12 +945,8 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
         if self.shared.deterministic {
-            // Hand this worker's mapped fragments to the shared sink for the
-            // deterministic inference pass (bias models are collected there).
-            if !self.frag_buf.is_empty() {
-                let mut sink = self.shared.frag_sink.lock().unwrap();
-                sink.append(&mut self.frag_buf);
-            }
+            // Flush any fragments not yet written by a batch boundary.
+            flush_rad(self);
         } else {
             merge_bias(self);
         }
@@ -1046,7 +1045,9 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        if !self.shared.deterministic {
+        if self.shared.deterministic {
+            flush_rad(self);
+        } else {
             self.shared.fld.refresh_online();
         }
         flush_sam(self);
@@ -1055,16 +1056,25 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
         if self.shared.deterministic {
-            if !self.frag_buf.is_empty() {
-                let mut sink = self.shared.frag_sink.lock().unwrap();
-                sink.append(&mut self.frag_buf);
-            }
+            flush_rad(self);
         } else {
             merge_bias(self);
         }
         merge_unmapped(self);
         flush_sam(self);
         Ok(())
+    }
+}
+
+/// Write this thread's buffered mapped fragments to the RAD store as one chunk
+/// and clear the buffer (deterministic path only). Called at batch boundaries to
+/// stream the store to disk rather than holding every fragment in memory.
+fn flush_rad(proc: &mut QuantProcessor) {
+    if let Some(rad) = proc.shared.rad {
+        if !proc.frag_buf.is_empty() {
+            rad.write_chunk(&proc.frag_buf);
+            proc.frag_buf.clear();
+        }
     }
 }
 

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -1,11 +1,13 @@
-//! paraseq parallel processor that maps reads and accumulates equivalence
-//! classes, fragment lengths, observed library formats, and (for `--seqBias`)
-//! observed sequence-bias contexts.
+//! Two-pass reads-mode quantification core.
 //!
-//! Shared `&'a` references hold the index and thread-safe accumulators; the
-//! per-thread scratch (a [`HitSearcher`] and, when bias-correcting, observed
-//! sequence-bias models) is rebuilt on `Clone` (paraseq clones the processor
-//! per worker) and merged into shared state in `on_thread_complete`.
+//! **Pass 1** (parallel, paraseq): each worker maps its reads, samples the
+//! library format, writes SAM/`--writeMappings`, and buffers every mapped
+//! fragment's `(read_id, mappings)` into [`Shared::frag_sink`]. No inference runs
+//! here. **Pass 2** ([`run_inference_serial`]): the buffered fragments are sorted
+//! by a stable per-fragment key and the online posterior, FLD training, bias
+//! collection, and equivalence-class accumulation are replayed single-threaded in
+//! that fixed order. Every order-dependent accumulation is therefore
+//! byte-identical regardless of how many threads mapped the reads.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -108,6 +110,12 @@ pub(crate) struct Shared<'a> {
     pub unmapped_names: Option<&'a Mutex<Vec<String>>>,
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
+    /// Mapping-phase fragment sink. The parallel pass maps each fragment and
+    /// appends `(read_id, mappings)` here; the inference (online posterior, FLD
+    /// training, bias collection, eq-class accumulation) then runs in a
+    /// deterministic, key-sorted, single-threaded second pass, so the result is
+    /// byte-identical regardless of thread count (see [`run_inference_serial`]).
+    pub frag_sink: &'a Mutex<Vec<(Vec<u8>, Vec<ScoredMapping>)>>,
 }
 
 /// Per-thread mapping processor.
@@ -116,45 +124,24 @@ pub(crate) struct QuantProcessor<'a> {
     pub hs: Option<HitSearcher<'a>>,
     /// per-thread reusable sketch caches (avoids per-read MappingCache allocs)
     pub sketch_scratch: Option<salmon_map::SketchScratch>,
-    /// per-thread observed (fw, rc) sequence-bias models (when collecting)
-    pub seqbias: Option<(SBModel, SBModel)>,
-    /// per-thread observed fragment-GC model (when collecting)
-    pub gcbias: Option<GcFragModel>,
-    /// per-thread observed (5', 3') positional-bias models, per length class
-    pub posbias: Option<(Vec<SimplePosBias>, Vec<SimplePosBias>)>,
     /// per-thread collected unmapped-fragment names (merged in on_thread_complete)
     pub unmapped: Vec<String>,
     /// per-thread SAM record buffer (flushed to the shared writer per batch)
     pub sam_buf: String,
+    /// per-thread buffer of mapped fragments `(read_id, mappings)`, drained into
+    /// `Shared::frag_sink` at thread completion for the deterministic second pass.
+    pub frag_buf: Vec<(Vec<u8>, Vec<ScoredMapping>)>,
 }
 
 impl<'a> QuantProcessor<'a> {
     pub fn new(shared: Shared<'a>) -> Self {
-        let seqbias = shared
-            .collect_seqbias
-            .then(|| (SBModel::new(), SBModel::new()));
-        let gcbias = shared
-            .collect_gcbias
-            .then(|| GcFragModel::new(shared.cond_gc_bins, shared.gc_bins));
-        let posbias = shared.collect_posbias.then(|| {
-            (
-                (0..NUM_LENGTH_CLASSES)
-                    .map(|_| SimplePosBias::default())
-                    .collect(),
-                (0..NUM_LENGTH_CLASSES)
-                    .map(|_| SimplePosBias::default())
-                    .collect(),
-            )
-        });
         Self {
             shared,
             hs: None,
             sketch_scratch: None,
-            seqbias,
-            gcbias,
-            posbias,
             unmapped: Vec::new(),
             sam_buf: String::new(),
+            frag_buf: Vec::new(),
         }
     }
 }
@@ -385,7 +372,8 @@ fn record(
     gcbias: Option<&mut GcFragModel>,
     posbias: Option<&mut (Vec<SimplePosBias>, Vec<SimplePosBias>)>,
 ) {
-    sh.num_processed.fetch_add(1, Ordering::Relaxed);
+    // `num_processed` is counted during the mapping pass; pass 2 only receives
+    // mapped fragments.
     if maps.is_empty() {
         return;
     }
@@ -545,7 +533,10 @@ fn record(
     // differs and coarsening the range-factorized classes. The FLD term is only
     // applied once the auxiliary model is trained (after `pre_burnin` fragments),
     // matching salmon's `numPreAuxModelSamples` gating.
-    let use_aux = sh.num_processed.load(Ordering::Relaxed) >= sh.pre_burnin;
+    // Gate on the online inference's own progressive count (equal to the
+    // fragments processed so far in the deterministic pass), not the pre-counted
+    // total `num_processed`, so the burn-in window is honored in pass 2.
+    let use_aux = sh.online.map_or(0, |o| o.num_assigned()) >= sh.pre_burnin;
     // Per-mapping FLD log-probability via the shared `frag_log_prob` term — the
     // same one the online posterior uses, reading the same per-fragment snapshot
     // pair captured above (so the two paths share one consistent FLD view, as
@@ -685,17 +676,66 @@ fn merge_unmapped(proc: &mut QuantProcessor) {
     }
 }
 
-fn merge_bias(proc: &QuantProcessor) {
-    if let (Some(local), Some(shared_mtx)) = (proc.seqbias.as_ref(), proc.shared.seqbias_obs) {
+/// Run the per-fragment inference over the mapped fragments in a deterministic,
+/// key-sorted, single-threaded order. The parallel mapping pass only maps and
+/// buffers fragments; this pass replays the online posterior, FLD training, bias
+/// collection, and eq-class accumulation in a fixed order (sorted by a stable
+/// per-fragment key), so every order-dependent accumulation — the online masses,
+/// the FLD, and the observed bias models — is byte-identical regardless of how
+/// many threads mapped the reads. `batch_size` sets the mini-batch granularity
+/// for the forgetting-mass schedule and the FLD-snapshot refresh.
+pub(crate) fn run_inference_serial(
+    sh: &Shared,
+    mut frags: Vec<(Vec<u8>, Vec<ScoredMapping>)>,
+    batch_size: usize,
+) {
+    frags.sort_by_key(|(id, _)| xxhash_rust::xxh3::xxh3_128(id));
+
+    let mut seqbias = sh.collect_seqbias.then(|| (SBModel::new(), SBModel::new()));
+    let mut gcbias = sh
+        .collect_gcbias
+        .then(|| GcFragModel::new(sh.cond_gc_bins, sh.gc_bins));
+    let mut posbias = sh.collect_posbias.then(|| {
+        (
+            (0..NUM_LENGTH_CLASSES)
+                .map(|_| SimplePosBias::default())
+                .collect::<Vec<_>>(),
+            (0..NUM_LENGTH_CLASSES)
+                .map(|_| SimplePosBias::default())
+                .collect::<Vec<_>>(),
+        )
+    });
+
+    let bs = batch_size.max(1);
+    for chunk in frags.chunks(bs) {
+        // one forgetting-mass timestep per minibatch (online inference)
+        let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
+        for (read_id, maps) in chunk {
+            record(
+                sh,
+                read_id,
+                maps,
+                log_fm,
+                seqbias.as_mut(),
+                gcbias.as_mut(),
+                posbias.as_mut(),
+            );
+        }
+        // refresh the FLD snapshot at the minibatch boundary (mirrors salmon)
+        sh.fld.refresh_online();
+    }
+
+    // Merge the collected bias models into the shared accumulators that the
+    // effective-length step reads.
+    if let (Some(local), Some(shared_mtx)) = (seqbias.as_ref(), sh.seqbias_obs) {
         let mut g = shared_mtx.lock().unwrap();
         g.0.combine_counts(&local.0);
         g.1.combine_counts(&local.1);
     }
-    if let (Some(local), Some(shared_mtx)) = (proc.gcbias.as_ref(), proc.shared.gcbias_obs) {
-        let mut g = shared_mtx.lock().unwrap();
-        g.combine_counts(local);
+    if let (Some(local), Some(shared_mtx)) = (gcbias.as_ref(), sh.gcbias_obs) {
+        shared_mtx.lock().unwrap().combine_counts(local);
     }
-    if let (Some(local), Some(shared_mtx)) = (proc.posbias.as_ref(), proc.shared.posbias_obs) {
+    if let (Some(local), Some(shared_mtx)) = (posbias.as_ref(), sh.posbias_obs) {
         let mut g = shared_mtx.lock().unwrap();
         for (a, b) in g.0.iter_mut().zip(&local.0) {
             a.combine(b);
@@ -715,11 +755,10 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             shared,
             hs,
             sketch_scratch,
-            seqbias,
-            gcbias,
-            posbias,
             unmapped,
             sam_buf,
+            frag_buf,
+            ..
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -730,8 +769,6 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         if sh.sketch && sketch_scratch.is_none() {
             *sketch_scratch = Some(salmon_map::SketchScratch::new(idx.k()));
         }
-        // one forgetting-mass timestep per minibatch (online inference)
-        let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
         for (r1, r2) in pairs {
             let s1 = r1.seq();
             let s2 = r2.seq();
@@ -786,30 +823,29 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     &maps,
                 );
             }
-            record(
-                &sh,
-                r1.id(),
-                &maps,
-                log_fm,
-                seqbias.as_mut(),
-                gcbias.as_mut(),
-                posbias.as_mut(),
-            );
+            // Pass 1 only maps + buffers; the inference runs deterministically in
+            // pass 2 (see `run_inference_serial`).
+            sh.num_processed.fetch_add(1, Ordering::Relaxed);
+            if !maps.is_empty() {
+                frag_buf.push((r1.id().to_vec(), maps));
+            }
         }
         Ok(())
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Refresh the FLD online PMF snapshot at the mini-batch boundary so the
-        // next batch's per-fragment reads are stable (see `record`). No-op once the
-        // final FLD cache is taken; amortized over the whole batch.
-        self.shared.fld.refresh_online();
+        // Pass 1 only maps; the FLD is trained in the deterministic pass 2.
         flush_sam(self);
         Ok(())
     }
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
-        merge_bias(self);
+        // Hand this worker's mapped fragments to the shared sink for the
+        // deterministic inference pass (bias models are collected there, not here).
+        if !self.frag_buf.is_empty() {
+            let mut sink = self.shared.frag_sink.lock().unwrap();
+            sink.append(&mut self.frag_buf);
+        }
         merge_unmapped(self);
         flush_sam(self);
         Ok(())
@@ -825,11 +861,10 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             shared,
             hs,
             sketch_scratch,
-            seqbias,
-            gcbias,
-            posbias,
             unmapped,
             sam_buf,
+            frag_buf,
+            ..
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -840,7 +875,6 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         if sh.sketch && sketch_scratch.is_none() {
             *sketch_scratch = Some(salmon_map::SketchScratch::new(idx.k()));
         }
-        let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
         for rec in records {
             let s = rec.seq();
             let mut maps = if sh.sketch {
@@ -877,30 +911,27 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             if sh.sam.is_some() && !maps.is_empty() {
                 crate::sam::write_fragment(sam_buf, sh.salmon, rec.id(), s.as_ref(), None, &maps);
             }
-            record(
-                &sh,
-                rec.id(),
-                &maps,
-                log_fm,
-                seqbias.as_mut(),
-                gcbias.as_mut(),
-                posbias.as_mut(),
-            );
+            sh.num_processed.fetch_add(1, Ordering::Relaxed);
+            if !maps.is_empty() {
+                frag_buf.push((rec.id().to_vec(), maps));
+            }
         }
         Ok(())
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Refresh the FLD online PMF snapshot at the mini-batch boundary so the
-        // next batch's per-fragment reads are stable (see `record`). No-op once the
-        // final FLD cache is taken; amortized over the whole batch.
-        self.shared.fld.refresh_online();
+        // Pass 1 only maps; the FLD is trained in the deterministic pass 2.
         flush_sam(self);
         Ok(())
     }
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
-        merge_bias(self);
+        // Hand this worker's mapped fragments to the shared sink for the
+        // deterministic inference pass (bias models are collected there, not here).
+        if !self.frag_buf.is_empty() {
+            let mut sink = self.shared.frag_sink.lock().unwrap();
+            sink.append(&mut self.frag_buf);
+        }
         merge_unmapped(self);
         flush_sam(self);
         Ok(())

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -2,7 +2,7 @@
 //!
 //! **Pass 1** (parallel, paraseq): each worker maps its reads, samples the
 //! library format, writes SAM/`--writeMappings`, and buffers every mapped
-//! fragment's `(read_id, mappings)` into [`Shared::frag_sink`]. No inference runs
+//! fragment's `(key, mappings)` into [`Shared::frag_sink`]. No inference runs
 //! here. **Pass 2** ([`run_inference_serial`]): the buffered fragments are sorted
 //! by a stable per-fragment key and the online posterior, FLD training, bias
 //! collection, and equivalence-class accumulation are replayed single-threaded in
@@ -111,11 +111,11 @@ pub(crate) struct Shared<'a> {
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
     /// Mapping-phase fragment sink. The parallel pass maps each fragment and
-    /// appends `(read_id, mappings)` here; the inference (online posterior, FLD
+    /// appends `(key, mappings)` here; the inference (online posterior, FLD
     /// training, bias collection, eq-class accumulation) then runs in a
     /// deterministic, key-sorted, single-threaded second pass, so the result is
     /// byte-identical regardless of thread count (see [`run_inference_serial`]).
-    pub frag_sink: &'a Mutex<Vec<(Vec<u8>, Vec<ScoredMapping>)>>,
+    pub frag_sink: &'a Mutex<Vec<(u128, Vec<ScoredMapping>)>>,
 }
 
 /// Per-thread mapping processor.
@@ -128,9 +128,9 @@ pub(crate) struct QuantProcessor<'a> {
     pub unmapped: Vec<String>,
     /// per-thread SAM record buffer (flushed to the shared writer per batch)
     pub sam_buf: String,
-    /// per-thread buffer of mapped fragments `(read_id, mappings)`, drained into
+    /// per-thread buffer of mapped fragments `(key, mappings)`, drained into
     /// `Shared::frag_sink` at thread completion for the deterministic second pass.
-    pub frag_buf: Vec<(Vec<u8>, Vec<ScoredMapping>)>,
+    pub frag_buf: Vec<(u128, Vec<ScoredMapping>)>,
 }
 
 impl<'a> QuantProcessor<'a> {
@@ -242,12 +242,11 @@ struct FldSampler {
 }
 
 impl FldSampler {
-    /// Seed from the stable fragment name (the full read id bytes). xxh3 is the
-    /// workspace hash already used for eq-class labels. The `| 1` keeps the seed
-    /// nonzero for any input (including an empty id).
-    fn for_read(read_id: &[u8]) -> Self {
+    /// Seed from the fragment's precomputed key (`xxh3_128(read_id)`); the low 64
+    /// bits give a stable per-fragment seed. `| 1` keeps it nonzero.
+    fn from_key(key: u128) -> Self {
         FldSampler {
-            seed: xxhash_rust::xxh3::xxh3_64(read_id) | 1,
+            seed: (key as u64) | 1,
         }
     }
 
@@ -365,7 +364,7 @@ fn collect_pos(
 /// inference is active).
 fn record(
     sh: &Shared,
-    read_id: &[u8],
+    key: u128,
     maps: &[ScoredMapping],
     log_fm: f64,
     seqbias: Option<&mut (SBModel, SBModel)>,
@@ -597,7 +596,7 @@ fn record(
         // thread processed this fragment (the documented source of multi-threaded
         // run-to-run wobble). Computed once per fragment, only inside the
         // training window.
-        let sampler = FldSampler::for_read(read_id);
+        let sampler = FldSampler::from_key(key);
         for (i, (m, _)) in compat.iter().enumerate() {
             let conc = m.status == MateStatus::PairedEndPaired
                 && m.fragment_len > 0
@@ -628,12 +627,8 @@ fn record(
     } else {
         TranscriptGroup::from_sorted(tids)
     };
-    // Key the contribution by the fragment's identity so the per-class weight sum
-    // is reduced in a fixed, thread-count-independent order (determinism).
-    // Key the contribution by the fragment's identity so the per-class weight sum
-    // is reduced in a fixed, thread-count-independent order (determinism).
-    let eq_key = xxhash_rust::xxh3::xxh3_128(read_id);
-    sh.eq.add_group_keyed(eq_key, group, weights, 1);
+    // The fragment's key fixes the per-class weight-summation order (determinism).
+    sh.eq.add_group_keyed(key, group, weights, 1);
 }
 
 /// Fold the most recent fragment's selective-alignment [`MapStats`] into the
@@ -686,10 +681,10 @@ fn merge_unmapped(proc: &mut QuantProcessor) {
 /// for the forgetting-mass schedule and the FLD-snapshot refresh.
 pub(crate) fn run_inference_serial(
     sh: &Shared,
-    mut frags: Vec<(Vec<u8>, Vec<ScoredMapping>)>,
+    mut frags: Vec<(u128, Vec<ScoredMapping>)>,
     batch_size: usize,
 ) {
-    frags.sort_by_key(|(id, _)| xxhash_rust::xxh3::xxh3_128(id));
+    frags.sort_by_key(|(key, _)| *key);
 
     let mut seqbias = sh.collect_seqbias.then(|| (SBModel::new(), SBModel::new()));
     let mut gcbias = sh
@@ -710,10 +705,10 @@ pub(crate) fn run_inference_serial(
     for chunk in frags.chunks(bs) {
         // one forgetting-mass timestep per minibatch (online inference)
         let log_fm = sh.online.map_or(0.0, |o| o.next_log_fm());
-        for (read_id, maps) in chunk {
+        for (key, maps) in chunk {
             record(
                 sh,
-                read_id,
+                *key,
                 maps,
                 log_fm,
                 seqbias.as_mut(),
@@ -827,7 +822,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             // pass 2 (see `run_inference_serial`).
             sh.num_processed.fetch_add(1, Ordering::Relaxed);
             if !maps.is_empty() {
-                frag_buf.push((r1.id().to_vec(), maps));
+                frag_buf.push((xxhash_rust::xxh3::xxh3_128(r1.id()), maps));
             }
         }
         Ok(())
@@ -913,7 +908,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             }
             sh.num_processed.fetch_add(1, Ordering::Relaxed);
             if !maps.is_empty() {
-                frag_buf.push((rec.id().to_vec(), maps));
+                frag_buf.push((xxhash_rust::xxh3::xxh3_128(rec.id()), maps));
             }
         }
         Ok(())
@@ -954,8 +949,8 @@ mod tests {
 
     /// Reproduce the FLD-acceptance rule exactly: accept mapping `i` iff
     /// `u01(i) < post[i]`, evaluating the indices in the given `order`.
-    fn accepts(read_id: &[u8], posts: &[f64], order: &[usize]) -> Vec<bool> {
-        let s = FldSampler::for_read(read_id);
+    fn accepts(key: u128, posts: &[f64], order: &[usize]) -> Vec<bool> {
+        let s = FldSampler::from_key(key);
         let mut out = vec![false; posts.len()];
         for &i in order {
             out[i] = s.u01(i) < posts[i];
@@ -965,7 +960,7 @@ mod tests {
 
     #[test]
     fn fld_acceptance_is_order_and_thread_independent() {
-        let read_id = b"SRR1039508.frag_0042";
+        let key: u128 = 0x1234_5678_9ABC_DEF0_0FED_CBA9_8765_4321;
         // Mix certain-accept (1.0), certain-reject (0.0), and middling probs so
         // the decision actually depends on the draws.
         let posts = [1.0, 0.0, 0.5, 0.5, 0.0, 1.0, 0.3, 0.7, 0.9, 0.1];
@@ -975,13 +970,13 @@ mod tests {
         reversed.reverse();
         let shuffled = [3usize, 7, 0, 9, 1, 5, 8, 2, 6, 4];
 
-        let a = accepts(read_id, &posts, &forward);
-        let b = accepts(read_id, &posts, &reversed);
-        let c = accepts(read_id, &posts, &shuffled);
+        let a = accepts(key, &posts, &forward);
+        let b = accepts(key, &posts, &reversed);
+        let c = accepts(key, &posts, &shuffled);
 
-        // The accept decision for index i is a pure function of (read_id, i,
-        // post[i]); permuting evaluation order (i.e. thread scheduling) must not
-        // change any decision.
+        // The accept decision for index i is a pure function of (key, i, post[i]);
+        // permuting evaluation order (i.e. thread scheduling) must not change any
+        // decision.
         assert_eq!(a, b, "acceptance must not depend on evaluation order");
         assert_eq!(a, c, "acceptance must not depend on evaluation order");
 
@@ -992,19 +987,16 @@ mod tests {
 
     #[test]
     fn fld_sampler_is_deterministic_and_seed_robust() {
-        // Same id -> identical draws (run-to-run determinism).
-        let s1 = FldSampler::for_read(b"frag_x");
-        let s2 = FldSampler::for_read(b"frag_x");
+        // Same key -> identical draws (run-to-run determinism).
+        let s1 = FldSampler::from_key(0xAAAA_BBBB_CCCC_DDDD);
+        let s2 = FldSampler::from_key(0xAAAA_BBBB_CCCC_DDDD);
         for i in 0..16 {
             assert_eq!(s1.u01(i), s2.u01(i));
         }
-        // Different ids -> different seeds (no collapse onto a global constant).
-        assert_ne!(
-            FldSampler::for_read(b"frag_a").seed,
-            FldSampler::for_read(b"frag_b").seed
-        );
-        // Empty id is still a usable, nonzero-seeded, in-range stream.
-        let se = FldSampler::for_read(b"");
+        // Different keys -> different seeds (no collapse onto a global constant).
+        assert_ne!(FldSampler::from_key(1).seed, FldSampler::from_key(2).seed);
+        // A zero key still yields a usable, nonzero-seeded, in-range stream.
+        let se = FldSampler::from_key(0);
         assert_ne!(se.seed, 0);
         for i in 0..16 {
             let u = se.u01(i);
@@ -1014,7 +1006,7 @@ mod tests {
 
     #[test]
     fn fld_u01_in_unit_interval() {
-        let s = FldSampler::for_read(b"range_check");
+        let s = FldSampler::from_key(0xDEAD_BEEF_F00D);
         for i in 0..10_000 {
             let u = s.u01(i);
             assert!((0.0..1.0).contains(&u), "u01({i}) = {u} out of [0,1)");

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -1,13 +1,20 @@
-//! Two-pass reads-mode quantification core.
+//! Reads-mode quantification core, with two inference strategies.
 //!
-//! **Pass 1** (parallel, paraseq): each worker maps its reads, samples the
-//! library format, writes SAM/`--writeMappings`, and buffers every mapped
-//! fragment's `(key, mappings)` into [`Shared::frag_sink`]. No inference runs
-//! here. **Pass 2** ([`run_inference_serial`]): the buffered fragments are sorted
-//! by a stable per-fragment key and the online posterior, FLD training, bias
-//! collection, and equivalence-class accumulation are replayed single-threaded in
-//! that fixed order. Every order-dependent accumulation is therefore
-//! byte-identical regardless of how many threads mapped the reads.
+//! **Default (inline, fully parallel):** each worker maps its reads and runs the
+//! per-fragment inference ([`record`]) immediately, accumulating the online
+//! posterior, FLD training, bias models, and equivalence classes concurrently.
+//! This is the historical behaviour: fast, no fragment store, but the
+//! accumulation order (hence the last ULPs of `quant.sf`) depends on thread
+//! scheduling.
+//!
+//! **`--deterministic` (opt-in, two-pass):** pass 1 maps in parallel and only
+//! buffers every mapped fragment's `(key, mappings)` into [`Shared::frag_sink`];
+//! pass 2 ([`run_inference_serial`]) sorts the buffered fragments by a stable
+//! per-fragment key and replays the inference single-threaded in that fixed order.
+//! Every order-dependent accumulation is then byte-identical regardless of how
+//! many threads mapped the reads, at the cost of holding the mappings between
+//! passes and a single-threaded inference phase. Selected by
+//! [`Shared::deterministic`].
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -110,11 +117,17 @@ pub(crate) struct Shared<'a> {
     pub unmapped_names: Option<&'a Mutex<Vec<String>>>,
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
-    /// Mapping-phase fragment sink. The parallel pass maps each fragment and
-    /// appends `(key, mappings)` here; the inference (online posterior, FLD
-    /// training, bias collection, eq-class accumulation) then runs in a
-    /// deterministic, key-sorted, single-threaded second pass, so the result is
-    /// byte-identical regardless of thread count (see [`run_inference_serial`]).
+    /// opt-in byte-for-byte reproducibility (`--deterministic`). When `true`, the
+    /// mapping pass only buffers fragments into `frag_sink` and the inference runs
+    /// in a deterministic key-sorted second pass ([`run_inference_serial`]); when
+    /// `false` (default) the inference runs inline during the parallel mapping pass
+    /// (no fragment store, no extra overhead), as before.
+    pub deterministic: bool,
+    /// Mapping-phase fragment sink for the deterministic second pass; appended to
+    /// only when `deterministic` is set. The parallel pass maps each fragment and
+    /// appends `(key, mappings)`; [`run_inference_serial`] then replays the
+    /// inference key-sorted and single-threaded, byte-identical across thread
+    /// counts.
     pub frag_sink: &'a Mutex<Vec<(u128, Vec<ScoredMapping>)>>,
 }
 
@@ -124,21 +137,54 @@ pub(crate) struct QuantProcessor<'a> {
     pub hs: Option<HitSearcher<'a>>,
     /// per-thread reusable sketch caches (avoids per-read MappingCache allocs)
     pub sketch_scratch: Option<salmon_map::SketchScratch>,
+    /// per-thread observed (fw, rc) sequence-bias models (inline path only)
+    pub seqbias: Option<(SBModel, SBModel)>,
+    /// per-thread observed fragment-GC model (inline path only)
+    pub gcbias: Option<GcFragModel>,
+    /// per-thread observed (5', 3') positional-bias models (inline path only)
+    pub posbias: Option<(Vec<SimplePosBias>, Vec<SimplePosBias>)>,
     /// per-thread collected unmapped-fragment names (merged in on_thread_complete)
     pub unmapped: Vec<String>,
     /// per-thread SAM record buffer (flushed to the shared writer per batch)
     pub sam_buf: String,
     /// per-thread buffer of mapped fragments `(key, mappings)`, drained into
-    /// `Shared::frag_sink` at thread completion for the deterministic second pass.
+    /// `Shared::frag_sink` at thread completion for the deterministic second pass
+    /// (used only when `Shared::deterministic`).
     pub frag_buf: Vec<(u128, Vec<ScoredMapping>)>,
 }
 
 impl<'a> QuantProcessor<'a> {
     pub fn new(shared: Shared<'a>) -> Self {
+        // Per-thread bias models for the inline (non-deterministic) path; the
+        // deterministic path collects bias in `run_inference_serial` instead.
+        let (seqbias, gcbias, posbias) = if shared.deterministic {
+            (None, None, None)
+        } else {
+            let seqbias = shared
+                .collect_seqbias
+                .then(|| (SBModel::new(), SBModel::new()));
+            let gcbias = shared
+                .collect_gcbias
+                .then(|| GcFragModel::new(shared.cond_gc_bins, shared.gc_bins));
+            let posbias = shared.collect_posbias.then(|| {
+                (
+                    (0..NUM_LENGTH_CLASSES)
+                        .map(|_| SimplePosBias::default())
+                        .collect(),
+                    (0..NUM_LENGTH_CLASSES)
+                        .map(|_| SimplePosBias::default())
+                        .collect(),
+                )
+            });
+            (seqbias, gcbias, posbias)
+        };
         Self {
             shared,
             hs: None,
             sketch_scratch: None,
+            seqbias,
+            gcbias,
+            posbias,
             unmapped: Vec::new(),
             sam_buf: String::new(),
             frag_buf: Vec::new(),
@@ -532,10 +578,17 @@ fn record(
     // differs and coarsening the range-factorized classes. The FLD term is only
     // applied once the auxiliary model is trained (after `pre_burnin` fragments),
     // matching salmon's `numPreAuxModelSamples` gating.
-    // Gate on the online inference's own progressive count (equal to the
-    // fragments processed so far in the deterministic pass), not the pre-counted
-    // total `num_processed`, so the burn-in window is honored in pass 2.
-    let use_aux = sh.online.map_or(0, |o| o.num_assigned()) >= sh.pre_burnin;
+    // Burn-in gate. The inline (default) path reads the shared `num_processed`
+    // counter as it did before, matching the non-deterministic behaviour. The
+    // deterministic pass instead gates on the online inference's own progressive
+    // count (the fragments replayed so far in key-sorted order), so the burn-in
+    // window is honored in that fixed order rather than against the pre-counted
+    // total.
+    let use_aux = if sh.deterministic {
+        sh.online.map_or(0, |o| o.num_assigned())
+    } else {
+        sh.num_processed.load(Ordering::Relaxed)
+    } >= sh.pre_burnin;
     // Per-mapping FLD log-probability via the shared `frag_log_prob` term — the
     // same one the online posterior uses, reading the same per-fragment snapshot
     // pair captured above (so the two paths share one consistent FLD view, as
@@ -671,6 +724,30 @@ fn merge_unmapped(proc: &mut QuantProcessor) {
     }
 }
 
+/// Merge this thread's observed bias models (sequence, GC, positional) into the
+/// shared accumulators. Inline (non-deterministic) path only; the deterministic
+/// pass collects bias directly into shared models in [`run_inference_serial`].
+fn merge_bias(proc: &QuantProcessor) {
+    if let (Some(local), Some(shared_mtx)) = (proc.seqbias.as_ref(), proc.shared.seqbias_obs) {
+        let mut g = shared_mtx.lock().unwrap();
+        g.0.combine_counts(&local.0);
+        g.1.combine_counts(&local.1);
+    }
+    if let (Some(local), Some(shared_mtx)) = (proc.gcbias.as_ref(), proc.shared.gcbias_obs) {
+        let mut g = shared_mtx.lock().unwrap();
+        g.combine_counts(local);
+    }
+    if let (Some(local), Some(shared_mtx)) = (proc.posbias.as_ref(), proc.shared.posbias_obs) {
+        let mut g = shared_mtx.lock().unwrap();
+        for (a, b) in g.0.iter_mut().zip(&local.0) {
+            a.combine(b);
+        }
+        for (a, b) in g.1.iter_mut().zip(&local.1) {
+            a.combine(b);
+        }
+    }
+}
+
 /// Run the per-fragment inference over the mapped fragments in a deterministic,
 /// key-sorted, single-threaded order. The parallel mapping pass only maps and
 /// buffers fragments; this pass replays the online posterior, FLD training, bias
@@ -750,10 +827,12 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             shared,
             hs,
             sketch_scratch,
+            seqbias,
+            gcbias,
+            posbias,
             unmapped,
             sam_buf,
             frag_buf,
-            ..
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -764,6 +843,14 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         if sh.sketch && sketch_scratch.is_none() {
             *sketch_scratch = Some(salmon_map::SketchScratch::new(idx.k()));
         }
+        // One forgetting-mass timestep per mapped batch for the inline online
+        // posterior; the deterministic pass advances it per mini-batch in pass 2
+        // instead, so leave the schedule untouched here when buffering.
+        let log_fm = if sh.deterministic {
+            0.0
+        } else {
+            sh.online.map_or(0.0, |o| o.next_log_fm())
+        };
         for (r1, r2) in pairs {
             let s1 = r1.seq();
             let s2 = r2.seq();
@@ -818,28 +905,51 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     &maps,
                 );
             }
-            // Pass 1 only maps + buffers; the inference runs deterministically in
-            // pass 2 (see `run_inference_serial`).
             sh.num_processed.fetch_add(1, Ordering::Relaxed);
-            if !maps.is_empty() {
-                frag_buf.push((xxhash_rust::xxh3::xxh3_128(r1.id()), maps));
+            if maps.is_empty() {
+                continue;
+            }
+            let key = xxhash_rust::xxh3::xxh3_128(r1.id());
+            if sh.deterministic {
+                // Pass 1 only maps + buffers; the inference runs deterministically
+                // in pass 2 (see `run_inference_serial`).
+                frag_buf.push((key, maps));
+            } else {
+                // Inline (default): run the per-fragment inference now, in parallel.
+                record(
+                    &sh,
+                    key,
+                    &maps,
+                    log_fm,
+                    seqbias.as_mut(),
+                    gcbias.as_mut(),
+                    posbias.as_mut(),
+                );
             }
         }
         Ok(())
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Pass 1 only maps; the FLD is trained in the deterministic pass 2.
+        // Inline path refreshes the FLD online snapshot at the mini-batch boundary
+        // (see `record`); the deterministic pass trains the FLD in pass 2 instead.
+        if !self.shared.deterministic {
+            self.shared.fld.refresh_online();
+        }
         flush_sam(self);
         Ok(())
     }
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
-        // Hand this worker's mapped fragments to the shared sink for the
-        // deterministic inference pass (bias models are collected there, not here).
-        if !self.frag_buf.is_empty() {
-            let mut sink = self.shared.frag_sink.lock().unwrap();
-            sink.append(&mut self.frag_buf);
+        if self.shared.deterministic {
+            // Hand this worker's mapped fragments to the shared sink for the
+            // deterministic inference pass (bias models are collected there).
+            if !self.frag_buf.is_empty() {
+                let mut sink = self.shared.frag_sink.lock().unwrap();
+                sink.append(&mut self.frag_buf);
+            }
+        } else {
+            merge_bias(self);
         }
         merge_unmapped(self);
         flush_sam(self);
@@ -856,10 +966,12 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             shared,
             hs,
             sketch_scratch,
+            seqbias,
+            gcbias,
+            posbias,
             unmapped,
             sam_buf,
             frag_buf,
-            ..
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -870,6 +982,11 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         if sh.sketch && sketch_scratch.is_none() {
             *sketch_scratch = Some(salmon_map::SketchScratch::new(idx.k()));
         }
+        let log_fm = if sh.deterministic {
+            0.0
+        } else {
+            sh.online.map_or(0.0, |o| o.next_log_fm())
+        };
         for rec in records {
             let s = rec.seq();
             let mut maps = if sh.sketch {
@@ -907,25 +1024,43 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                 crate::sam::write_fragment(sam_buf, sh.salmon, rec.id(), s.as_ref(), None, &maps);
             }
             sh.num_processed.fetch_add(1, Ordering::Relaxed);
-            if !maps.is_empty() {
-                frag_buf.push((xxhash_rust::xxh3::xxh3_128(rec.id()), maps));
+            if maps.is_empty() {
+                continue;
+            }
+            let key = xxhash_rust::xxh3::xxh3_128(rec.id());
+            if sh.deterministic {
+                frag_buf.push((key, maps));
+            } else {
+                record(
+                    &sh,
+                    key,
+                    &maps,
+                    log_fm,
+                    seqbias.as_mut(),
+                    gcbias.as_mut(),
+                    posbias.as_mut(),
+                );
             }
         }
         Ok(())
     }
 
     fn on_batch_complete(&mut self) -> paraseq::Result<()> {
-        // Pass 1 only maps; the FLD is trained in the deterministic pass 2.
+        if !self.shared.deterministic {
+            self.shared.fld.refresh_online();
+        }
         flush_sam(self);
         Ok(())
     }
 
     fn on_thread_complete(&mut self) -> paraseq::Result<()> {
-        // Hand this worker's mapped fragments to the shared sink for the
-        // deterministic inference pass (bias models are collected there, not here).
-        if !self.frag_buf.is_empty() {
-            let mut sink = self.shared.frag_sink.lock().unwrap();
-            sink.append(&mut self.frag_buf);
+        if self.shared.deterministic {
+            if !self.frag_buf.is_empty() {
+                let mut sink = self.shared.frag_sink.lock().unwrap();
+                sink.append(&mut self.frag_buf);
+            }
+        } else {
+            merge_bias(self);
         }
         merge_unmapped(self);
         flush_sam(self);

--- a/crates/salmon-quant/src/rad.rs
+++ b/crates/salmon-quant/src/rad.rs
@@ -328,9 +328,9 @@ fn skip_tag_section<R: Read>(r: &mut R) -> Result<()> {
     Ok(())
 }
 
-/// Read the prelude and return `num_chunks`.
-fn read_prelude<R: Read>(r: &mut R) -> Result<u64> {
-    let _is_paired = read_u8(r)?;
+/// Read the prelude and return `(is_paired, num_chunks)`.
+fn read_prelude<R: Read>(r: &mut R) -> Result<(bool, u64)> {
+    let is_paired = read_u8(r)? != 0;
     let ref_count = read_u64(r)?;
     for _ in 0..ref_count {
         let len = read_u16(r)? as usize;
@@ -341,7 +341,58 @@ fn read_prelude<R: Read>(r: &mut R) -> Result<u64> {
     skip_tag_section(r).context("reading RAD file tag section")?;
     skip_tag_section(r).context("reading RAD read tag section")?;
     skip_tag_section(r).context("reading RAD alignment tag section")?;
-    Ok(num_chunks)
+    Ok((is_paired, num_chunks))
+}
+
+/// The alignment-level tag names of salmon's own full-fidelity profile, in order.
+/// Used to recognize a RAD written by salmon (vs. e.g. a piscem bulk RAD).
+const SALMON_ALN_TAGS: [&str; 10] = [
+    "tid",
+    "weight",
+    "status",
+    "is_fw",
+    "fragment_len",
+    "read_len",
+    "ref_pos",
+    "fw_pos",
+    "rc_pos",
+    "format",
+];
+
+/// Read just the `is_paired` flag from a RAD file header (for quantification
+/// input, where there are no FASTQ mates to infer it from).
+pub fn read_is_paired(path: &Path) -> Result<bool> {
+    let f = File::open(path).with_context(|| format!("opening RAD file {}", path.display()))?;
+    let mut r = BufReader::new(f);
+    Ok(read_u8(&mut r)? != 0)
+}
+
+/// Verify the file carries salmon's own full-fidelity alignment-level tag schema,
+/// so [`read_record`] can decode it exactly. Returns an error for other RAD
+/// profiles (for example a piscem bulk RAD, whose reduced records this reader does
+/// not yet decode), rather than silently misreading them.
+pub fn verify_salmon_profile(path: &Path) -> Result<()> {
+    use libradicl::header::RadPrelude;
+    let f = File::open(path).with_context(|| format!("opening RAD file {}", path.display()))?;
+    let mut r = BufReader::new(f);
+    let prelude = RadPrelude::from_bytes(&mut r)
+        .with_context(|| format!("parsing RAD prelude of {}", path.display()))?;
+    let aln: Vec<&str> = prelude
+        .aln_tags
+        .tags
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect();
+    if aln != SALMON_ALN_TAGS {
+        bail!(
+            "RAD file {} does not use salmon's mapping-store profile (alignment tags = {:?}); \
+             only RAD written by salmon (e.g. via --writeRad) is supported as input so far. \
+             piscem bulk RAD input is a planned follow-up.",
+            path.display(),
+            aln
+        );
+    }
+    Ok(())
 }
 
 /// Read one alignment's tag values (the inverse of the per-mapping write in
@@ -404,7 +455,7 @@ fn read_record<R: Read>(r: &mut R) -> Result<(u128, Vec<ScoredMapping>)> {
 pub fn read_rad(path: &Path) -> Result<Vec<(u128, Vec<ScoredMapping>)>> {
     let f = File::open(path).with_context(|| format!("opening RAD file {}", path.display()))?;
     let mut r = BufReader::new(f);
-    let num_chunks = read_prelude(&mut r)?;
+    let (_is_paired, num_chunks) = read_prelude(&mut r)?;
     let mut out = Vec::new();
     let read_one_chunk = |r: &mut BufReader<File>, out: &mut Vec<_>| -> Result<()> {
         let nrec = read_u32(r)?;
@@ -452,7 +503,7 @@ impl RadRecordReader {
         let f =
             File::open(path).with_context(|| format!("opening RAD store {}", path.display()))?;
         let mut r = BufReader::new(f);
-        let num_chunks = read_prelude(&mut r)?;
+        let (_is_paired, num_chunks) = read_prelude(&mut r)?;
         Ok(Self {
             r,
             in_chunk: 0,

--- a/crates/salmon-quant/src/rad.rs
+++ b/crates/salmon-quant/src/rad.rs
@@ -34,8 +34,9 @@
 //!   alignment the alignment-level tag values in the declared order.
 
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::Path;
+use std::sync::Mutex;
 
 use anyhow::{bail, Context, Result};
 use libradicl::rad_types::{RadFloatId, RadIntId, RadType, TagDesc, TagSection, TagSectionLabel};
@@ -157,9 +158,26 @@ fn write_prelude<W: Write>(
     Ok(())
 }
 
-/// Write a complete single-chunk RAD file holding `frags`. Used for the in-memory
-/// store and as the round-trip reference; the parallel store appends chunks
-/// incrementally (a later step).
+/// Serialize one chunk (`nbytes`, `nrec`, records) into a standalone byte
+/// buffer. Doing this off-lock lets the parallel store hold its file mutex only
+/// for the final `write_all`.
+fn serialize_chunk(frags: &[(u128, Vec<ScoredMapping>)]) -> Vec<u8> {
+    let mut body = Vec::new();
+    for (key, maps) in frags {
+        write_record(&mut body, *key, maps);
+    }
+    // A single chunk over 4 GiB would need splitting; per-batch chunks are far
+    // below that, so saturate rather than fail (the reader streams to EOF).
+    let nbytes: u32 = (body.len() + 8).try_into().unwrap_or(u32::MAX);
+    let mut out = Vec::with_capacity(body.len() + 8);
+    out.extend_from_slice(&nbytes.to_le_bytes());
+    out.extend_from_slice(&(frags.len() as u32).to_le_bytes());
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Write a complete single-chunk RAD file holding `frags`. Convenience for tests
+/// and small in-memory stores; the parallel path uses [`RadChunkWriter`].
 pub fn write_rad(
     path: &Path,
     salmon: &SalmonIndex,
@@ -169,19 +187,64 @@ pub fn write_rad(
     let f = File::create(path).with_context(|| format!("creating RAD file {}", path.display()))?;
     let mut w = BufWriter::new(f);
     write_prelude(&mut w, salmon, is_paired, 1)?;
-
-    let mut body = Vec::new();
-    for (key, maps) in frags {
-        write_record(&mut body, *key, maps);
-    }
-    let nbytes: u32 = (body.len() + 8)
-        .try_into()
-        .context("RAD chunk exceeds 4 GiB; chunking not yet implemented")?;
-    w.write_all(&nbytes.to_le_bytes())?;
-    w.write_all(&(frags.len() as u32).to_le_bytes())?;
-    w.write_all(&body)?;
+    w.write_all(&serialize_chunk(frags))?;
     w.flush()?;
     Ok(())
+}
+
+/// Concurrent, append-only RAD writer for the deterministic two-pass store. The
+/// prelude (with `num_chunks = 0`, "stream to EOF") is written at construction;
+/// each mapping worker then appends its batch as a chunk via [`Self::write_chunk`]
+/// (serialized off-lock, so the file mutex is held only for the append). Records
+/// land in thread-arrival order; pass 2 sorts them by key, so the order on disk
+/// does not affect the result.
+pub struct RadChunkWriter {
+    inner: Mutex<BufWriter<File>>,
+    /// first append error, surfaced by [`Self::flush`] (the per-chunk write path
+    /// is called from `paraseq` callbacks that cannot return our error type).
+    err: Mutex<Option<io::Error>>,
+}
+
+impl RadChunkWriter {
+    pub fn create(path: &Path, salmon: &SalmonIndex, is_paired: bool) -> Result<Self> {
+        let f =
+            File::create(path).with_context(|| format!("creating RAD file {}", path.display()))?;
+        let mut w = BufWriter::new(f);
+        write_prelude(&mut w, salmon, is_paired, 0)?;
+        Ok(Self {
+            inner: Mutex::new(w),
+            err: Mutex::new(None),
+        })
+    }
+
+    /// Append `frags` as one chunk. No-op when empty. Errors are captured and
+    /// reported later by [`Self::flush`].
+    pub fn write_chunk(&self, frags: &[(u128, Vec<ScoredMapping>)]) {
+        if frags.is_empty() {
+            return;
+        }
+        let bytes = serialize_chunk(frags);
+        let mut w = self.inner.lock().unwrap();
+        if let Err(e) = w.write_all(&bytes) {
+            let mut slot = self.err.lock().unwrap();
+            if slot.is_none() {
+                *slot = Some(e);
+            }
+        }
+    }
+
+    /// Flush the buffered writer and surface the first append error, if any.
+    pub fn flush(&self) -> Result<()> {
+        if let Some(e) = self.err.lock().unwrap().take() {
+            return Err(anyhow::Error::from(e).context("appending to RAD mapping store"));
+        }
+        self.inner
+            .lock()
+            .unwrap()
+            .flush()
+            .context("flushing RAD mapping store")?;
+        Ok(())
+    }
 }
 
 fn read_u8<R: Read>(r: &mut R) -> Result<u8> {
@@ -198,6 +261,16 @@ fn read_u32<R: Read>(r: &mut R) -> Result<u32> {
     let mut b = [0u8; 4];
     r.read_exact(&mut b)?;
     Ok(u32::from_le_bytes(b))
+}
+/// Read a `u32`, returning `None` on a clean end of file (used to detect the last
+/// chunk when `num_chunks` is the "stream to EOF" sentinel `0`).
+fn read_u32_opt<R: Read>(r: &mut R) -> Result<Option<u32>> {
+    let mut b = [0u8; 4];
+    match r.read_exact(&mut b) {
+        Ok(()) => Ok(Some(u32::from_le_bytes(b))),
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => Ok(None),
+        Err(e) => Err(e.into()),
+    }
 }
 fn read_u64<R: Read>(r: &mut R) -> Result<u64> {
     let mut b = [0u8; 8];
@@ -297,12 +370,24 @@ pub fn read_rad(path: &Path) -> Result<Vec<(u128, Vec<ScoredMapping>)>> {
     let mut r = BufReader::new(f);
     let num_chunks = read_prelude(&mut r)?;
     let mut out = Vec::new();
-    for _ in 0..num_chunks {
-        let _nbytes = read_u32(&mut r)?;
-        let nrec = read_u32(&mut r)?;
+    let read_one_chunk = |r: &mut BufReader<File>, out: &mut Vec<_>| -> Result<()> {
+        let nrec = read_u32(r)?;
         out.reserve(nrec as usize);
         for _ in 0..nrec {
-            out.push(read_record(&mut r)?);
+            out.push(read_record(r)?);
+        }
+        Ok(())
+    };
+    if num_chunks == 0 {
+        // "stream to EOF" sentinel: keep reading chunks until the file ends
+        // (the parallel writer does not know the chunk count up front).
+        while read_u32_opt(&mut r)?.is_some() {
+            read_one_chunk(&mut r, &mut out)?;
+        }
+    } else {
+        for _ in 0..num_chunks {
+            let _nbytes = read_u32(&mut r)?;
+            read_one_chunk(&mut r, &mut out)?;
         }
     }
     Ok(out)

--- a/crates/salmon-quant/src/rad.rs
+++ b/crates/salmon-quant/src/rad.rs
@@ -34,9 +34,11 @@
 //!   two `u64` halves, low then high), then per alignment the alignment-level tag
 //!   values in the declared order.
 
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use anyhow::{bail, Context, Result};
@@ -342,43 +344,59 @@ fn read_prelude<R: Read>(r: &mut R) -> Result<u64> {
     Ok(num_chunks)
 }
 
-/// Read one mapped fragment record (the inverse of [`write_record`]).
-fn read_record<R: Read>(r: &mut R) -> Result<(u128, Vec<ScoredMapping>)> {
-    let na = read_u32(r)? as usize;
+/// Read one alignment's tag values (the inverse of the per-mapping write in
+/// [`write_record`]).
+fn read_aln<R: Read>(r: &mut R) -> Result<ScoredMapping> {
+    let tid = read_u32(r)?;
+    let weight = read_f64(r)?;
+    let status = status_from_u8(read_u8(r)?)?;
+    let is_fw = read_u8(r)? != 0;
+    let fragment_len = read_u32(r)? as i32;
+    let read_len = read_u32(r)? as i32;
+    let ref_pos = read_u32(r)? as i32;
+    let fw_pos = read_u32(r)? as i32;
+    let rc_pos = read_u32(r)? as i32;
+    let fmt_id = read_u8(r)?;
+    let format = (fmt_id != FORMAT_NONE).then(|| LibraryFormat::from_format_id(fmt_id));
+    Ok(ScoredMapping {
+        tid,
+        is_fw,
+        status,
+        score: 0,
+        fragment_len,
+        read_len,
+        weight,
+        ref_pos,
+        fw_pos,
+        rc_pos,
+        format,
+        // SAM-output-only fields; not used by pass-2 inference.
+        r1_pos: -1,
+        r2_pos: -1,
+        r2_fw: false,
+        r1_score: 0,
+    })
+}
+
+/// Read one mapped fragment record, or `None` at a clean end of file (used by the
+/// run reader, which streams to EOF).
+fn read_record_opt<R: Read>(r: &mut R) -> Result<Option<(u128, Vec<ScoredMapping>)>> {
+    let na = match read_u32_opt(r)? {
+        Some(na) => na as usize,
+        None => return Ok(None),
+    };
     let key = read_u128(r)?;
     let mut maps = Vec::with_capacity(na);
     for _ in 0..na {
-        let tid = read_u32(r)?;
-        let weight = read_f64(r)?;
-        let status = status_from_u8(read_u8(r)?)?;
-        let is_fw = read_u8(r)? != 0;
-        let fragment_len = read_u32(r)? as i32;
-        let read_len = read_u32(r)? as i32;
-        let ref_pos = read_u32(r)? as i32;
-        let fw_pos = read_u32(r)? as i32;
-        let rc_pos = read_u32(r)? as i32;
-        let fmt_id = read_u8(r)?;
-        let format = (fmt_id != FORMAT_NONE).then(|| LibraryFormat::from_format_id(fmt_id));
-        maps.push(ScoredMapping {
-            tid,
-            is_fw,
-            status,
-            score: 0,
-            fragment_len,
-            read_len,
-            weight,
-            ref_pos,
-            fw_pos,
-            rc_pos,
-            format,
-            // SAM-output-only fields; not used by pass-2 inference.
-            r1_pos: -1,
-            r2_pos: -1,
-            r2_fw: false,
-            r1_score: 0,
-        });
+        maps.push(read_aln(r)?);
     }
-    Ok((key, maps))
+    Ok(Some((key, maps)))
+}
+
+/// Read one mapped fragment record (the inverse of [`write_record`]); errors on
+/// an unexpected end of file (the caller knows a record must be present).
+fn read_record<R: Read>(r: &mut R) -> Result<(u128, Vec<ScoredMapping>)> {
+    read_record_opt(r)?.context("unexpected EOF reading RAD record")
 }
 
 /// Read a full RAD file written by [`write_rad`] back into `(key, mappings)`
@@ -411,6 +429,187 @@ pub fn read_rad(path: &Path) -> Result<Vec<(u128, Vec<ScoredMapping>)>> {
     Ok(out)
 }
 
+/// Number of fragments held in memory per sort run. Run generation reads the
+/// store in blocks of this size, sorts each in memory, and spills it to a run
+/// file; the merge then streams. This bounds pass-2 peak memory to roughly one
+/// run (plus one front record per run), independent of total input size.
+pub const RUN_SIZE: usize = 4_000_000;
+
+/// Sequential record reader over a complete RAD file, hiding chunk framing:
+/// [`Self::next_record`] yields fragments one at a time across chunk boundaries.
+struct RadRecordReader {
+    r: BufReader<File>,
+    /// records left in the current chunk
+    in_chunk: u32,
+    /// `true` when the header said `num_chunks == 0` (read chunks until EOF)
+    streaming: bool,
+    /// chunks left to read when not streaming
+    chunks_left: u64,
+}
+
+impl RadRecordReader {
+    fn open(path: &Path) -> Result<Self> {
+        let f =
+            File::open(path).with_context(|| format!("opening RAD store {}", path.display()))?;
+        let mut r = BufReader::new(f);
+        let num_chunks = read_prelude(&mut r)?;
+        Ok(Self {
+            r,
+            in_chunk: 0,
+            streaming: num_chunks == 0,
+            chunks_left: num_chunks,
+        })
+    }
+
+    fn next_record(&mut self) -> Result<Option<(u128, Vec<ScoredMapping>)>> {
+        // Advance over chunk headers (and any empty chunks) until a record is due.
+        while self.in_chunk == 0 {
+            if self.streaming {
+                match read_u32_opt(&mut self.r)? {
+                    None => return Ok(None),
+                    Some(_nbytes) => self.in_chunk = read_u32(&mut self.r)?,
+                }
+            } else {
+                if self.chunks_left == 0 {
+                    return Ok(None);
+                }
+                self.chunks_left -= 1;
+                let _nbytes = read_u32(&mut self.r)?;
+                self.in_chunk = read_u32(&mut self.r)?;
+            }
+        }
+        self.in_chunk -= 1;
+        Ok(Some(read_record(&mut self.r)?))
+    }
+}
+
+/// Write a sorted run: just the concatenated records (no prelude), read back to
+/// EOF by [`RunFront`].
+fn write_run(path: &Path, frags: &[(u128, Vec<ScoredMapping>)]) -> Result<()> {
+    let f = File::create(path).with_context(|| format!("creating sort run {}", path.display()))?;
+    let mut w = BufWriter::new(f);
+    let mut body = Vec::new();
+    for (key, maps) in frags {
+        write_record(&mut body, *key, maps);
+    }
+    w.write_all(&body)?;
+    w.flush()?;
+    Ok(())
+}
+
+/// One sorted run during the merge: its reader plus the next (smallest-key)
+/// record not yet emitted.
+struct RunFront {
+    r: BufReader<File>,
+    front: Option<(u128, Vec<ScoredMapping>)>,
+}
+
+impl RunFront {
+    fn open(path: &Path) -> Result<Self> {
+        let f = File::open(path).with_context(|| format!("opening sort run {}", path.display()))?;
+        let mut r = BufReader::new(f);
+        let front = read_record_opt(&mut r)?;
+        Ok(Self { r, front })
+    }
+
+    fn advance(&mut self) -> Result<()> {
+        self.front = read_record_opt(&mut self.r)?;
+        Ok(())
+    }
+}
+
+/// External merge sort over a RAD mapping store, yielding fragments in ascending
+/// key order without holding the whole store in memory.
+///
+/// Construction spills the store into sorted runs of [`RUN_SIZE`] fragments each;
+/// iteration k-way merges them via a min-heap keyed by `(frag_key, run_index)`
+/// (the run index makes the order total and reproducible). The temporary run
+/// files are removed on drop. This is what lets pass 2 stay deterministic and
+/// memory-bounded on very large inputs.
+pub struct ExternalSort {
+    runs: Vec<RunFront>,
+    heap: BinaryHeap<Reverse<(u128, usize)>>,
+    run_paths: Vec<PathBuf>,
+}
+
+impl ExternalSort {
+    /// Spill `store` into sorted runs of `run_size` fragments under `tmp_dir`, and
+    /// prime the merge. `run_size` is clamped to at least 1.
+    pub fn new(store: &Path, run_size: usize, tmp_dir: &Path) -> Result<Self> {
+        let run_size = run_size.max(1);
+        let mut reader = RadRecordReader::open(store)?;
+        let mut run_paths: Vec<PathBuf> = Vec::new();
+
+        let spill = |block: &mut Vec<(u128, Vec<ScoredMapping>)>,
+                     run_paths: &mut Vec<PathBuf>|
+         -> Result<()> {
+            if block.is_empty() {
+                return Ok(());
+            }
+            // keys are 128-bit hashes (effectively unique), so an unstable sort
+            // gives the same total order as a stable one, faster.
+            block.sort_unstable_by_key(|(k, _)| *k);
+            let path = tmp_dir.join(format!("det_run_{}.rad", run_paths.len()));
+            write_run(&path, block)?;
+            run_paths.push(path);
+            block.clear();
+            Ok(())
+        };
+
+        let mut block: Vec<(u128, Vec<ScoredMapping>)> = Vec::with_capacity(run_size.min(1 << 16));
+        while let Some(rec) = reader.next_record()? {
+            block.push(rec);
+            if block.len() >= run_size {
+                spill(&mut block, &mut run_paths)?;
+            }
+        }
+        spill(&mut block, &mut run_paths)?;
+
+        let mut runs = Vec::with_capacity(run_paths.len());
+        let mut heap = BinaryHeap::with_capacity(run_paths.len());
+        for (i, path) in run_paths.iter().enumerate() {
+            let rf = RunFront::open(path)?;
+            if let Some((k, _)) = rf.front.as_ref() {
+                heap.push(Reverse((*k, i)));
+            }
+            runs.push(rf);
+        }
+        Ok(Self {
+            runs,
+            heap,
+            run_paths,
+        })
+    }
+}
+
+impl Iterator for ExternalSort {
+    type Item = Result<(u128, Vec<ScoredMapping>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Reverse((_key, idx)) = self.heap.pop()?;
+        // The heap only holds runs whose `front` is `Some`, so this is present.
+        let rec = self.runs[idx]
+            .front
+            .take()
+            .expect("merge heap/front invariant");
+        if let Err(e) = self.runs[idx].advance() {
+            return Some(Err(e));
+        }
+        if let Some((k, _)) = self.runs[idx].front.as_ref() {
+            self.heap.push(Reverse((*k, idx)));
+        }
+        Some(Ok(rec))
+    }
+}
+
+impl Drop for ExternalSort {
+    fn drop(&mut self) {
+        for path in &self.run_paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -418,7 +617,7 @@ mod tests {
     fn sample_mapping(tid: u32, status: MateStatus, fmt: Option<LibraryFormat>) -> ScoredMapping {
         ScoredMapping {
             tid,
-            is_fw: tid % 2 == 0,
+            is_fw: (tid & 1) == 0,
             status,
             score: 0,
             fragment_len: 250 + tid as i32,
@@ -480,6 +679,42 @@ mod tests {
         let mut cur = std::io::Cursor::new(buf);
         let (_k, rmaps) = read_record(&mut cur).unwrap();
         assert_eq!(rmaps[0].format, None);
+    }
+
+    #[test]
+    fn external_sort_merges_runs_in_key_order() {
+        use std::io::Write as _;
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join("store.rad");
+
+        let mk =
+            |key: u128, tid: u32| (key, vec![sample_mapping(tid, MateStatus::SingleEnd, None)]);
+        // Keys in scrambled order, split across two chunks (so the streaming
+        // reader crosses a chunk boundary too).
+        let chunk_a = vec![mk(50, 0), mk(10, 1), mk(30, 2)];
+        let chunk_b = vec![mk(20, 3), mk(40, 4), mk(5, 5), mk(25, 6)];
+        {
+            let mut f = std::fs::File::create(&store).unwrap();
+            write_prelude_parts(&mut f, false, &["a"], 0).unwrap(); // num_chunks = 0 -> stream
+            f.write_all(&serialize_chunk(&chunk_a)).unwrap();
+            f.write_all(&serialize_chunk(&chunk_b)).unwrap();
+            f.flush().unwrap();
+        }
+
+        // run_size = 2 over 7 records forces 4 runs, exercising the k-way merge.
+        let sorter = ExternalSort::new(&store, 2, tmp.path()).unwrap();
+        let got: Vec<u128> = sorter.map(|r| r.unwrap().0).collect();
+
+        let mut expected: Vec<u128> = chunk_a.iter().chain(&chunk_b).map(|(k, _)| *k).collect();
+        expected.sort_unstable();
+        assert_eq!(got, expected, "external sort must yield key-sorted output");
+
+        // Run files are cleaned up when the sorter drops.
+        let leftover = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().starts_with("det_run_"));
+        assert!(!leftover, "temporary run files were not removed");
     }
 
     #[test]

--- a/crates/salmon-quant/src/rad.rs
+++ b/crates/salmon-quant/src/rad.rs
@@ -30,8 +30,9 @@
 //!   [`TagSection`]s (written via `libradicl`).
 //! - one or more chunks: `nbytes (u32, incl. this 8-byte header)`, `nrec (u32)`,
 //!   then `nrec` records.
-//! - record: `num_aln (u32)`, the read-level `frag_key (u128)`, then per
-//!   alignment the alignment-level tag values in the declared order.
+//! - record: `num_aln (u32)`, the read-level `frag_key` (a 128-bit key stored as
+//!   two `u64` halves, low then high), then per alignment the alignment-level tag
+//!   values in the declared order.
 
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter, Read, Write};
@@ -50,13 +51,20 @@ use salmon_map::ScoredMapping;
 /// `u8` value is free to use as the "absent" marker.
 const FORMAT_NONE: u8 = 0xFF;
 
-/// The read-level tag section: the stable per-fragment sort key.
+/// The read-level tag section: the stable per-fragment sort key, declared as two
+/// `u64` halves (low then high) rather than one `u128`. The published `libradicl`
+/// 0.10 reader does not decode the `u128` type id (9), so a single-`u128` tag,
+/// though encodable, would make the prelude unparseable by the canonical reader;
+/// two `u64`s are byte-identical to the `u128` little-endian layout and fully
+/// conformant. Our own hot-path reader still reads the 16 bytes as one `u128`.
 fn read_tag_section() -> TagSection {
     let mut s = TagSection::new_with_label(TagSectionLabel::ReadTags);
-    s.add_tag_desc(TagDesc {
-        name: "frag_key".to_string(),
-        typeid: RadType::Int(RadIntId::U128),
-    });
+    let u64tag = |name: &str| TagDesc {
+        name: name.to_string(),
+        typeid: RadType::Int(RadIntId::U64),
+    };
+    s.add_tag_desc(u64tag("frag_key_lo"));
+    s.add_tag_desc(u64tag("frag_key_hi"));
     s
 }
 
@@ -132,11 +140,21 @@ fn write_prelude<W: Write>(
     is_paired: bool,
     num_chunks: u64,
 ) -> Result<()> {
+    let names: Vec<&str> = (0..salmon.num_refs()).map(|t| salmon.ref_name(t)).collect();
+    write_prelude_parts(w, is_paired, &names, num_chunks)
+}
+
+/// Prelude writer parameterized by the raw reference names, so it can be unit
+/// tested (and round-tripped through `libradicl`'s reader) without a full index.
+fn write_prelude_parts<W: Write>(
+    w: &mut W,
+    is_paired: bool,
+    ref_names: &[&str],
+    num_chunks: u64,
+) -> Result<()> {
     w.write_all(&[is_paired as u8])?;
-    let num_refs = salmon.num_refs();
-    w.write_all(&(num_refs as u64).to_le_bytes())?;
-    for t in 0..num_refs {
-        let name = salmon.ref_name(t);
+    w.write_all(&(ref_names.len() as u64).to_le_bytes())?;
+    for name in ref_names {
         let len: u16 = name
             .len()
             .try_into()
@@ -462,6 +480,56 @@ mod tests {
         let mut cur = std::io::Cursor::new(buf);
         let (_k, rmaps) = read_record(&mut cur).unwrap();
         assert_eq!(rmaps[0].format, None);
+    }
+
+    #[test]
+    fn prelude_parses_with_libradicl() {
+        // The canonical reader must accept our prelude: this is what makes the
+        // store genuine RAD (readable by piscem-infer / alevin-fry tooling) rather
+        // than a bespoke format wearing RAD's name.
+        use libradicl::header::RadPrelude;
+        let names = ["txA", "transcript_B", "c"];
+        let mut buf = Vec::new();
+        write_prelude_parts(&mut buf, true, &names, 0).unwrap();
+
+        let mut cur = std::io::Cursor::new(buf);
+        let prelude = RadPrelude::from_bytes(&mut cur).expect("libradicl parses our prelude");
+
+        assert_eq!(prelude.hdr.is_paired, 1);
+        assert_eq!(prelude.hdr.ref_count, 3);
+        let got: Vec<&str> = prelude.hdr.ref_names.iter().map(String::as_str).collect();
+        assert_eq!(got, names);
+        assert_eq!(prelude.hdr.num_chunks, 0);
+
+        assert!(prelude.file_tags.tags.is_empty());
+        let read: Vec<&str> = prelude
+            .read_tags
+            .tags
+            .iter()
+            .map(|t| t.name.as_str())
+            .collect();
+        assert_eq!(read, ["frag_key_lo", "frag_key_hi"]);
+        let aln: Vec<&str> = prelude
+            .aln_tags
+            .tags
+            .iter()
+            .map(|t| t.name.as_str())
+            .collect();
+        assert_eq!(
+            aln,
+            [
+                "tid",
+                "weight",
+                "status",
+                "is_fw",
+                "fragment_len",
+                "read_len",
+                "ref_pos",
+                "fw_pos",
+                "rc_pos",
+                "format",
+            ]
+        );
     }
 
     #[test]

--- a/crates/salmon-quant/src/rad.rs
+++ b/crates/salmon-quant/src/rad.rs
@@ -1,0 +1,396 @@
+//! RAD-format mapping store for the deterministic two-pass path (`--deterministic`).
+//!
+//! Pass 1 maps in parallel and writes each mapped fragment's `(key, mappings)`
+//! here as a RAD record; pass 2 reads them back and replays inference in a fixed
+//! key-sorted order. We reuse the RAD container and tag framework (the format
+//! used by piscem, piscem-infer, and alevin-fry, via `libradicl`'s type
+//! primitives) rather than a bespoke binary format, so this store shares an
+//! ingestion route with those tools and lays the groundwork for RAD-format
+//! *input* to salmon-quant (`piscem map` -> `salmon quant`).
+//!
+//! ## Profile
+//!
+//! Standard bulk RAD keeps `(ref | orientation, position, frag_length)` per
+//! alignment. salmon's selective-alignment inference also needs the per-mapping
+//! coverage weight and a few more per-mapping fields, so we declare a
+//! salmon-specific alignment-level tag schema that is a superset of the bulk
+//! profile. A RAD that lacks the extra tags (for example one produced by
+//! `piscem map`) maps onto the uniform-weight path instead; consuming that is a
+//! separate, future feature.
+//!
+//! Only the fields the per-fragment inference ([`crate::processor`]'s `record`)
+//! reads are stored; the SAM-output-only fields of [`ScoredMapping`] (`score`,
+//! `r1_pos`, `r2_pos`, `r2_fw`, `r1_score`) are written during pass 1 and are not
+//! needed in pass 2, so they are reconstructed at their inert defaults on read.
+//!
+//! ## Byte layout (RAD-conformant, little-endian)
+//!
+//! - prelude: `is_paired (u8)`, `ref_count (u64)`, `ref_count x (name_len u16 +
+//!   name bytes)`, `num_chunks (u64)`, then the file / read / alignment
+//!   [`TagSection`]s (written via `libradicl`).
+//! - one or more chunks: `nbytes (u32, incl. this 8-byte header)`, `nrec (u32)`,
+//!   then `nrec` records.
+//! - record: `num_aln (u32)`, the read-level `frag_key (u128)`, then per
+//!   alignment the alignment-level tag values in the declared order.
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use libradicl::rad_types::{RadFloatId, RadIntId, RadType, TagDesc, TagSection, TagSectionLabel};
+
+use salmon_core::{LibraryFormat, MateStatus};
+use salmon_index::SalmonIndex;
+use salmon_map::ScoredMapping;
+
+/// Sentinel `format` tag value standing for `ScoredMapping::format == None`
+/// (no library format determinable). Library `format_id`s are small, so the top
+/// `u8` value is free to use as the "absent" marker.
+const FORMAT_NONE: u8 = 0xFF;
+
+/// The read-level tag section: the stable per-fragment sort key.
+fn read_tag_section() -> TagSection {
+    let mut s = TagSection::new_with_label(TagSectionLabel::ReadTags);
+    s.add_tag_desc(TagDesc {
+        name: "frag_key".to_string(),
+        typeid: RadType::Int(RadIntId::U128),
+    });
+    s
+}
+
+/// The alignment-level tag section: salmon's full-fidelity per-mapping fields.
+/// Signed values (`fragment_len`, `read_len`, `*_pos`, which use `-1` sentinels)
+/// are stored as their `u32` two's-complement bit pattern (RAD ints are
+/// unsigned) and cast back on read.
+fn aln_tag_section() -> TagSection {
+    let mut s = TagSection::new_with_label(TagSectionLabel::AlignmentTags);
+    let int = |name: &str, id| TagDesc {
+        name: name.to_string(),
+        typeid: RadType::Int(id),
+    };
+    s.add_tag_desc(int("tid", RadIntId::U32));
+    s.add_tag_desc(TagDesc {
+        name: "weight".to_string(),
+        typeid: RadType::Float(RadFloatId::F64),
+    });
+    s.add_tag_desc(int("status", RadIntId::U8));
+    s.add_tag_desc(int("is_fw", RadIntId::U8));
+    s.add_tag_desc(int("fragment_len", RadIntId::U32));
+    s.add_tag_desc(int("read_len", RadIntId::U32));
+    s.add_tag_desc(int("ref_pos", RadIntId::U32));
+    s.add_tag_desc(int("fw_pos", RadIntId::U32));
+    s.add_tag_desc(int("rc_pos", RadIntId::U32));
+    s.add_tag_desc(int("format", RadIntId::U8));
+    s
+}
+
+fn status_to_u8(s: MateStatus) -> u8 {
+    match s {
+        MateStatus::PairedEndLeft => 0,
+        MateStatus::PairedEndRight => 1,
+        MateStatus::PairedEndPaired => 2,
+        MateStatus::SingleEnd => 3,
+    }
+}
+
+fn status_from_u8(v: u8) -> Result<MateStatus> {
+    Ok(match v {
+        0 => MateStatus::PairedEndLeft,
+        1 => MateStatus::PairedEndRight,
+        2 => MateStatus::PairedEndPaired,
+        3 => MateStatus::SingleEnd,
+        other => bail!("invalid MateStatus tag value {other}"),
+    })
+}
+
+/// Append one fragment's record (`num_aln`, `frag_key`, per-alignment tags) to
+/// `buf`. Hand-written little-endian bytes in the declared tag order: this is the
+/// hot path, so it avoids per-record allocation (as piscem's own RAD writer does).
+fn write_record(buf: &mut Vec<u8>, key: u128, maps: &[ScoredMapping]) {
+    buf.extend_from_slice(&(maps.len() as u32).to_le_bytes());
+    buf.extend_from_slice(&key.to_le_bytes());
+    for m in maps {
+        buf.extend_from_slice(&m.tid.to_le_bytes());
+        buf.extend_from_slice(&m.weight.to_le_bytes());
+        buf.push(status_to_u8(m.status));
+        buf.push(m.is_fw as u8);
+        buf.extend_from_slice(&(m.fragment_len as u32).to_le_bytes());
+        buf.extend_from_slice(&(m.read_len as u32).to_le_bytes());
+        buf.extend_from_slice(&(m.ref_pos as u32).to_le_bytes());
+        buf.extend_from_slice(&(m.fw_pos as u32).to_le_bytes());
+        buf.extend_from_slice(&(m.rc_pos as u32).to_le_bytes());
+        buf.push(m.format.map_or(FORMAT_NONE, |f| f.format_id()));
+    }
+}
+
+/// Write the RAD prelude: header + the three tag sections.
+fn write_prelude<W: Write>(
+    w: &mut W,
+    salmon: &SalmonIndex,
+    is_paired: bool,
+    num_chunks: u64,
+) -> Result<()> {
+    w.write_all(&[is_paired as u8])?;
+    let num_refs = salmon.num_refs();
+    w.write_all(&(num_refs as u64).to_le_bytes())?;
+    for t in 0..num_refs {
+        let name = salmon.ref_name(t);
+        let len: u16 = name
+            .len()
+            .try_into()
+            .context("reference name longer than 65535 bytes")?;
+        w.write_all(&len.to_le_bytes())?;
+        w.write_all(name.as_bytes())?;
+    }
+    w.write_all(&num_chunks.to_le_bytes())?;
+    // file tags: none (the deterministic store carries no file-level values).
+    TagSection::new_with_label(TagSectionLabel::FileTags)
+        .write(w)
+        .context("writing RAD file tag section")?;
+    read_tag_section()
+        .write(w)
+        .context("writing RAD read tag section")?;
+    aln_tag_section()
+        .write(w)
+        .context("writing RAD alignment tag section")?;
+    Ok(())
+}
+
+/// Write a complete single-chunk RAD file holding `frags`. Used for the in-memory
+/// store and as the round-trip reference; the parallel store appends chunks
+/// incrementally (a later step).
+pub fn write_rad(
+    path: &Path,
+    salmon: &SalmonIndex,
+    is_paired: bool,
+    frags: &[(u128, Vec<ScoredMapping>)],
+) -> Result<()> {
+    let f = File::create(path).with_context(|| format!("creating RAD file {}", path.display()))?;
+    let mut w = BufWriter::new(f);
+    write_prelude(&mut w, salmon, is_paired, 1)?;
+
+    let mut body = Vec::new();
+    for (key, maps) in frags {
+        write_record(&mut body, *key, maps);
+    }
+    let nbytes: u32 = (body.len() + 8)
+        .try_into()
+        .context("RAD chunk exceeds 4 GiB; chunking not yet implemented")?;
+    w.write_all(&nbytes.to_le_bytes())?;
+    w.write_all(&(frags.len() as u32).to_le_bytes())?;
+    w.write_all(&body)?;
+    w.flush()?;
+    Ok(())
+}
+
+fn read_u8<R: Read>(r: &mut R) -> Result<u8> {
+    let mut b = [0u8; 1];
+    r.read_exact(&mut b)?;
+    Ok(b[0])
+}
+fn read_u16<R: Read>(r: &mut R) -> Result<u16> {
+    let mut b = [0u8; 2];
+    r.read_exact(&mut b)?;
+    Ok(u16::from_le_bytes(b))
+}
+fn read_u32<R: Read>(r: &mut R) -> Result<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b)?;
+    Ok(u32::from_le_bytes(b))
+}
+fn read_u64<R: Read>(r: &mut R) -> Result<u64> {
+    let mut b = [0u8; 8];
+    r.read_exact(&mut b)?;
+    Ok(u64::from_le_bytes(b))
+}
+fn read_u128<R: Read>(r: &mut R) -> Result<u128> {
+    let mut b = [0u8; 16];
+    r.read_exact(&mut b)?;
+    Ok(u128::from_le_bytes(b))
+}
+fn read_f64<R: Read>(r: &mut R) -> Result<f64> {
+    let mut b = [0u8; 8];
+    r.read_exact(&mut b)?;
+    Ok(f64::from_le_bytes(b))
+}
+
+/// Advance the reader past one tag section (`num_tags u16`, then each
+/// `name_len u16 + name + type u8`, plus two type ids for an `Array` tag). The
+/// deterministic store reads back its own fixed schema, so the section contents
+/// only need to be skipped to reach the chunks.
+fn skip_tag_section<R: Read>(r: &mut R) -> Result<()> {
+    let num_tags = read_u16(r)?;
+    for _ in 0..num_tags {
+        let name_len = read_u16(r)? as usize;
+        let mut name = vec![0u8; name_len];
+        r.read_exact(&mut name)?;
+        let type_id = read_u8(r)?;
+        if type_id == 7 {
+            // Array: length-type id + value-type id
+            let _ = read_u8(r)?;
+            let _ = read_u8(r)?;
+        }
+    }
+    Ok(())
+}
+
+/// Read the prelude and return `num_chunks`.
+fn read_prelude<R: Read>(r: &mut R) -> Result<u64> {
+    let _is_paired = read_u8(r)?;
+    let ref_count = read_u64(r)?;
+    for _ in 0..ref_count {
+        let len = read_u16(r)? as usize;
+        let mut name = vec![0u8; len];
+        r.read_exact(&mut name)?;
+    }
+    let num_chunks = read_u64(r)?;
+    skip_tag_section(r).context("reading RAD file tag section")?;
+    skip_tag_section(r).context("reading RAD read tag section")?;
+    skip_tag_section(r).context("reading RAD alignment tag section")?;
+    Ok(num_chunks)
+}
+
+/// Read one mapped fragment record (the inverse of [`write_record`]).
+fn read_record<R: Read>(r: &mut R) -> Result<(u128, Vec<ScoredMapping>)> {
+    let na = read_u32(r)? as usize;
+    let key = read_u128(r)?;
+    let mut maps = Vec::with_capacity(na);
+    for _ in 0..na {
+        let tid = read_u32(r)?;
+        let weight = read_f64(r)?;
+        let status = status_from_u8(read_u8(r)?)?;
+        let is_fw = read_u8(r)? != 0;
+        let fragment_len = read_u32(r)? as i32;
+        let read_len = read_u32(r)? as i32;
+        let ref_pos = read_u32(r)? as i32;
+        let fw_pos = read_u32(r)? as i32;
+        let rc_pos = read_u32(r)? as i32;
+        let fmt_id = read_u8(r)?;
+        let format = (fmt_id != FORMAT_NONE).then(|| LibraryFormat::from_format_id(fmt_id));
+        maps.push(ScoredMapping {
+            tid,
+            is_fw,
+            status,
+            score: 0,
+            fragment_len,
+            read_len,
+            weight,
+            ref_pos,
+            fw_pos,
+            rc_pos,
+            format,
+            // SAM-output-only fields; not used by pass-2 inference.
+            r1_pos: -1,
+            r2_pos: -1,
+            r2_fw: false,
+            r1_score: 0,
+        });
+    }
+    Ok((key, maps))
+}
+
+/// Read a full RAD file written by [`write_rad`] back into `(key, mappings)`
+/// fragments (inference fields only).
+pub fn read_rad(path: &Path) -> Result<Vec<(u128, Vec<ScoredMapping>)>> {
+    let f = File::open(path).with_context(|| format!("opening RAD file {}", path.display()))?;
+    let mut r = BufReader::new(f);
+    let num_chunks = read_prelude(&mut r)?;
+    let mut out = Vec::new();
+    for _ in 0..num_chunks {
+        let _nbytes = read_u32(&mut r)?;
+        let nrec = read_u32(&mut r)?;
+        out.reserve(nrec as usize);
+        for _ in 0..nrec {
+            out.push(read_record(&mut r)?);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_mapping(tid: u32, status: MateStatus, fmt: Option<LibraryFormat>) -> ScoredMapping {
+        ScoredMapping {
+            tid,
+            is_fw: tid % 2 == 0,
+            status,
+            score: 0,
+            fragment_len: 250 + tid as i32,
+            read_len: 100,
+            weight: 0.5 + (tid as f64) * 0.125,
+            ref_pos: 42 + tid as i32,
+            fw_pos: tid as i32,
+            rc_pos: -1,
+            format: fmt,
+            r1_pos: -1,
+            r2_pos: -1,
+            r2_fw: false,
+            r1_score: 0,
+        }
+    }
+
+    /// Assert that the fields pass-2 inference reads survive a RAD round trip.
+    fn assert_inference_fields_eq(a: &ScoredMapping, b: &ScoredMapping) {
+        assert_eq!(a.tid, b.tid);
+        assert_eq!(a.is_fw, b.is_fw);
+        assert_eq!(a.status, b.status);
+        assert_eq!(a.fragment_len, b.fragment_len);
+        assert_eq!(a.read_len, b.read_len);
+        assert_eq!(a.weight.to_bits(), b.weight.to_bits());
+        assert_eq!(a.ref_pos, b.ref_pos);
+        assert_eq!(a.fw_pos, b.fw_pos);
+        assert_eq!(a.rc_pos, b.rc_pos);
+        assert_eq!(a.format, b.format);
+    }
+
+    #[test]
+    fn record_round_trips_through_buffer() {
+        let fmt = Some(LibraryFormat::paired_default());
+        let maps = vec![
+            sample_mapping(0, MateStatus::PairedEndPaired, fmt),
+            sample_mapping(7, MateStatus::PairedEndLeft, None),
+            sample_mapping(123_456, MateStatus::SingleEnd, fmt),
+        ];
+        let key: u128 = 0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210;
+
+        let mut buf = Vec::new();
+        write_record(&mut buf, key, &maps);
+        let mut cur = std::io::Cursor::new(buf);
+        let (rkey, rmaps) = read_record(&mut cur).expect("read record");
+
+        assert_eq!(rkey, key);
+        assert_eq!(rmaps.len(), maps.len());
+        for (a, b) in maps.iter().zip(&rmaps) {
+            assert_inference_fields_eq(a, b);
+        }
+    }
+
+    #[test]
+    fn format_none_sentinel_round_trips() {
+        // FORMAT_NONE must not collide with any real format_id.
+        let maps = vec![sample_mapping(1, MateStatus::PairedEndPaired, None)];
+        let mut buf = Vec::new();
+        write_record(&mut buf, 1, &maps);
+        let mut cur = std::io::Cursor::new(buf);
+        let (_k, rmaps) = read_record(&mut cur).unwrap();
+        assert_eq!(rmaps[0].format, None);
+    }
+
+    #[test]
+    fn tag_sections_skip_is_consistent_with_write() {
+        // A prelude's tag sections must be skippable back to byte alignment:
+        // write read+aln sections, then skip them, and confirm we land exactly at
+        // end of buffer.
+        let mut buf = Vec::new();
+        read_tag_section().write(&mut buf).unwrap();
+        aln_tag_section().write(&mut buf).unwrap();
+        let total = buf.len() as u64;
+        let mut cur = std::io::Cursor::new(buf);
+        skip_tag_section(&mut cur).unwrap();
+        skip_tag_section(&mut cur).unwrap();
+        assert_eq!(cur.position(), total, "tag section skip misaligned");
+    }
+}

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -210,6 +210,105 @@ fn quant_is_byte_identical_across_thread_counts() {
     assert_eq!(p1, p4a, "-p 1 and -p 4 differ");
 }
 
+fn simulate_multimapping(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let backbone = gen_seq(1500, 99);
+    let snp = |seed: u64, n: usize| {
+        let mut s = backbone.clone();
+        let mut x = seed;
+        for _ in 0..n {
+            x = x
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let pos = (x >> 33) as usize % s.len();
+            s[pos] = match s[pos] {
+                b'A' => b'C',
+                b'C' => b'G',
+                b'G' => b'T',
+                _ => b'A',
+            };
+        }
+        s
+    };
+    let txs = [
+        ("d0", backbone.clone()),
+        ("d1", snp(1, 6)),
+        ("d2", snp(2, 6)),
+    ];
+    let fasta = dir.join("multi.fa");
+    let mut fa = std::fs::File::create(&fasta).unwrap();
+    for (name, seq) in &txs {
+        writeln!(fa, ">{name}").unwrap();
+        fa.write_all(seq).unwrap();
+        writeln!(fa).unwrap();
+    }
+    drop(fa);
+    let r1p = dir.join("m1.fq");
+    let r2p = dir.join("m2.fq");
+    let mut w = FastqWriters {
+        r1: std::io::BufWriter::new(std::fs::File::create(&r1p).unwrap()),
+        r2: std::io::BufWriter::new(std::fs::File::create(&r2p).unwrap()),
+    };
+    let mut rng = 0x0BEE_F00Du64;
+    let mut next = || {
+        rng = rng
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        rng >> 33
+    };
+    // Enough fragments to span multiple paraseq batches / worker threads (so the
+    // multi-threaded path is actually exercised).
+    for id in 0..20000 {
+        let frag = 200 + (next() % 100) as usize;
+        let max_start = backbone.len() - frag;
+        let pos = (next() as usize) % (max_start + 1);
+        let s1 = backbone[pos..pos + READ_LEN].to_vec();
+        let s2 = revcomp(&backbone[pos + frag - READ_LEN..pos + frag]);
+        w.write_pair(id, &s1, &s2);
+    }
+    w.r1.flush().unwrap();
+    w.r2.flush().unwrap();
+    (fasta, r1p, r2p)
+}
+
+/// Strongest end-to-end determinism guard: compares the **full-precision** `f64`
+/// abundances (`res.counts`, not the truncated `quant.sf` text) across thread
+/// counts, under the hardest conditions for thread-order sensitivity — many
+/// multimapping fragments (near-duplicate transcripts -> fractional eq-class
+/// weights), `--seqBias --gcBias` on (online masses + bias models), and the
+/// after-burn-in FLD path forced on. With stages 1 (#1027), 2a (#1028) and 2b
+/// (#1030) this is bit-identical; the residual online-mass differences are far
+/// too small to flip the per-fragment-seeded FLD acceptance or the binned bias
+/// models.
+#[test]
+fn multimapping_counts_bit_identical_across_threads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = simulate_multimapping(tmp.path());
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let run = |threads: usize| -> Vec<u64> {
+        let out = tmp.path().join(format!("mm_{threads}"));
+        let mut opts = QuantOptions::new(idx_dir.clone(), out);
+        opts.mates1 = vec![r1.clone()];
+        opts.mates2 = vec![r2.clone()];
+        opts.lib_type = "IU".to_string();
+        opts.num_threads = threads;
+        opts.seq_bias = true;
+        opts.gc_bias = true;
+        // force the after-burn-in FLD path on small data
+        opts.num_pre_aux_model_samples = 50;
+        let res = quantify(&opts).expect("quantify");
+        res.counts.iter().map(|c| c.to_bits()).collect()
+    };
+    let p1 = run(1);
+    let p8a = run(8);
+    let p8b = run(8);
+    assert_eq!(p8a, p8b, "two -p 8 runs differ (full precision)");
+    assert_eq!(p1, p8a, "-p 1 and -p 8 differ (full precision)");
+}
+
 #[test]
 fn pseudoalignment_quantification_tracks_truth() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -196,6 +196,7 @@ fn quant_is_byte_identical_across_thread_counts() {
         opts.mates2 = vec![r2.clone()];
         opts.lib_type = "IU".to_string();
         opts.num_threads = threads;
+        opts.deterministic = true;
         quantify(&opts).expect("quantify");
         std::fs::read_to_string(out.join("quant.sf")).unwrap()
     };
@@ -299,6 +300,9 @@ fn multimapping_counts_bit_identical_across_threads() {
         opts.gc_bias = true;
         // force the after-burn-in FLD path on small data
         opts.num_pre_aux_model_samples = 50;
+        // byte-for-byte reproducibility is opt-in (#1031 review): the two-pass,
+        // key-sorted inference path is what makes this bit-identical across `-p`.
+        opts.deterministic = true;
         let res = quantify(&opts).expect("quantify");
         res.counts.iter().map(|c| c.to_bits()).collect()
     };

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -388,6 +388,55 @@ fn multi_run_external_sort_is_bit_identical_across_threads() {
     );
 }
 
+/// RAD input round trip: map once with `--writeRad` to persist the mapping store,
+/// then quantify from it with `--rad` (no reads). The decoupled quant must
+/// reproduce the byte-identical `quant.sf`, and it must be independent of the
+/// thread count used either to build the store or (irrelevant, serial) to read it.
+#[test]
+fn rad_input_reproduces_quant_from_written_store() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = simulate_multimapping(tmp.path());
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let store = tmp.path().join("mappings.rad");
+
+    // Map at -p 4, writing and keeping the RAD store.
+    let out_a = tmp.path().join("a");
+    let mut a = QuantOptions::new(idx_dir.clone(), out_a.clone());
+    a.mates1 = vec![r1.clone()];
+    a.mates2 = vec![r2.clone()];
+    a.lib_type = "IU".to_string();
+    a.num_threads = 4;
+    a.seq_bias = true;
+    a.gc_bias = true;
+    a.num_pre_aux_model_samples = 50;
+    a.write_rad = Some(store.clone());
+    quantify(&a).expect("quantify + writeRad");
+    assert!(store.exists(), "--writeRad did not keep the store");
+    let sf_a = std::fs::read_to_string(out_a.join("quant.sf")).unwrap();
+
+    // Re-quantify from the store alone (no reads), at a different thread count and
+    // matching inference settings.
+    let out_b = tmp.path().join("b");
+    let mut b = QuantOptions::new(idx_dir.clone(), out_b.clone());
+    b.lib_type = "IU".to_string();
+    b.num_threads = 8;
+    b.seq_bias = true;
+    b.gc_bias = true;
+    b.num_pre_aux_model_samples = 50;
+    b.rad_input = Some(store.clone());
+    quantify(&b).expect("quantify from --rad");
+    let sf_b = std::fs::read_to_string(out_b.join("quant.sf")).unwrap();
+
+    assert_eq!(
+        sf_a, sf_b,
+        "RAD-input quant differs from the store-producing run"
+    );
+}
+
 #[test]
 fn pseudoalignment_quantification_tracks_truth() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -180,6 +180,37 @@ fn selective_alignment_quantification_tracks_truth() {
 }
 
 #[test]
+fn quant_is_byte_identical_across_thread_counts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2, _truth) = simulate(tmp.path());
+
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let run = |threads: usize, tag: &str| {
+        let out = tmp.path().join(format!("quant_{tag}"));
+        let mut opts = QuantOptions::new(idx_dir.clone(), out.clone());
+        opts.mates1 = vec![r1.clone()];
+        opts.mates2 = vec![r2.clone()];
+        opts.lib_type = "IU".to_string();
+        opts.num_threads = threads;
+        quantify(&opts).expect("quantify");
+        std::fs::read_to_string(out.join("quant.sf")).unwrap()
+    };
+
+    let p1 = run(1, "p1");
+    let p4a = run(4, "p4a");
+    let p4b = run(4, "p4b");
+
+    // Multi-threaded runs must be byte-identical to each other and to the
+    // single-threaded run (no thread-scheduling-dependent drift).
+    assert_eq!(p4a, p4b, "two -p 4 runs differ");
+    assert_eq!(p1, p4a, "-p 1 and -p 4 differ");
+}
+
+#[test]
 fn pseudoalignment_quantification_tracks_truth() {
     let tmp = tempfile::tempdir().unwrap();
     let (fasta, r1, r2, truth) = simulate(tmp.path());

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -345,6 +345,49 @@ fn single_end_counts_bit_identical_across_threads() {
     assert_eq!(p1, p8a, "single-end -p 1 and -p 8 differ (full precision)");
 }
 
+/// Determinism must hold when pass 2 streams through a multi-run external sort,
+/// not just a single in-memory run. Force a tiny run size (≈20 runs over the 20k
+/// multimapping fragments) so the k-way merge is exercised, and assert the result
+/// is byte-identical across thread counts (and to the heavier single-run guard
+/// above, which uses the same inputs).
+#[test]
+fn multi_run_external_sort_is_bit_identical_across_threads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = simulate_multimapping(tmp.path());
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let run = |threads: usize, run_size: Option<usize>| -> Vec<u64> {
+        let out = tmp.path().join(format!("mr_{threads}_{run_size:?}"));
+        let mut opts = QuantOptions::new(idx_dir.clone(), out);
+        opts.mates1 = vec![r1.clone()];
+        opts.mates2 = vec![r2.clone()];
+        opts.lib_type = "IU".to_string();
+        opts.num_threads = threads;
+        opts.seq_bias = true;
+        opts.gc_bias = true;
+        opts.num_pre_aux_model_samples = 50;
+        opts.deterministic = true;
+        opts.det_run_size = run_size;
+        let res = quantify(&opts).expect("quantify");
+        res.counts.iter().map(|c| c.to_bits()).collect()
+    };
+    // ~20 runs over 20k fragments at -p 1 and -p 8, plus a single-run reference.
+    let many_p1 = run(1, Some(1000));
+    let many_p8 = run(8, Some(1000));
+    let single = run(8, None);
+    assert_eq!(
+        many_p1, many_p8,
+        "multi-run external sort not deterministic across -p"
+    );
+    assert_eq!(
+        single, many_p1,
+        "multi-run merge result differs from single-run result"
+    );
+}
+
 #[test]
 fn pseudoalignment_quantification_tracks_truth() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -313,6 +313,38 @@ fn multimapping_counts_bit_identical_across_threads() {
     assert_eq!(p1, p8a, "-p 1 and -p 8 differ (full precision)");
 }
 
+/// Same determinism guarantee for the single-end (unmated) path, which uses the
+/// other `ParallelProcessor` impl and the single-read RAD record. Reuses the 20k
+/// multimapping reads as unmated single-end input so the multi-thread store is
+/// genuinely exercised.
+#[test]
+fn single_end_counts_bit_identical_across_threads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, _r2) = simulate_multimapping(tmp.path());
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let run = |threads: usize| -> Vec<u64> {
+        let out = tmp.path().join(format!("se_{threads}"));
+        let mut opts = QuantOptions::new(idx_dir.clone(), out);
+        opts.unmated = vec![r1.clone()];
+        opts.lib_type = "U".to_string();
+        opts.num_threads = threads;
+        opts.seq_bias = true;
+        opts.num_pre_aux_model_samples = 50;
+        opts.deterministic = true;
+        let res = quantify(&opts).expect("quantify");
+        res.counts.iter().map(|c| c.to_bits()).collect()
+    };
+    let p1 = run(1);
+    let p8a = run(8);
+    let p8b = run(8);
+    assert_eq!(p8a, p8b, "two single-end -p 8 runs differ (full precision)");
+    assert_eq!(p1, p8a, "single-end -p 1 and -p 8 differ (full precision)");
+}
+
 #[test]
 fn pseudoalignment_quantification_tracks_truth() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## What

Make the RAD mapping store a real interchange format, decoupling mapping from inference:

- **`--writeRad <file>`** writes salmon's mapping store to a path and keeps it.
- **`--rad <file>`** quantifies from a salmon-written RAD store instead of FASTQ reads.

So you can run mapping once and re-quantify without re-mapping, and it is the foundation for the `piscem map -> salmon quant` path discussed in #1032.

> Stacks on #1033 (the RAD store) and #1031. The commit unique to this branch is the input/output wiring.

## Change

- `--rad` skips mapping and runs the same deterministic, key-sorted pass-2 inference (`ExternalSort` + `run_inference_serial`) over the store, then the usual effective-length / EM / bias-correction / output. The index (`-i`) still supplies reference lengths and sequences (for effective lengths and bias). paired-vs-single is read from the RAD header; `processed == mapped` since the store holds only mapped fragments.
- `--writeRad` produces the store (implies the deterministic store is generated) and keeps it instead of deleting it after pass 2.
- `rad.rs`: `read_is_paired` + `verify_salmon_profile`, which **rejects a non-salmon RAD** (e.g. a piscem bulk RAD, whose reduced records this reader does not yet decode) with a clear error rather than silently misreading it.
- CLI: `--rad` satisfies the input requirement and is mutually exclusive with read inputs (`-1/-2/-r`).

## Testing

- New end-to-end test: map once at `-p 4` with `--writeRad`, then quantify from the store with `--rad` at `-p 8`; the resulting `quant.sf` is **byte-identical** to the store-producing run (with `--seqBias --gcBias`). This exercises the whole decoupled path and confirms it is thread-count independent.
- `cargo test --workspace`: 166 passing. `cargo fmt --all --check`: clean. `cargo clippy`: no findings in the changed files.

## Scope

This reads salmon's **own** full-fidelity RAD profile (carrying the per-mapping coverage weight and positions, so selective-alignment fidelity is preserved). Consuming **piscem's bulk** RAD profile (reduced, uniform-weight) is the natural next step and is cleanly gated today (a bulk RAD currently produces an explanatory error). The reader will reuse libradicl's `PiscemBulkReadRecord` decoder so the orientation/position decoding stays canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
