### PR TITLE
index: configurable sshash scratch dir (--sshashTmpDir) + memory ceiling (--ramLimit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,9 +2089,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "piscem-rs"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5957c07d66e85df17edf48de4fee15bfe26a76c5a08836704d0513b0794b31d"
+checksum = "7d22949be8fb80f58c9507cca3eb628d83b4db83ff71864de02f0fa9c0046653"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ clap = { version = "4", features = ["derive"] }
 sha2 = "0.10"
 # COMBINE-lab dependencies, from crates.io.
 cf1-rs = "0.5"
-piscem-rs = "0.6.2"
+piscem-rs = "0.6.4"
 # RAD-format I/O (chunk compression + backpatchable file tags); the `zstd`
 # feature enables zstd-compressed RAD chunks (lz4 is always available).
 libradicl = { version = "0.14.2", features = ["zstd"] }

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -255,6 +255,17 @@ struct IndexArgs {
     /// index still lands in --index. Defaults to the index dir. (salmon's --tmpdir)
     #[arg(long = "tmpdir")]
     tmpdir: Option<PathBuf>,
+    /// Directory for sshash's external minimizer-sort scratch. Defaults to a
+    /// `sshash_tmp` subdirectory of --tmpdir (or the index dir when --tmpdir is
+    /// unset). Override to place the sort scratch on a separate/fast disk; the
+    /// directory is created before the build and removed afterwards.
+    #[arg(long = "sshashTmpDir")]
+    sshash_tmp_dir: Option<PathBuf>,
+    /// RAM ceiling, in GiB, for sshash's external minimizer sort (the main
+    /// build-time memory/disk trade-off). Default is 8; a smaller value uses
+    /// less RAM but spills to disk sooner.
+    #[arg(long = "ramLimit")]
+    ram_limit_gib: Option<usize>,
     /// Retain exact-duplicate transcript sequences instead of collapsing them
     /// (salmon collapses duplicates by default).
     #[arg(long = "keepDuplicates")]
@@ -696,6 +707,8 @@ fn run_index(args: IndexArgs) -> Result<()> {
     opts.keep_intermediate = args.keep_intermediate;
     opts.keep_fixed_fasta = args.keep_fixed_fasta;
     opts.tmpdir = args.tmpdir;
+    opts.sshash_tmp = args.sshash_tmp_dir;
+    opts.ram_limit_gib = args.ram_limit_gib;
     opts.keep_duplicates = args.keep_duplicates;
     opts.decoys = args.decoys;
     opts.gencode = args.gencode;

--- a/crates/salmon-index/src/lib.rs
+++ b/crates/salmon-index/src/lib.rs
@@ -123,6 +123,18 @@ pub struct IndexBuildOptions {
     /// its trailing `A`s trimmed; an all-`A` reference is dropped from the index.
     /// Reference hashes are computed pre-clip, so this does not change provenance.
     pub clip_polya: bool,
+    /// Directory for sshash's external minimizer-sort scratch. `None` defaults to
+    /// a `sshash_tmp` subdirectory of the build-intermediate dir (i.e. `--tmpdir`
+    /// when set, else the output dir); `Some(dir)` overrides it, e.g. to place the
+    /// sort scratch on a separate/fast disk. Salmon creates the directory before
+    /// the build and removes it afterwards unless `keep_intermediate` is set.
+    /// (Without this, sshash writes to `sshash_tmp` relative to the current
+    /// working directory and leaves the empty directory behind.)
+    pub sshash_tmp: Option<PathBuf>,
+    /// RAM ceiling, in GiB, for sshash's external minimizer sort (the dominant
+    /// build-time memory/disk trade-off). `None` keeps sshash's default (8 GiB);
+    /// a smaller value spills to disk sooner (less RAM, more I/O).
+    pub ram_limit_gib: Option<usize>,
 }
 
 impl IndexBuildOptions {
@@ -144,6 +156,8 @@ impl IndexBuildOptions {
             decoys: None,
             gencode: false,
             clip_polya: true,
+            sshash_tmp: None,
+            ram_limit_gib: None,
         }
     }
 }
@@ -683,6 +697,20 @@ pub fn build(opts: &IndexBuildOptions) -> Result<IndexInfo> {
         );
     }
 
+    // sshash sorts its minimizer tuples through an on-disk scratch directory.
+    // Left to its default it writes to `sshash_tmp` relative to the *current
+    // working directory* and leaves the (emptied) directory behind. Anchor it
+    // under our build-intermediate dir instead (a `sshash_tmp` subdir of
+    // `--tmpdir`, or the output dir when unset), or wherever the caller asked,
+    // so the scratch is co-located with the other intermediates and we can
+    // remove it cleanly afterwards.
+    let sshash_tmp = opts
+        .sshash_tmp
+        .clone()
+        .unwrap_or_else(|| intermediate_dir.join("sshash_tmp"));
+    std::fs::create_dir_all(&sshash_tmp)
+        .with_context(|| format!("creating sshash scratch dir {}", sshash_tmp.display()))?;
+
     // Stage 2: piscem SSHash + contig-table index over the tiling.
     info!("building piscem index (m={})", m);
     let config = BuildConfig {
@@ -696,6 +724,8 @@ pub fn build(opts: &IndexBuildOptions) -> Result<IndexInfo> {
         seed: 1,
         single_mphf: false,
         emit_tiny: None,
+        tmp_dir: Some(sshash_tmp.clone()),
+        ram_limit_gib: opts.ram_limit_gib,
     };
     build_index(&config).context("piscem index construction failed")?;
 
@@ -787,6 +817,10 @@ pub fn build(opts: &IndexBuildOptions) -> Result<IndexInfo> {
         if !opts.keep_fixed_fasta {
             let _ = std::fs::remove_file(&cleaned);
         }
+        // sshash removes its own scratch files but leaves the directory. Prune
+        // it: `remove_dir` only succeeds on an empty directory, so a caller-
+        // supplied override that is shared / pre-populated is left untouched.
+        let _ = std::fs::remove_dir(&sshash_tmp);
     }
 
     info!("index built: {} references", info.num_refs);
@@ -1138,6 +1172,12 @@ mod tests {
         // info.json persisted and the cDBG intermediates were cleaned up.
         assert!(out.join("info.json").exists());
         assert!(!out.join("cdbg.cf_seg").exists());
+        // sshash's scratch defaults under the output dir and is pruned after the
+        // build (no stray `sshash_tmp` left behind — the bug #1045 addressed).
+        assert!(
+            !out.join("sshash_tmp").exists(),
+            "sshash scratch dir should be pruned after a default build"
+        );
 
         let idx = SalmonIndex::load(&out).expect("index load");
         assert_eq!(idx.k(), 31);
@@ -1156,6 +1196,39 @@ mod tests {
             );
             assert!(seq.iter().all(|b| matches!(b, b'A' | b'C' | b'G' | b'T')));
         }
+    }
+
+    /// The sshash scratch dir honors an explicit override and the
+    /// `keep_intermediate` flag: with `keep_intermediate` it survives at the
+    /// overridden location; without it, it is pruned. In neither case does a
+    /// `sshash_tmp` appear relative to the current working directory.
+    #[test]
+    fn sshash_scratch_override_and_keep() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fasta = write_fasta(tmp.path());
+        let scratch = tmp.path().join("fastdisk").join("scratch");
+
+        // keep_intermediate => the overridden scratch dir is retained.
+        let mut opts = IndexBuildOptions::new(vec![fasta.clone()], tmp.path().join("idx_keep"));
+        opts.threads = 1;
+        opts.sshash_tmp = Some(scratch.clone());
+        opts.keep_intermediate = true;
+        build(&opts).expect("index build (keep)");
+        assert!(
+            scratch.is_dir(),
+            "overridden scratch dir should be kept with keep_intermediate"
+        );
+
+        // default (no keep) => the same overridden dir is pruned afterwards.
+        let scratch2 = tmp.path().join("fastdisk2").join("scratch");
+        let mut opts = IndexBuildOptions::new(vec![fasta], tmp.path().join("idx_prune"));
+        opts.threads = 1;
+        opts.sshash_tmp = Some(scratch2.clone());
+        build(&opts).expect("index build (prune)");
+        assert!(
+            !scratch2.exists(),
+            "overridden scratch dir should be pruned without keep_intermediate"
+        );
     }
 
     /// Build ONE index that simultaneously exercises every short/decoy edge case


### PR DESCRIPTION
## Summary

A cohesive replacement for #1045. sshash's external minimizer sort wrote its
scratch to a `sshash_tmp` directory **relative to the current working
directory** and, after removing its temp *files*, left the emptied directory
behind. #1045 pruned that stray directory; this PR instead gives the caller
control over *where* the scratch lives (and how much RAM the sort may use), so
the leftover can't happen in the first place.

The two knobs already existed in `sshash-lib`'s `BuildConfiguration`
(`tmp_dirname`, `ram_limit_gib`) — they were just hard-coded at the piscem-rs
layer. This is pure plumbing across the stack:

- **piscem-rs** (published as **0.6.4**): `BuildConfig` gains `tmp_dir:
  Option<PathBuf>` and `ram_limit_gib: Option<usize>` (`None` = keep sshash's
  defaults), plus matching flags on its own `build` CLI. Salmon's dep is bumped
  `0.6.2 → 0.6.4` here.
- **salmon**: the sshash scratch now defaults to a `sshash_tmp` subdirectory of
  the build-intermediate dir — i.e. `--tmpdir` when set, else the index output
  dir — so it's co-located with the other intermediates and pruned afterwards.
  Cleanup uses **empty-only `remove_dir`**, so a caller-supplied override that is
  shared or pre-populated is never deleted, and it is retained under
  `--keepIntermediate`.

## New CLI flags (`salmon index`)

- `--sshashTmpDir <dir>` — override the sort-scratch location (e.g. a fast local
  disk), independent of `--tmpdir`.
- `--ramLimit <GiB>` — cap the external minimizer sort's memory (spills to disk
  sooner; default 8).

## Validation

- 5-case CLI matrix (default / `--tmpdir` / `--sshashTmpDir` / `--ramLimit` /
  `--keepIntermediate`): no stray `sshash_tmp` in the CWD, correct placement and
  cleanup in each; `RUST_LOG=debug` confirmed sshash receives the configured
  `tmp_dirname` and `ram_limit_gib`.
- 2 new `salmon-index` unit tests (override + keep/prune; default-build prune
  assertion added to the roundtrip test).
- Full workspace test suite green against the **published** piscem-rs 0.6.4;
  `cargo fmt` + `clippy -D warnings` clean.

Supersedes #1045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7JMur5DmDpECddErpi2JS