### PR TITLE
chore(cli): tidy help output (hide removed `alevin`, drop "Rust port")

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -3,8 +3,9 @@
 //! Provides the two most-used subcommands so far: `index` (build a salmon
 //! index over a transcriptome) and `quant` (quantify from FASTQ reads, via
 //! selective alignment or the pseudoalignment-only `--sketch` path). Flag
-//! names mirror C++ salmon where they overlap. Alignment-based `quant -a`,
-//! `quantmerge`, and `alevin` are stubbed for later phases.
+//! names mirror C++ salmon where they overlap. Alignment-based `quant -a` and
+//! `quantmerge` are stubbed for later phases; `alevin` is a permanent redirect
+//! to the alevin-fry ecosystem.
 
 use std::path::PathBuf;
 
@@ -133,11 +134,7 @@ impl Drop for ProgressGuard {
 }
 
 #[derive(Parser)]
-#[command(
-    name = "salmon",
-    version,
-    about = "RNA-seq transcript quantification (Rust port)"
-)]
+#[command(name = "salmon", version, about = "RNA-seq transcript quantification")]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -164,8 +161,9 @@ enum Command {
     Quantmerge(QuantMergeArgs),
     /// Diagnostic: per-read best-mapping detail (placement, seed coverage, score).
     DebugMap(DebugMapArgs),
-    /// Single-cell quantification (removed; redirects to alevin-fry).
-    #[command(disable_help_flag = true)]
+    /// Single-cell quantification: removed; use the alevin-fry ecosystem.
+    /// Hidden from help; retained only to redirect legacy `salmon alevin` calls.
+    #[command(hide = true, disable_help_flag = true)]
     Alevin(AlevinArgs),
     /// Perform super-secret operation.
     #[command(hide = true)]


### PR DESCRIPTION
## What

Two small cosmetic cleanups to the top-level `salmon --help` output:

1. **Hide the removed `alevin` subcommand.** It was listed as a real command whose only description was that it had been removed, which reads as clutter. The variant is now `#[command(hide = true)]`, matching the already-hidden `swim` command, so it no longer appears in the command list.
2. **Drop the `(Rust port)` parenthetical** from the `about` string, so the header reads simply `RNA-seq transcript quantification`.

Also refreshes a stale module doc comment that still described `alevin` as "stubbed for later phases" (it is a permanent redirect).

## Behavior is unchanged

`salmon alevin ...` (and `salmon alevin --help`) still parse and still emit the alevin-fry redirect before logging init, exiting 1. The migration hint for genuinely unknown subcommands is unaffected.

Before / after `salmon --help`:

```
  debug-map   Diagnostic: per-read best-mapping detail (placement, seed coverage, score)
- alevin      Single-cell quantification (removed; redirects to alevin-fry)
  help        Print this message or the help of the given subcommand(s)
```

## Testing

- `cargo build -p salmon-cli`
- `salmon --help` no longer lists `alevin`; header no longer says "(Rust port)"
- `salmon alevin foo` and `salmon alevin --help` both still print the redirect and exit 1
- `salmon bogus` still prints the migration hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)