### PR TITLE
docs(cli): clarify salmon quant --threads help (auxiliary I/O thread, #993)

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -338,7 +338,9 @@ struct QuantArgs {
     /// gene-level estimates to `quant.genes.sf`.
     #[arg(short = 'g', long = "geneMap", value_name = "FILE")]
     gene_map: Option<PathBuf>,
-    /// Worker threads (0 = all cores).
+    /// Worker threads (0 = all cores). salmon also runs one auxiliary thread for
+    /// FASTQ parsing/decompression, so total CPU use can slightly exceed this
+    /// value; on schedulers that enforce the limit, request one extra core.
     #[arg(short = 'p', long = "threads", default_value_t = 0)]
     threads: usize,
     /// Use the alignment-free pseudoalignment path.


### PR DESCRIPTION
## What

`salmon quant` runs one auxiliary thread for FASTQ parsing/decompression on top of the `-p N` worker threads, so total CPU use slightly exceeds `-p` (e.g. ~1100% in `top` for `-p 10`). This surprised a user on an HPC scheduler that kills jobs exceeding their core allocation (#993).

This reword spells that out in the quant `--threads` help text and points HPC users to request one extra core.

## Change

A single doc-comment on the **quant** `--threads` arg. The `index` `--threads` is left unchanged (it reads a FASTA, not FASTQ, so the auxiliary-parser note doesn't apply there).

After:

```
-p, --threads <THREADS>
    Worker threads (0 = all cores). salmon also runs one auxiliary thread for
    FASTQ parsing/decompression, so total CPU use can slightly exceed this
    value; on schedulers that enforce the limit, request one extra core.
```

Docs-only; no behavior change.

Refs #993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)