### PR TITLE
fix(index): remove empty sshash_tmp directory after index build

### DIFF
--- a/crates/salmon-index/src/lib.rs
+++ b/crates/salmon-index/src/lib.rs
@@ -554,6 +554,15 @@ pub fn build(opts: &IndexBuildOptions) -> Result<IndexInfo> {
     };
     build_index(&config).context("piscem index construction failed")?;
 
+    // sshash-lib's external minimizer sort creates an `sshash_tmp/` directory
+    // (relative to the CWD; the name is hard-coded and not exposed through
+    // piscem-rs's BuildConfig). It removes the temp files it writes there but
+    // never the directory itself, leaving an empty `sshash_tmp/` behind. Prune
+    // it here: `remove_dir` only succeeds on an empty directory, so a
+    // still-in-use one (or a pre-existing non-empty one) is left untouched, and
+    // any error (missing dir, permissions) is intentionally ignored.
+    let _ = std::fs::remove_dir("sshash_tmp");
+
     // Load once to capture reference count and confirm the index is usable.
     let idx = ReferenceIndex::load(&index_prefix, opts.build_ec_table, false)
         .context("loading freshly built index")?;


### PR DESCRIPTION
## Problem

Every large index build leaves an empty `sshash_tmp/` directory behind in the working directory.

`sshash-lib`'s external minimizer sort is taken whenever a build's estimated k-mer count exceeds its 8 GiB RAM budget (in practice, any decoy-aware genome). On that path `ExternalSorter::new` calls `create_dir_all("sshash_tmp")` **relative to the CWD**, writes its `sshash.tmp.run_*.minimizers.*.bin` files there, and on `Drop` removes those temp *files* but never the directory itself. The result is a stray, empty `sshash_tmp/` after the build finishes.

The tmp-dir name is hard-coded in `sshash-lib` and not exposed through `piscem-rs`'s `BuildConfig`, so salmon can't redirect it into `--tmpdir` or the output dir.

## Fix

Prune the empty directory after `build_index` returns. `std::fs::remove_dir` only succeeds on an **empty** directory, so a still-in-use one (concurrent build) or a pre-existing non-empty one is left untouched, and any error (missing dir, permissions) is intentionally ignored.

```rust
let _ = std::fs::remove_dir("sshash_tmp");
```

## Verification

Built the GRCh38 Ensembl r115 gentrome (external-sort path):

```
Using external sorting: estimated 2668998921 k-mers exceeds RAM limit of 8 GiB
Step 2: External sort...
  Sorted 438804053 tuples to disk
index built: 516176 references
```

- `sshash_tmp/` is observed being created during the build, and is gone afterward (`CLEANED — no sshash_tmp leftover`).
- The index builds identically (all `index.*` artifacts present).
- Small in-memory builds (which never create `sshash_tmp/`) are unaffected; existing `salmon-index` tests pass.

## Note / follow-up

This only removes the leftover directory. A cleaner long-term fix is to let the SSHash RAM budget scale to the machine (and/or route the tmp dir into `--tmpdir`), which requires exposing `ram_limit_gib` / the tmp path through `piscem-rs`'s `BuildConfig`. Tracking that separately upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)