### PR TITLE
fix(infer): thread-count-independent EM reduction on the deterministic paths (fixes flaky thread_count_invariant)

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -1461,6 +1461,14 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
     let start_time = asctime_now();
     let run_timer = std::time::Instant::now();
     let mut timer = PhaseTimer::new();
+    // Alignment-mode eq-classes are order-independent; run the parallel M-step
+    // with a thread-count-independent reduction so the point estimate is
+    // byte-identical across `-p`.
+    let det_em = {
+        let mut e = opts.em.clone();
+        e.deterministic_reduction = true;
+        e
+    };
     let header = read_alignment_header(&opts.bam)?;
 
     // Reject coordinate-sorted input up front (header-only check, no per-record cost):
@@ -1676,12 +1684,12 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             dropped_mass: 0.0,
         }
     } else if opts.init_uniform {
-        optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths))
+        optimize(&collapsed, num_refs, &det_em, Some(&eff_lengths))
     } else {
         optimize_with_init(
             &collapsed,
             num_refs,
-            &opts.em,
+            &det_em,
             init_alphas.as_deref(),
             Some(&eff_lengths),
         )
@@ -1710,7 +1718,7 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             opts.no_bias_length_threshold,
         );
         collapsed.update_eff_lengths(&eff_lengths);
-        em = optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths));
+        em = optimize(&collapsed, num_refs, &det_em, Some(&eff_lengths));
     }
     let inference_truncated_mass = em.dropped_mass;
     let (em_iters, em_converged) = (em.iters, em.converged);

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -1002,6 +1002,15 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     let start_time = asctime_now();
     let run_timer = std::time::Instant::now();
     let mut timer = PhaseTimer::new();
+    // RAD quantification is order-independent by construction; run the parallel
+    // M-step with a thread-count-independent reduction so the point estimate is
+    // byte-identical across `-p` (bootstrap already uses the sequential,
+    // deterministic M-step).
+    let det_em = {
+        let mut e = opts.em.clone();
+        e.deterministic_reduction = true;
+        e
+    };
 
     // Bias correction is computed from the REFERENCE sequence at each fragment's
     // RAD position (never the read bases). seq/GC need the reference bases;
@@ -1148,7 +1157,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         // lib type is resolved, then build uniform eq-classes for the rough EM.
         let mut c = eqb.finish(expected_format);
         c.update_eff_lengths(&eff_lengths);
-        let mut ro = opts.em.clone();
+        let mut ro = det_em.clone();
         ro.min_iter = opts.bias_seed_em_iters;
         ro.max_iter = opts.bias_seed_em_iters;
         ro.min_alpha = 0.0;
@@ -1358,9 +1367,9 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             opts.no_bias_length_threshold,
         );
         collapsed.update_eff_lengths(&eff_lengths);
-        salmon_infer::optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths))
+        salmon_infer::optimize(&collapsed, num_refs, &det_em, Some(&eff_lengths))
     } else {
-        let mut em = salmon_infer::optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths));
+        let mut em = salmon_infer::optimize(&collapsed, num_refs, &det_em, Some(&eff_lengths));
         if bias_on {
             // Abundances weighting bias collection: baked prior if present, else
             // this run's (converged) first EM. (Reached only when no up-front
@@ -1426,7 +1435,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                 opts.no_bias_length_threshold,
             );
             collapsed.update_eff_lengths(&eff_lengths);
-            em = salmon_infer::optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths));
+            em = salmon_infer::optimize(&collapsed, num_refs, &det_em, Some(&eff_lengths));
         }
         em
     };

--- a/crates/salmon-infer/src/lib.rs
+++ b/crates/salmon-infer/src/lib.rs
@@ -26,6 +26,13 @@ pub use online::OnlineInference;
 pub use packed::PackedEqClasses;
 pub use uncertainty::{ambiguity_counts, bootstrap, gibbs_sample, GibbsOptions};
 
+/// Upper bound on the number of M-step accumulation shards. Fixed (not derived
+/// from the thread count) so the per-transcript reduction order — and thus the
+/// converged estimate to the last bit — is identical at any `-p`. 64 preserves
+/// accumulation parallelism up to 64 cores; problems with fewer classes use
+/// fewer shards.
+const EM_MAX_SHARDS: usize = 64;
+
 /// EM/VBEM acceleration scheme applied on top of the fixed-point map.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EmAccel {
@@ -67,6 +74,12 @@ pub struct EmOptions {
     pub per_nucleotide_prior: bool,
     /// convergence acceleration scheme (default [`EmAccel::None`]).
     pub accel: EmAccel,
+    /// use a fixed, thread-count-independent M-step reduction so the converged
+    /// estimate is byte-identical across `-p`. Set by the deterministic input
+    /// paths (`--deterministic` / `--rad` / alignment mode); the default online
+    /// path leaves it `false` and shards by thread count (its output is not
+    /// thread-count-identical regardless, so it gains nothing from fixing it).
+    pub deterministic_reduction: bool,
 }
 
 impl Default for EmOptions {
@@ -81,6 +94,7 @@ impl Default for EmOptions {
             vb_prior: 1e-2,
             per_nucleotide_prior: false,
             accel: EmAccel::None,
+            deterministic_reduction: false,
         }
     }
 }
@@ -258,17 +272,28 @@ pub(crate) fn run_em_counts(
     let prior_alphas = prior_alphas_vec(opts, eff_lens, num_txps);
     let mut exp_theta = vec![0.0f64; num_txps];
     let mut scratch: Vec<f64> = Vec::with_capacity(64);
-    // Per-shard dense accumulators reused across all parallel M-steps (allocated
-    // once here, not per-task per-iteration). Each shard processes a contiguous
-    // slice of the classes with plain adds, then they are summed into `alpha_out`
-    // — avoiding the cross-thread CAS contention of a single shared atomic array.
-    // Capped at 64 shards: beyond that, the per-iteration zero/reduce overhead
-    // outweighs the extra accumulation parallelism.
-    let mut shards: Vec<Vec<f64>> = if parallel {
-        let nshards = rayon::current_num_threads().clamp(1, 64);
-        vec![vec![0.0f64; num_txps]; nshards]
+    // Per-shard dense accumulators (+ precomputed touched-tid lists) reused across
+    // all parallel M-steps, allocated once here. The M-step sums each transcript's
+    // mass across shards; f64 addition is non-associative, so the summation
+    // grouping — hence the last bit of the estimate — depends on the shard count.
+    let mut shard_ctx: Option<packed::ShardCtx> = if parallel {
+        let nshards = if opts.deterministic_reduction {
+            // Fixed, thread-count-INDEPENDENT shard count so the reduction
+            // grouping (and the result to the last bit) is identical at any
+            // `-p`. Required where output must be byte-identical across thread
+            // counts (`--deterministic` / `--rad` / `-a`); byte-identical on
+            // x86_64 without this too, but only by luck — it flakes on aarch64.
+            p.num_classes().clamp(1, EM_MAX_SHARDS)
+        } else {
+            // Default / online: match the thread count for load balancing. Online
+            // output is not thread-count-identical regardless (the FLD is built
+            // with a thread-dependent estimator), so nothing is lost, and the
+            // sparse zero/reduce keeps this at least as fast as before.
+            rayon::current_num_threads().clamp(1, EM_MAX_SHARDS)
+        };
+        Some(packed::ShardCtx::new(p, num_txps, nshards))
     } else {
-        Vec::new()
+        None
     };
 
     // One fixed-point M-step `dst = F(src)`, dispatched by (VBEM?, parallel?) and
@@ -276,7 +301,7 @@ pub(crate) fn run_em_counts(
     // and SQUAREM loops drive `F` through this closure, so the accelerated path
     // reuses the exact same (already tuned) kernels.
     let mut f = |src: &[f64], dst: &mut [f64]| match (opts.use_vbem, parallel) {
-        (false, true) => packed::em_step_par(p, counts, src, dst, &mut shards),
+        (false, true) => packed::em_step_par(p, counts, src, dst, shard_ctx.as_mut().unwrap()),
         (false, false) => packed::em_step_seq(p, counts, src, dst, &mut scratch),
         (true, true) => packed::vbem_step_par(
             p,
@@ -285,7 +310,7 @@ pub(crate) fn run_em_counts(
             src,
             dst,
             &mut exp_theta,
-            &mut shards,
+            shard_ctx.as_mut().unwrap(),
         ),
         (true, false) => packed::vbem_step_seq(
             p,

--- a/crates/salmon-infer/src/packed.rs
+++ b/crates/salmon-infer/src/packed.rs
@@ -204,60 +204,107 @@ pub(crate) fn em_step_seq(
     }
 }
 
-/// Reduce per-shard dense accumulators into `alpha_out` (one writer per `tid`,
-/// no contention). Parallelized over transcripts.
-fn reduce_shards(shards: &[Vec<f64>], alpha_out: &mut [f64]) {
-    alpha_out.par_iter_mut().enumerate().for_each(|(tid, out)| {
-        let mut s = 0.0;
-        for buf in shards {
-            s += buf[tid];
-        }
-        *out = s;
-    });
+/// Per-shard M-step accumulators plus the metadata that makes the reduction
+/// cheap *and* deterministic.
+///
+/// Each shard owns a private dense `num_txps` buffer and processes a contiguous
+/// range of equivalence classes with plain (non-atomic) adds; the shards are
+/// then summed into `alpha_out`. The equivalence classes are fixed for the whole
+/// EM run, so [`ShardCtx::new`] precomputes, once, the sorted-unique transcript
+/// ids each shard's class range touches. Every M-step then zeroes and reduces
+/// only those entries — `O(incidences)` — instead of every shard's full
+/// `num_txps` buffer (`O(nshards * num_txps)`), which otherwise dominates when
+/// the shard count is fixed high for determinism.
+pub(crate) struct ShardCtx {
+    bufs: Vec<Vec<f64>>,
+    /// `tids[s]` = sorted-unique transcript ids in shard `s`'s class range.
+    tids: Vec<Vec<u32>>,
+    chunk: usize,
 }
 
-/// Parallel EM M-step. Each shard owns a private dense `num_txps` buffer and
-/// processes a contiguous slice of the classes with plain (non-atomic) adds;
-/// the shards are then summed into `alpha_out`. This avoids both the per-task
-/// allocation of a naive fold/reduce and the cross-thread CAS contention of a
-/// single shared `AtomicF64` array (which, on hot transcripts, dominated the
-/// M-step). The buffers are allocated once in [`run_em_counts`] and reused.
+impl ShardCtx {
+    pub(crate) fn new(p: &PackedEqClasses, num_txps: usize, nshards: usize) -> Self {
+        let nclasses = p.num_classes();
+        let nshards = nshards.max(1);
+        let chunk = nclasses.div_ceil(nshards);
+        let tids: Vec<Vec<u32>> = (0..nshards)
+            .map(|s| {
+                let start = s * chunk;
+                let end = ((s + 1) * chunk).min(nclasses);
+                let mut t: Vec<u32> = (start..end)
+                    .flat_map(|ci| p.class(ci).0.iter().copied())
+                    .collect();
+                t.sort_unstable();
+                t.dedup();
+                t
+            })
+            .collect();
+        Self {
+            bufs: vec![vec![0.0f64; num_txps]; nshards],
+            tids,
+            chunk,
+        }
+    }
+}
+
+/// Deterministic sparse reduce: `alpha_out[tid] = Σ_s bufs[s][tid]`, summed in
+/// shard order over only the shards that touched `tid`. Skipping a shard that
+/// left `tid` at 0 cannot change the f64 sum (`x + 0.0 == x`), so this is
+/// bit-identical to summing every shard — but it costs `O(incidences)` and, when
+/// `nshards` is fixed, the summation grouping is independent of the thread count.
+fn sparse_reduce(bufs: &[Vec<f64>], tids: &[Vec<u32>], alpha_out: &mut [f64]) {
+    alpha_out.iter_mut().for_each(|x| *x = 0.0);
+    for (buf, ts) in bufs.iter().zip(tids) {
+        for &tid in ts {
+            alpha_out[tid as usize] += buf[tid as usize];
+        }
+    }
+}
+
+/// Parallel EM M-step over a [`ShardCtx`]; see its docs for the sparse
+/// zero/reduce that keeps this fast at a fixed (thread-independent) shard count.
 pub(crate) fn em_step_par(
     p: &PackedEqClasses,
     counts: &[u64],
     alpha_in: &[f64],
     alpha_out: &mut [f64],
-    shards: &mut [Vec<f64>],
+    ctx: &mut ShardCtx,
 ) {
     let nclasses = p.num_classes();
-    let chunk = nclasses.div_ceil(shards.len().max(1));
-    shards.par_iter_mut().enumerate().for_each(|(s, buf)| {
-        buf.iter_mut().for_each(|x| *x = 0.0);
-        let start = s * chunk;
-        let end = ((s + 1) * chunk).min(nclasses);
-        for ci in start..end {
-            let count = counts[ci] as f64;
-            let (tids, ws) = p.class(ci);
-            if tids.len() > 1 {
-                let mut denom = 0.0;
-                for (&tid, &w) in tids.iter().zip(ws) {
-                    denom += alpha_in[tid as usize] * w;
-                }
-                if denom > MIN_EQ_CLASS_WEIGHT {
-                    let inv = count / denom;
+    let ShardCtx { bufs, tids, chunk } = ctx;
+    let chunk = *chunk;
+    bufs.par_iter_mut()
+        .zip(tids.par_iter())
+        .enumerate()
+        .for_each(|(s, (buf, my_tids))| {
+            for &tid in my_tids.iter() {
+                buf[tid as usize] = 0.0;
+            }
+            let start = s * chunk;
+            let end = ((s + 1) * chunk).min(nclasses);
+            for ci in start..end {
+                let count = counts[ci] as f64;
+                let (tids, ws) = p.class(ci);
+                if tids.len() > 1 {
+                    let mut denom = 0.0;
                     for (&tid, &w) in tids.iter().zip(ws) {
-                        let v = alpha_in[tid as usize] * w;
-                        if !v.is_nan() {
-                            buf[tid as usize] += v * inv;
+                        denom += alpha_in[tid as usize] * w;
+                    }
+                    if denom > MIN_EQ_CLASS_WEIGHT {
+                        let inv = count / denom;
+                        for (&tid, &w) in tids.iter().zip(ws) {
+                            let v = alpha_in[tid as usize] * w;
+                            if !v.is_nan() {
+                                buf[tid as usize] += v * inv;
+                            }
                         }
                     }
+                } else {
+                    buf[tids[0] as usize] += count;
                 }
-            } else {
-                buf[tids[0] as usize] += count;
             }
-        }
-    });
-    reduce_shards(shards, alpha_out);
+        });
+    sparse_reduce(bufs, tids, alpha_out);
 }
 
 /// `exp_theta[i] = exp(digamma(alpha_in[i]+prior_i) - digamma(Σ_j alpha_in[j]+prior_j))`,
@@ -321,42 +368,48 @@ pub(crate) fn vbem_step_par(
     alpha_in: &[f64],
     alpha_out: &mut [f64],
     exp_theta: &mut [f64],
-    shards: &mut [Vec<f64>],
+    ctx: &mut ShardCtx,
 ) {
     fill_exp_theta(alpha_in, prior_alphas, exp_theta);
     let nclasses = p.num_classes();
-    let chunk = nclasses.div_ceil(shards.len().max(1));
     let exp_theta: &[f64] = exp_theta;
-    shards.par_iter_mut().enumerate().for_each(|(s, buf)| {
-        buf.iter_mut().for_each(|x| *x = 0.0);
-        let start = s * chunk;
-        let end = ((s + 1) * chunk).min(nclasses);
-        for ci in start..end {
-            let count = counts[ci] as f64;
-            let (tids, ws) = p.class(ci);
-            if tids.len() > 1 {
-                let mut denom = 0.0;
-                for (&tid, &w) in tids.iter().zip(ws) {
-                    let et = exp_theta[tid as usize];
-                    if et > 0.0 {
-                        denom += et * w;
-                    }
-                }
-                if denom > MIN_EQ_CLASS_WEIGHT {
-                    let inv = count / denom;
+    let ShardCtx { bufs, tids, chunk } = ctx;
+    let chunk = *chunk;
+    bufs.par_iter_mut()
+        .zip(tids.par_iter())
+        .enumerate()
+        .for_each(|(s, (buf, my_tids))| {
+            for &tid in my_tids.iter() {
+                buf[tid as usize] = 0.0;
+            }
+            let start = s * chunk;
+            let end = ((s + 1) * chunk).min(nclasses);
+            for ci in start..end {
+                let count = counts[ci] as f64;
+                let (tids, ws) = p.class(ci);
+                if tids.len() > 1 {
+                    let mut denom = 0.0;
                     for (&tid, &w) in tids.iter().zip(ws) {
                         let et = exp_theta[tid as usize];
                         if et > 0.0 {
-                            buf[tid as usize] += et * w * inv;
+                            denom += et * w;
                         }
                     }
+                    if denom > MIN_EQ_CLASS_WEIGHT {
+                        let inv = count / denom;
+                        for (&tid, &w) in tids.iter().zip(ws) {
+                            let et = exp_theta[tid as usize];
+                            if et > 0.0 {
+                                buf[tid as usize] += et * w * inv;
+                            }
+                        }
+                    }
+                } else {
+                    buf[tids[0] as usize] += count;
                 }
-            } else {
-                buf[tids[0] as usize] += count;
             }
-        }
-    });
-    reduce_shards(shards, alpha_out);
+        });
+    sparse_reduce(bufs, tids, alpha_out);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

The parallel EM/VBEM M-step shards the equivalence classes by
`rayon::current_num_threads()` and sums each transcript's mass across the shards.
f64 addition is non-associative, so the summation **grouping** — and the
converged estimate to the last bit — depends on the runtime thread count. On
x86_64 the groupings round identically; on **aarch64** they occasionally don't,
which made the RAD path's `thread_count_invariant` test (asserts bit-exact
counts across `-p`) **flaky in CI** (e.g. the v2.3.3 release-bump run failed on
`ubuntu-24.04-arm` while the identical commit passed on x86_64).

## Fix

Make the M-step reduction **thread-count-independent** — but only where a
cross-thread byte-identity guarantee actually exists, and without a perf hit.

**1. Confine to the deterministic paths.** New `EmOptions.deterministic_reduction`
selects a **fixed** shard count (`nclasses.clamp(1, 64)`) instead of one derived
from the thread count, so the reduction grouping (and the result) is identical at
any `-p`. It's set by `quantify_rad` and `quantify_alignments` (`--deterministic`
/ `--rad` / alignment mode). The **default online path is untouched** — its
output isn't thread-count-identical anyway (the FLD is built with a
thread-dependent online estimator), so it keeps the fast thread-adaptive shards.

**2. Keep it fast (sparse M-step).** A fixed high shard count with the old dense
per-shard buffers zeroed and reduced `O(nshards × num_txps)` per iteration — up
to **3.2× slower** EM. The new `ShardCtx` precomputes each shard's touched
transcript ids **once** (the eq-classes are constant across EM iterations) and
zeroes/reduces only those → `O(incidences)`. This is **value-identical** (adding
the skipped zeros cannot change an f64 sum), so it's a pure speedup.

## Results (5M-read human sample, `em_bias` phase)

| | naive fixed-64 | **fixed-64 + sparse (this PR)** |
|---|---|---|
| deterministic-path EM, `-p 16` | +96% | **+4%** |
| deterministic-path EM, `-p 1` | +222% | **+19%** |
| **default online EM** | (n/a) | **unchanged** (±noise) |

- **Determinism:** `--deterministic` output is now byte-identical across `-p 1/8/16`
  **by construction** (so aarch64-safe, not luck); `thread_count_invariant` passes
  20/20 locally (was flaky).
- **Output unchanged:** `quant.sf` is identical to before (the last-ULP grouping
  differences round away at `sigDigits`); the default online path is unchanged.
- Full workspace tests (incl. all EM/VBEM correctness tests) pass; `fmt` +
  `clippy -D warnings` clean.

The remaining ~19% at `-p 1` is inherent to a fixed 64-shard count on a single
thread (uncommon for real quant, and only in opt-in reproducible mode); it can be
tuned via `EM_MAX_SHARDS` if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7JMur5DmDpECddErpi2JS