### PR TITLE
bias: abundance-free within-transcript GC-bias estimator (opt-in --gcBiasMethod within-txp) [post-2.3.2]

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -418,6 +418,11 @@ struct QuantArgs {
     /// Enable fragment-GC bias correction.
     #[arg(long = "gcBias")]
     gc_bias: bool,
+    /// GC-bias estimation method (reads mode): `obs-exp` (default,
+    /// cross-transcript observed/expected) or `within-txp` (abundance-free
+    /// within-transcript shape). Only used with `--gcBias`.
+    #[arg(long = "gcBiasMethod", default_value = "obs-exp")]
+    gc_bias_method: String,
     /// Enable positional bias correction.
     #[arg(long = "posBias")]
     pos_bias: bool,
@@ -1350,6 +1355,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.write_rad = args.write_rad;
     opts.seq_bias = args.seq_bias;
     opts.gc_bias = args.gc_bias;
+    opts.within_txp_gc_bias = args.gc_bias_method.eq_ignore_ascii_case("within-txp");
     opts.pos_bias = args.pos_bias;
     opts.bias_seed_em_iters = args.bias_seed_em_iters;
     opts.dump_bias_models = args.dump_bias_models;

--- a/crates/salmon-model/src/gcbias.rs
+++ b/crates/salmon-model/src/gcbias.rs
@@ -117,6 +117,33 @@ impl GcFragModel {
         self.counts[self.idx(ctx_frac, gc_frac)]
     }
 
+    /// Overwrite this (ratio) model with a marginal GC curve broadcast across all
+    /// conditioning bins. `curve` must have `gc_bins` entries. Marks the model
+    /// normalized (ratio models are consumed directly). Used to install an
+    /// abundance-free within-transcript bias curve as the GC ratio model.
+    pub fn set_marginal_ratio(&mut self, curve: &[f64]) {
+        assert_eq!(curve.len(), self.gc_bins, "curve must have gc_bins entries");
+        for ctx in 0..self.cond_bins {
+            for gc in 0..self.gc_bins {
+                self.counts[ctx * self.gc_bins + gc] = curve[gc];
+            }
+        }
+        self.normalized = true;
+    }
+
+    /// The marginal GC distribution (summed over conditioning bins), length
+    /// `gc_bins`. Reads the materialized `counts` (call after `normalize`, or on a
+    /// model built by [`transcript_gc_geometry`]).
+    pub fn marginal_gc(&self) -> Vec<f64> {
+        let mut m = vec![0.0; self.gc_bins];
+        for ctx in 0..self.cond_bins {
+            for gc in 0..self.gc_bins {
+                m[gc] += self.counts[ctx * self.gc_bins + gc];
+            }
+        }
+        m
+    }
+
     /// Merge another (compatible) model's counts. Both must be pre-normalization.
     pub fn combine_counts(&mut self, other: &GcFragModel) {
         debug_assert!(!self.normalized && !other.normalized);
@@ -175,6 +202,168 @@ pub fn gc_ratio(
     }
     out.normalized = true; // a ratio model is used directly, not re-normalized
     out
+}
+
+/// The unweighted per-transcript *possible-fragment* GC marginal — salmon's
+/// geometry-aware background for ONE transcript: the same inner computation as
+/// [`build_expected_gc`]'s per-transcript term, but WITHOUT the `alpha/effLen`
+/// abundance weighting. This is the denominator `B_t` of the abundance-free
+/// within-transcript bias estimator. Using salmon's own fragment geometry (not
+/// naive sliding windows) is what makes the recovered shape flat on bias-free
+/// data. Returns a length-`gc_bins` vector (unnormalized fragment mass per GC
+/// bin), or `None` if the transcript is too short / carries negligible FLD mass.
+pub fn transcript_gc_geometry(
+    view: &GcView,
+    ref_len: usize,
+    cdf: &[f64],
+    fld_low: usize,
+    fld_high: usize,
+    gc_bins: usize,
+    k: usize,
+    stride: usize,
+) -> Option<Vec<f64>> {
+    if ref_len <= k {
+        return None;
+    }
+    let cdf_max_arg = (cdf.len() - 1).min(ref_len);
+    let cdf_max_val = cdf[cdf_max_arg];
+    if cdf_max_val < MIN_CDF_MASS {
+        return None;
+    }
+    let ctx = GcContext::build(view);
+    let cond = |x: i32| conditional_cdf(cdf, cdf_max_arg, cdf_max_val, x);
+    let sp = if fld_low > 0 { fld_low as i32 - 1 } else { 0 };
+    let stride = stride.max(1) as i32;
+    let mut marg = vec![0.0f64; gc_bins];
+    for frag_start in 0..(ref_len - k) {
+        let mut prev = cond(sp);
+        let mut fl = fld_low as i32;
+        while fl <= fld_high as i32 {
+            let frag_end = frag_start as i32 + fl - 1;
+            if (frag_end as usize) < ref_len {
+                if let Some((ff, _cf)) = ctx.desc(frag_start as i32, frag_end) {
+                    marg[bin_frac(ff, gc_bins)] += cond(fl) - prev;
+                }
+                prev = cond(fl);
+            } else {
+                break;
+            }
+            fl += stride;
+        }
+    }
+    Some(marg)
+}
+
+/// Estimate the abundance-free GC-bias SHAPE from within-transcript variation:
+/// each transcript is its own abundance control. Given per-covered-transcript
+/// observed GC counts `obs` and possible-fragment GC marginals `poss` (both
+/// length `gc_bins`, parallel slices), solve the two-way fixed-effects model
+///
+/// ```text
+/// log( obs_frac_t(g) / poss_frac_t(g) ) = logb(g) + offset_t + noise
+/// ```
+///
+/// by alternating means (Gauss–Seidel); the per-transcript `offset_t` absorbs
+/// that transcript's abundance and normalization, leaving `logb(g)` — the
+/// abundance-free bias shape. Returns the RATIO curve `exp(logb)`, normalized to
+/// mean 1, with GC bins the panel never probes set to the nearest sampled edge
+/// (neutral tails, no cliffs). `min_support` is the minimum transcript count a
+/// bin needs to be trusted (else edge-filled).
+pub fn estimate_within_txp_gc_curve(
+    obs: &[Vec<f64>],
+    poss: &[Vec<f64>],
+    gc_bins: usize,
+    min_support: usize,
+) -> Vec<f64> {
+    assert_eq!(obs.len(), poss.len());
+    // Sparse (transcript, bin, log-ratio) entries over the GC bins each
+    // transcript actually probes (`poss` has support there).
+    let (mut ti, mut bi, mut rv) = (Vec::new(), Vec::new(), Vec::new());
+    let mut nt = 0usize;
+    for (o, p) in obs.iter().zip(poss.iter()) {
+        let nobs: f64 = o.iter().sum();
+        let npos: f64 = p.iter().sum();
+        if nobs <= 0.0 || npos <= 0.0 {
+            continue;
+        }
+        let mut any = false;
+        for g in 0..gc_bins {
+            let bfrac = p[g] / npos;
+            if bfrac <= 0.004 {
+                continue;
+            }
+            let ofrac = (o[g] + 0.5) / (nobs + 0.5 * gc_bins as f64);
+            ti.push(nt as u32);
+            bi.push(g as u32);
+            rv.push(ofrac.ln() - bfrac.ln());
+            any = true;
+        }
+        if any {
+            nt += 1;
+        }
+    }
+    let mut logb = vec![0.0f64; gc_bins];
+    let mut off = vec![0.0f64; nt];
+    let mut cnt_bin = vec![0.0f64; gc_bins];
+    let mut cnt_t = vec![0.0f64; nt];
+    for &b in &bi {
+        cnt_bin[b as usize] += 1.0;
+    }
+    for &t in &ti {
+        cnt_t[t as usize] += 1.0;
+    }
+    for _ in 0..300 {
+        let mut num_b = vec![0.0f64; gc_bins];
+        for e in 0..rv.len() {
+            num_b[bi[e] as usize] += rv[e] - off[ti[e] as usize];
+        }
+        let mut max_d = 0.0f64;
+        for g in 0..gc_bins {
+            if cnt_bin[g] > 0.0 {
+                let nb = num_b[g] / cnt_bin[g];
+                max_d = max_d.max((nb - logb[g]).abs());
+                logb[g] = nb;
+            }
+        }
+        let mut num_t = vec![0.0f64; nt];
+        for e in 0..rv.len() {
+            num_t[ti[e] as usize] += rv[e] - logb[bi[e] as usize];
+        }
+        for t in 0..nt {
+            if cnt_t[t] > 0.0 {
+                off[t] = num_t[t] / cnt_t[t];
+            }
+        }
+        if max_d < 1e-7 {
+            break;
+        }
+    }
+    let sampled: Vec<usize> = (0..gc_bins)
+        .filter(|&g| cnt_bin[g] >= min_support as f64)
+        .collect();
+    if sampled.is_empty() {
+        return vec![1.0; gc_bins];
+    }
+    let mean: f64 = sampled.iter().map(|&g| logb[g]).sum::<f64>() / sampled.len() as f64;
+    let mut curve = vec![1.0f64; gc_bins];
+    for &g in &sampled {
+        curve[g] = (logb[g] - mean).exp();
+    }
+    let (lo, hi) = (sampled[0], *sampled.last().unwrap());
+    let (lo_val, hi_val) = (curve[lo], curve[hi]);
+    for c in curve.iter_mut().take(lo) {
+        *c = lo_val;
+    }
+    for c in curve.iter_mut().take(gc_bins).skip(hi + 1) {
+        *c = hi_val;
+    }
+    let m: f64 = curve.iter().sum::<f64>() / gc_bins as f64;
+    if m > 0.0 {
+        for c in curve.iter_mut() {
+            *c /= m;
+        }
+    }
+    curve
 }
 
 // ===========================================================================
@@ -705,6 +894,59 @@ mod tests {
         assert_eq!(bin_frac(0, 101), 0);
         assert_eq!(bin_frac(57, 101), 57);
         assert_eq!(bin_frac(100, 101), 100);
+    }
+
+    #[test]
+    fn within_txp_recovers_monotonic_bias_abundance_free() {
+        // Synthetic panel: a monotonic GC bias b(g)=exp(0.2*(g-10)); each
+        // transcript probes a narrow overlapping GC window (its own abundance
+        // control) with a WILDLY different abundance scale. The estimator must
+        // recover the bias SHAPE despite the abundance variation (that is the
+        // whole point of the per-transcript offset).
+        let nb = 20usize;
+        let true_b: Vec<f64> = (0..nb).map(|g| (0.2 * (g as f64 - 10.0)).exp()).collect();
+        let mut obs = Vec::new();
+        let mut poss = Vec::new();
+        // transcripts centered across the range; 5-bin windows overlap to chain.
+        for c in 2..18 {
+            for rep in 0..4 {
+                // abundance scale spans 4 orders of magnitude across transcripts
+                let scale = 10f64.powi((c as i32 % 5) - 2) * (1.0 + rep as f64);
+                let mut p = vec![0.0; nb];
+                let mut o = vec![0.0; nb];
+                for g in c - 2..=c + 2 {
+                    p[g] = 100.0; // flat possible distribution over the window
+                    o[g] = 100.0 * true_b[g] * scale;
+                }
+                poss.push(p);
+                obs.push(o);
+            }
+        }
+        let curve = estimate_within_txp_gc_curve(&obs, &poss, nb, 3);
+        // recovered curve should be monotonically increasing over the sampled
+        // interior and match the true shape (ratio of endpoints) closely.
+        for g in 3..16 {
+            assert!(
+                curve[g + 1] >= curve[g] - 1e-9,
+                "not monotonic at {g}: {} -> {}",
+                curve[g],
+                curve[g + 1]
+            );
+        }
+        // Over the well-covered interior [5,15] the recovered shape should match
+        // the true bias tightly (the extreme edge bins saturate, as expected of a
+        // within-transcript estimator — less internal variation there).
+        let (lo, hi) = (5usize, 15usize);
+        let tmean: f64 = (lo..=hi).map(|g| true_b[g]).sum::<f64>() / (hi - lo + 1) as f64;
+        let cmean: f64 = (lo..=hi).map(|g| curve[g]).sum::<f64>() / (hi - lo + 1) as f64;
+        for g in lo..=hi {
+            let t = true_b[g] / tmean;
+            let c = curve[g] / cmean;
+            assert!(
+                (t - c).abs() / t < 0.10,
+                "bin {g}: recovered {c:.3} vs true {t:.3}"
+            );
+        }
     }
 
     #[test]

--- a/crates/salmon-model/src/lib.rs
+++ b/crates/salmon-model/src/lib.rs
@@ -39,8 +39,9 @@ pub use fld::{
     ambig_frag_log_prob, smoothed_effective_length, DiscreteFld, FragmentLengthDistribution,
 };
 pub use gcbias::{
-    build_expected_gc, gc_corrected_effective_length, gc_desc, gc_prefix, gc_ratio, GcFragModel,
-    GcRank, GcStore, GcView, GC_SAMP_STRIDE,
+    build_expected_gc, estimate_within_txp_gc_curve, gc_corrected_effective_length, gc_desc,
+    gc_prefix, gc_ratio, transcript_gc_geometry, GcFragModel, GcRank, GcStore, GcView,
+    GC_SAMP_STRIDE,
 };
 pub use libdetect::{infer_format_from_counts, LibraryTypeDetector};
 pub use posbias::{

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -151,6 +151,10 @@ pub struct QuantOptions {
     /// number of conditioning (context) bins in the GC bias model (salmon's
     /// `--conditionalGCBins`, default 3)
     pub cond_gc_bins: usize,
+    /// use the abundance-free within-transcript GC-bias estimator instead of the
+    /// default cross-transcript observed/expected ratio (`--gcBiasMethod
+    /// within-txp`). Only meaningful with `--gcBias`.
+    pub within_txp_gc_bias: bool,
     /// skip the abundance estimation (EM + Gibbs/bootstrap) and `quant.sf`,
     /// emitting only equivalence classes, library type, and metadata
     /// (salmon's `--skipQuant`)
@@ -211,6 +215,7 @@ impl QuantOptions {
             no_bias_length_threshold: false,
             gc_bins: salmon_model::gcbias::DEFAULT_GC_BINS,
             cond_gc_bins: salmon_model::gcbias::DEFAULT_COND_BINS,
+            within_txp_gc_bias: false,
             skip_quant: false,
             num_pre_aux_model_samples: processor::NUM_PRE_BURNIN,
             progress: None,
@@ -455,6 +460,11 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             opts.gc_bins,
         ))
     });
+    // Per-transcript observed fragment-GC accumulator for the within-transcript
+    // GC-bias estimator (`--gcBiasMethod within-txp`); only when GC-correcting.
+    let collect_within_txp = opts.gc_bias && opts.within_txp_gc_bias;
+    let within_txp_obs = collect_within_txp
+        .then(|| std::sync::Mutex::new(std::collections::HashMap::<u32, Vec<u32>>::new()));
 
     // For `--posBias`: transcript length-class quantiles + per-transcript class,
     // and the shared observed (5', 3') positional-bias models per length class.
@@ -519,6 +529,8 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             gc_bins: opts.gc_bins,
             gc_store,
             gcbias_obs: gcbias_obs.as_ref(),
+            collect_within_txp,
+            within_txp_obs: within_txp_obs.as_ref(),
             collect_posbias: opts.pos_bias,
             length_class: length_class.as_deref(),
             posbias_obs: posbias_obs.as_ref(),
@@ -761,31 +773,84 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         let store = gc_store;
         let gc_ratio_model = if let Some(m) = gcbias_obs {
             let mut obs = m.into_inner().unwrap();
-            let mut exp = salmon_model::build_expected_gc(
-                num_targets,
-                |t| salmon.ref_seq(t as u32),
-                |t| store.unwrap().view(t),
-                &em.alphas,
-                &eff_lengths,
-                &fld_cdf,
-                fld_low,
-                fld_high,
-                opts.cond_gc_bins,
-                opts.gc_bins,
-                k,
-                opts.bias_speed_samp,
-            );
-            // Capture the (normalized) observed/expected GC tables for the dumps
-            // before gc_ratio consumes them (normalize is idempotent).
-            obs.normalize();
-            exp.normalize();
-            bias_dump.obs_gc = obs.dump().to_vec();
-            bias_dump.exp_gc = exp.dump().to_vec();
-            Some(salmon_model::gc_ratio(
-                &mut obs,
-                &mut exp,
-                salmon_model::gcbias::GC_MAX_RATIO,
-            ))
+            if let Some(wt) = within_txp_obs {
+                // WITHIN-TRANSCRIPT estimator: abundance-free GC-bias shape from
+                // per-transcript observed (O_t) vs salmon's own geometry-aware
+                // possible-fragment (B_t) marginals, over well-covered transcripts.
+                // No abundance weighting (that is the whole point) → the expected
+                // model / seed abundances are not used for GC here.
+                const MIN_TXP_FRAGS: u32 = 80; // per-transcript coverage floor
+                const MIN_BIN_SUPPORT: usize = 30; // transcripts probing a GC bin
+                let obs_pt = wt.into_inner().unwrap();
+                let covered: Vec<(u32, Vec<f64>)> = obs_pt
+                    .into_iter()
+                    .filter(|(_, c)| c.iter().sum::<u32>() >= MIN_TXP_FRAGS)
+                    .map(|(tid, c)| (tid, c.iter().map(|&x| x as f64).collect()))
+                    .collect();
+                let poss: Vec<Option<Vec<f64>>> = covered
+                    .par_iter()
+                    .map(|(tid, _)| {
+                        let view = store.unwrap().view(*tid as usize);
+                        let ref_len = view.ref_len();
+                        salmon_model::transcript_gc_geometry(
+                            &view,
+                            ref_len,
+                            &fld_cdf,
+                            fld_low,
+                            fld_high,
+                            opts.gc_bins,
+                            k,
+                            opts.bias_speed_samp,
+                        )
+                    })
+                    .collect();
+                let (obs_marg, poss_marg): (Vec<_>, Vec<_>) = covered
+                    .into_iter()
+                    .zip(poss)
+                    .filter_map(|((_, o), p)| p.map(|pp| (o, pp)))
+                    .unzip();
+                tracing::info!(
+                    "GC bias: within-transcript estimator over {} well-covered transcripts",
+                    obs_marg.len()
+                );
+                let curve = salmon_model::estimate_within_txp_gc_curve(
+                    &obs_marg,
+                    &poss_marg,
+                    opts.gc_bins,
+                    MIN_BIN_SUPPORT,
+                );
+                obs.normalize();
+                bias_dump.obs_gc = obs.dump().to_vec();
+                let mut ratio = salmon_model::GcFragModel::new(opts.cond_gc_bins, opts.gc_bins);
+                ratio.set_marginal_ratio(&curve);
+                Some(ratio)
+            } else {
+                let mut exp = salmon_model::build_expected_gc(
+                    num_targets,
+                    |t| salmon.ref_seq(t as u32),
+                    |t| store.unwrap().view(t),
+                    &em.alphas,
+                    &eff_lengths,
+                    &fld_cdf,
+                    fld_low,
+                    fld_high,
+                    opts.cond_gc_bins,
+                    opts.gc_bins,
+                    k,
+                    opts.bias_speed_samp,
+                );
+                // Capture the (normalized) observed/expected GC tables for the dumps
+                // before gc_ratio consumes them (normalize is idempotent).
+                obs.normalize();
+                exp.normalize();
+                bias_dump.obs_gc = obs.dump().to_vec();
+                bias_dump.exp_gc = exp.dump().to_vec();
+                Some(salmon_model::gc_ratio(
+                    &mut obs,
+                    &mut exp,
+                    salmon_model::gcbias::GC_MAX_RATIO,
+                ))
+            }
         } else {
             None
         };

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -377,6 +377,12 @@ fn collect_gc(sh: &Shared, compat: &[(&ScoredMapping, f64)], bias_w: &[f64], gc:
 /// placement, keyed by transcript, on the same `gc_bins` grid as
 /// `transcript_gc_geometry`'s `B_t`. Unweighted integer counts → the per-thread
 /// maps merge order-independently (deterministic).
+///
+/// Uses ALL compatible proper-pair placements (not unique-only): on an
+/// isoform-rich transcriptome, restricting to uniquely-mapped fragments both
+/// starves coverage and selects a GC-skewed subset (the paralog-free transcripts)
+/// — empirically WORSE on accuracy and bias-free safety than keeping all
+/// placements (the multi-mapping smear averages out across the panel).
 fn collect_within_txp_gc(
     sh: &Shared,
     compat: &[(&ScoredMapping, f64)],

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -75,6 +75,12 @@ pub(crate) struct Shared<'a> {
     pub gc_store: Option<salmon_model::GcStore<'a>>,
     /// shared observed fragment-GC model to merge per-thread results into
     pub gcbias_obs: Option<&'a Mutex<GcFragModel>>,
+    /// collect per-transcript observed fragment-GC for the within-transcript
+    /// bias estimator (`--gcBiasMethod within-txp`)
+    pub collect_within_txp: bool,
+    /// shared per-transcript observed GC-bin counts (`tid -> [gc_bins]`) to merge
+    /// per-thread maps into (summed → order-independent)
+    pub within_txp_obs: Option<&'a Mutex<std::collections::HashMap<u32, Vec<u32>>>>,
     /// collect observed positional bias (`--posBias`)
     pub collect_posbias: bool,
     /// per-transcript length-class index (for positional bias), when pos-correcting
@@ -151,6 +157,9 @@ pub(crate) struct QuantProcessor<'a> {
     pub seqbias: Option<(SBModel, SBModel)>,
     /// per-thread observed fragment-GC model (when collecting)
     pub gcbias: Option<GcFragModel>,
+    /// per-thread per-transcript observed GC-bin counts (`tid -> [gc_bins]`) for
+    /// the within-transcript bias estimator (`--gcBiasMethod within-txp`)
+    pub within_txp_gc: Option<std::collections::HashMap<u32, Vec<u32>>>,
     /// per-thread observed (5', 3') positional-bias models, per length class
     pub posbias: Option<(Vec<SimplePosBias>, Vec<SimplePosBias>)>,
     /// per-thread collected unmapped-fragment names (merged in on_thread_complete)
@@ -170,6 +179,9 @@ impl<'a> QuantProcessor<'a> {
         let gcbias = shared
             .collect_gcbias
             .then(|| GcFragModel::new(shared.cond_gc_bins, shared.gc_bins));
+        let within_txp_gc = shared
+            .collect_within_txp
+            .then(std::collections::HashMap::new);
         let posbias = shared.collect_posbias.then(|| {
             (
                 (0..NUM_LENGTH_CLASSES)
@@ -186,6 +198,7 @@ impl<'a> QuantProcessor<'a> {
             sketch_scratch: None,
             seqbias,
             gcbias,
+            within_txp_gc,
             posbias,
             unmapped: Vec::new(),
             sam_buf: String::new(),
@@ -359,6 +372,34 @@ fn collect_gc(sh: &Shared, compat: &[(&ScoredMapping, f64)], bias_w: &[f64], gc:
     }
 }
 
+/// Accumulate per-transcript observed fragment-GC bin counts for the
+/// within-transcript bias estimator: one unit count per compatible proper-pair
+/// placement, keyed by transcript, on the same `gc_bins` grid as
+/// `transcript_gc_geometry`'s `B_t`. Unweighted integer counts → the per-thread
+/// maps merge order-independently (deterministic).
+fn collect_within_txp_gc(
+    sh: &Shared,
+    compat: &[(&ScoredMapping, f64)],
+    map: &mut std::collections::HashMap<u32, Vec<u32>>,
+) {
+    let Some(store) = sh.gc_store else { return };
+    for (m, _) in compat.iter() {
+        if m.status != MateStatus::PairedEndPaired || m.fragment_len <= 0 {
+            continue;
+        }
+        let start = m.ref_pos;
+        let stop = m.ref_pos + m.fragment_len - 1;
+        let view = store.view(m.tid as usize);
+        if start < 0 || stop >= view.ref_len() as i32 {
+            continue;
+        }
+        if let Some((ff, _cf)) = gc_desc(&view, start, stop) {
+            let bin = salmon_model::gcbias::bin_frac(ff, sh.gc_bins);
+            map.entry(m.tid).or_insert_with(|| vec![0u32; sh.gc_bins])[bin] += 1;
+        }
+    }
+}
+
 /// Collect observed positional-bias mass for one fragment's compatible mappings,
 /// each weighted by `bias_w[i]` (log space). Mirrors salmon's
 /// `observedPosBias{Fwd,RC}[lengthClass].addMass(pos, refLen, logProb)`.
@@ -464,6 +505,7 @@ fn record(
     log_fm: f64,
     seqbias: Option<&mut (SBModel, SBModel)>,
     gcbias: Option<&mut GcFragModel>,
+    within_txp_gc: Option<&mut std::collections::HashMap<u32, Vec<u32>>>,
     posbias: Option<&mut (Vec<SimplePosBias>, Vec<SimplePosBias>)>,
 ) {
     sh.num_processed.fetch_add(1, Ordering::Relaxed);
@@ -623,6 +665,9 @@ fn record(
         }
         if let Some(gc) = gcbias {
             collect_gc(sh, &compat, &bias_w, gc);
+        }
+        if let Some(map) = within_txp_gc {
+            collect_within_txp_gc(sh, &compat, map);
         }
         if let Some(pos) = posbias {
             collect_pos(sh, &compat, &bias_w, pos);
@@ -817,6 +862,17 @@ fn merge_bias(proc: &QuantProcessor) {
         let mut g = shared_mtx.lock().unwrap();
         g.combine_counts(local);
     }
+    if let (Some(local), Some(shared_mtx)) =
+        (proc.within_txp_gc.as_ref(), proc.shared.within_txp_obs)
+    {
+        let mut g = shared_mtx.lock().unwrap();
+        for (tid, counts) in local {
+            let e = g.entry(*tid).or_insert_with(|| vec![0u32; counts.len()]);
+            for (a, b) in e.iter_mut().zip(counts) {
+                *a += *b;
+            }
+        }
+    }
     if let (Some(local), Some(shared_mtx)) = (proc.posbias.as_ref(), proc.shared.posbias_obs) {
         let mut g = shared_mtx.lock().unwrap();
         for (a, b) in g.0.iter_mut().zip(&local.0) {
@@ -839,6 +895,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             sketch_scratch,
             seqbias,
             gcbias,
+            within_txp_gc,
             posbias,
             unmapped,
             sam_buf,
@@ -940,6 +997,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     log_fm,
                     seqbias.as_mut(),
                     gcbias.as_mut(),
+                    within_txp_gc.as_mut(),
                     posbias.as_mut(),
                 );
             }
@@ -977,6 +1035,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             sketch_scratch,
             seqbias,
             gcbias,
+            within_txp_gc,
             posbias,
             unmapped,
             sam_buf,
@@ -1050,6 +1109,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     log_fm,
                     seqbias.as_mut(),
                     gcbias.as_mut(),
+                    within_txp_gc.as_mut(),
                     posbias.as_mut(),
                 );
             }


### PR DESCRIPTION
> **Draft — do not land before 2.3.2.** Independent of the 2.3.2 content; rebases cleanly on current master (verified: no conflicts with #1044/#1048; only shared files `salmon-quant/lib.rs` and `salmon-cli/main.rs` auto-merge in disjoint regions).

## Summary

Adds an **opt-in**, abundance-free estimator for fragment **GC-bias shape**, selectable with `--gcBiasMethod within-txp` (default remains `obs-exp`, byte-for-byte unchanged).

The default GC model builds its *expected* distribution from the converged (biased) abundances, so it tends to **under-correct**. This estimator sidesteps abundance entirely: each transcript is its own control. For every transcript it compares observed fragment-GC (`O_t`) against a geometry-aware *possible-fragment* GC marginal (`B_t`), and solves a sparse two-way fixed-effects model `log(O_t/B_t)(g) = logb(g) + offset_t` where the per-transcript `offset_t` absorbs abundance. The recovered `b(g)` is the bias curve.

## What's here

- `salmon-model/src/gcbias.rs`: estimator core (`transcript_gc_geometry` for `B_t`, `estimate_within_txp_gc_curve` for the fixed-effects solve) + unit test recovering a known monotonic bias despite 4-orders-of-magnitude per-transcript abundance variation.
- `salmon-quant`: opt-in collection pass (`collect_within_txp_gc`) + wiring in the reads quant driver; default path untouched.
- `salmon-cli`: `--gcBiasMethod {obs-exp|within-txp}`.

## Validation

- **In-salmon accuracy** (poly-GC sim): err-vs-GC **0.295** vs default **0.693**; unbiased-safety −0.032 (geometry-aware `B_t` ~halved the external prototype's residual).
- **GEUVADIS across-center DE** (12 individuals × 2 labs, 24 samples, proper DESeq2 median-of-ratios normalization on NumReads/EffLen): within-txp drives the GC-shift systematic to ~0 (vs default's residual +0.064) and edges default on aggregate false-positive count. GC bias is real (Alpine-consistent) but a minor slice of total cross-center variation, most of which is a per-transcript batch effect that belongs downstream.

## Scope / notes

- Strictly additive and **opt-in**; `--gcBias` default behavior is unchanged.
- `O_t` uses all compatible placements (documented: unique-only starves coverage and is worse on isoform-rich transcriptomes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7JMur5DmDpECddErpi2JS