### PR TITLE
docs(readme): add CI/release/bioconda/homebrew/docker/license/DOI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # salmon
 
-[![CI](https://github.com/COMBINE-lab/salmon/actions/workflows/ci.yml/badge.svg?branch=rust-rewrite)](https://github.com/COMBINE-lab/salmon/actions/workflows/ci.yml)
+[![CI](https://github.com/COMBINE-lab/salmon/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/COMBINE-lab/salmon/actions/workflows/ci.yml)
+[![GitHub release](https://img.shields.io/github/v/release/COMBINE-lab/salmon)](https://github.com/COMBINE-lab/salmon/releases/latest)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io/recipes/salmon/README.html)
+[![Homebrew version](https://img.shields.io/homebrew/v/salmon)](https://formulae.brew.sh/formula/salmon)
+[![Docker pulls](https://img.shields.io/docker/pulls/combinelab/salmon)](https://hub.docker.com/r/combinelab/salmon)
+[![License: BSD-3-Clause](https://img.shields.io/github/license/COMBINE-lab/salmon)](https://github.com/COMBINE-lab/salmon/blob/master/LICENSE)
+[![DOI](https://img.shields.io/badge/DOI-10.1038%2Fnmeth.4197-blue)](https://doi.org/10.1038/nmeth.4197)
 
 > [!IMPORTANT]
 > **This is salmon 2.0 — a from-scratch Rust rewrite of salmon.** It keeps the


### PR DESCRIPTION
## What

Docs-only change: enrich the README header with a coherent row of status/distribution/citation badges, and fix the existing CI badge so it tracks the default branch.

No code, build, or workflow changes. Only `README.md` is touched.

## Badges

Every badge and every link target was verified to resolve before inclusion.

| Badge | Endpoint | Verification |
|-------|----------|--------------|
| **CI** (fixed) | `ci.yml/badge.svg?branch=master` | `ci.yml` runs on `master`; latest run is `success`. Old badge tracked the stale `rust-rewrite` branch, not the default branch. |
| **GitHub release** (new) | `img.shields.io/github/v/release/COMBINE-lab/salmon` | Latest release is `v2.3.2`. |
| **bioconda** (kept) | `bioconda.github.io/recipes/salmon/README.html` | Recipe page returns HTTP 200. |
| **Homebrew** (new) | `img.shields.io/homebrew/v/salmon` | `formulae.brew.sh/api/formula/salmon.json` returns real JSON (merged in homebrew/core, stable 2.3.2, BSD-3-Clause). |
| **Docker pulls** (new) | `img.shields.io/docker/pulls/combinelab/salmon` | Docker Hub `combinelab/salmon` is active (210k+ pulls); matches the `docker run combinelab/salmon` install path in the README. |
| **License** (new) | `img.shields.io/github/license/COMBINE-lab/salmon` | Repo license is BSD-3-Clause; links to `LICENSE` on `master`. |
| **DOI** (new) | `DOI-10.1038/nmeth.4197` | Salmon paper, Patro et al., *Nature Methods* 2017; DOI resolves. |

All shields.io badge images and all link targets (releases/latest, Homebrew formula page, Docker Hub repo, LICENSE, CI workflow, DOI) were confirmed to return HTTP 200 (DOI 302 → resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)