### PR TITLE
fix(align): classify single-end BAM/SAM records as SingleEnd (#1057)

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -392,7 +392,16 @@ fn frag_format(recs: &[FragRecord], idxs: &[usize]) -> (Option<LibraryFormat>, b
         )
     } else {
         let r = &recs[idxs[0]];
-        let status = if r.is_read1 {
+        // A record that is not part of a multi-segment template (`0x1` unset) is a
+        // genuine single-end read → SingleEnd. A paired read reported alone here is
+        // an orphan (its mate unmapped / not grouped), classified left/right by the
+        // `0x40` first-segment flag. Mirrors salmon's `hitType` and the genome
+        // projection path (`genome_project.rs`). Conflating single-end reads with
+        // PairedEndRight made strand filters (SF/SR) drop every single-end
+        // alignment (issue #1057).
+        let status = if !r.is_paired {
+            MateStatus::SingleEnd
+        } else if r.is_read1 {
             MateStatus::PairedEndLeft
         } else {
             MateStatus::PairedEndRight
@@ -472,6 +481,11 @@ struct FragRecord {
     is_reverse: bool,
     /// first mate of the pair (BAM `0x40` flag)
     is_read1: bool,
+    /// the read is part of a multi-segment template (BAM `0x1` "paired" flag).
+    /// `false` marks a genuine single-end read, distinguishing it from a
+    /// paired-end orphan (mate unmapped / absent) — the two are classified
+    /// differently by [`frag_format`] (SingleEnd vs PairedEndLeft/Right).
+    is_paired: bool,
     /// reference span (Σ ref-consuming CIGAR op lengths); the read's 3' end on
     /// the reference is `pos + ref_span − 1`
     ref_span: usize,
@@ -613,6 +627,7 @@ fn record_to_frag<R: sam::alignment::Record>(
     let frag_len = record.template_length().map(|t| t.abs()).unwrap_or(0);
     let is_reverse = flags.is_reverse_complemented();
     let is_read1 = flags.is_first_segment();
+    let is_paired = flags.is_segmented();
     // Mate linkage as the aligner recorded it (RNEXT/PNEXT); a mate that is
     // unmapped or absent leaves these `None`, making the record an orphan.
     let mate_tid = (!flags.is_mate_unmapped())
@@ -643,6 +658,7 @@ fn record_to_frag<R: sam::alignment::Record>(
             frag_len,
             is_reverse,
             is_read1,
+            is_paired,
             ref_span,
             mate_tid,
             mate_pos,
@@ -2073,5 +2089,68 @@ mod tests {
         assert_eq!(value_as_i32(&Value::UInt16(300)), Some(300));
         // a non-integer tag value (e.g. a character) has no integer reading
         assert_eq!(value_as_i32(&Value::Character(b'A')), None);
+    }
+
+    /// Minimal `FragRecord` for classification tests (only the flag-derived
+    /// fields matter to `frag_format`'s single-record branch).
+    fn frag(is_reverse: bool, is_read1: bool, is_paired: bool) -> FragRecord {
+        FragRecord {
+            tid: 0,
+            pos: 0,
+            read_2bit: Vec::new(),
+            ops: Vec::new(),
+            score: 0,
+            frag_len: 0,
+            is_reverse,
+            is_read1,
+            is_paired,
+            ref_span: 1,
+            mate_tid: None,
+            mate_pos: None,
+            hi: None,
+        }
+    }
+
+    /// A genuine single-end read (BAM `0x1` unset) is classified `SingleEnd`, so
+    /// the strand filters accept it per its own orientation — regression for
+    /// issue #1057 (single-end BAM dropped under `SF`/`SR`).
+    #[test]
+    fn single_end_record_is_single_end_and_strand_filters_apply() {
+        use salmon_core::LibraryFormat;
+        let sf = LibraryFormat::parse("SF").unwrap();
+        let sr = LibraryFormat::parse("SR").unwrap();
+        let u = LibraryFormat::parse("U").unwrap();
+
+        // forward single-end read (flags 0x0)
+        let fwd = vec![frag(false, false, false)];
+        let (obs, is_fw, status) = frag_format(&fwd, &[0]);
+        assert_eq!(status, MateStatus::SingleEnd);
+        assert!(is_fw);
+        assert!(obs.is_none());
+        assert!(is_compatible(sf, obs, is_fw, status)); // SF accepts forward
+        assert!(!is_compatible(sr, obs, is_fw, status)); // SR rejects forward
+        assert!(is_compatible(u, obs, is_fw, status)); // U accepts
+
+        // reverse single-end read (flags 0x10) — the reporter's case
+        let rev = vec![frag(true, false, false)];
+        let (obs, is_fw, status) = frag_format(&rev, &[0]);
+        assert_eq!(status, MateStatus::SingleEnd);
+        assert!(!is_fw);
+        assert!(!is_compatible(sf, obs, is_fw, status)); // SF rejects reverse
+        assert!(is_compatible(sr, obs, is_fw, status)); // SR accepts reverse
+        assert!(is_compatible(u, obs, is_fw, status)); // U accepts
+    }
+
+    /// A paired-end read reported alone (BAM `0x1` set) remains an orphan,
+    /// classified left/right by the first-segment (`0x40`) flag — unchanged.
+    #[test]
+    fn paired_orphan_keeps_left_right_status() {
+        let read1 = vec![frag(false, true, true)];
+        let (_, _, status) = frag_format(&read1, &[0]);
+        assert_eq!(status, MateStatus::PairedEndLeft);
+
+        let read2 = vec![frag(true, false, true)];
+        let (_, _, status) = frag_format(&read2, &[0]);
+        assert_eq!(status, MateStatus::PairedEndRight);
     }
 }

--- a/crates/salmon-align/tests/stranded_num_mapped.rs
+++ b/crates/salmon-align/tests/stranded_num_mapped.rs
@@ -44,6 +44,31 @@ fn write_sam(dir: &Path, n_fwd: usize, n_rev: usize) -> PathBuf {
     path
 }
 
+/// Write a tiny transcriptome SAM of *genuine single-end* records (BAM `0x1`
+/// unset, so neither `0x40` nor `0x80`) to `dir`. `n_fwd` reads align to the
+/// forward strand (flag `0x0`); `n_rev` to the reverse strand (flag `0x10`) —
+/// the flag-16-heavy shape reported in issue #1057. Returns the SAM path.
+fn write_single_end_sam(dir: &Path, n_fwd: usize, n_rev: usize) -> PathBuf {
+    let path = dir.join("se.sam");
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "@HD\tVN:1.6\tSO:unsorted").unwrap();
+    writeln!(f, "@SQ\tSN:tx0\tLN:5000").unwrap();
+    // 0x0 = mapped forward single-end; 0x10 = mapped reverse single-end.
+    let emit = |f: &mut std::fs::File, name: &str, flag: u16, p: usize| {
+        writeln!(f, "{name}\t{flag}\ttx0\t{}\t60\t100M\t*\t0\t0\t*\t*", p + 1).unwrap();
+    };
+    let mut pos = 1usize;
+    for i in 0..n_fwd {
+        emit(&mut f, &format!("fwd{i}"), 0, pos);
+        pos += 200;
+    }
+    for i in 0..n_rev {
+        emit(&mut f, &format!("rev{i}"), 0x10, pos);
+        pos += 200;
+    }
+    path
+}
+
 fn run(sam: &Path, out: &Path, lib_type: &str) -> salmon_align::AlignQuantResult {
     let mut opts = AlignQuantOptions::new(sam.to_path_buf(), out.to_path_buf());
     opts.lib_type = lib_type.to_string();
@@ -92,4 +117,48 @@ fn stranded_align_num_mapped_matches_quantified_mass() {
         "ISF: only the forward (ISF-compatible) fragments should map"
     );
     mass_conserved(&isf, "ISF");
+}
+
+/// Regression for issue #1057: genuine single-end records (BAM `0x1` unset) must
+/// be classified `SingleEnd`, so the single-end strand filters accept them by
+/// their own alignment orientation. Before the fix they were mislabeled as
+/// paired-end right orphans and dropped under `SF`/`SR` (0 fragments mapped),
+/// leaving `U` as the only library type that worked.
+#[test]
+fn single_end_strand_filters_respect_alignment_orientation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (n_fwd, n_rev) = (12usize, 48usize); // flag-16-heavy, as reported
+    let sam = write_single_end_sam(tmp.path(), n_fwd, n_rev);
+    let total = (n_fwd + n_rev) as u64;
+
+    let mass_conserved = |res: &salmon_align::AlignQuantResult, tag: &str| {
+        let sum: f64 = res.counts.iter().sum();
+        assert!(
+            (res.num_mapped as f64 - sum).abs() <= 1e-6,
+            "{tag}: mass not conserved: num_mapped={} but Σ counts={sum:.6}",
+            res.num_mapped
+        );
+    };
+
+    // U (unstranded single-end): accepts both orientations -> all map.
+    let u = run(&sam, &tmp.path().join("u"), "U");
+    assert_eq!(u.num_processed, total, "U: num_processed");
+    assert_eq!(u.num_mapped, total, "U: every single-end read should map");
+    mass_conserved(&u, "U");
+
+    // SF (forward single-end): accepts only the forward reads.
+    let sf = run(&sam, &tmp.path().join("sf"), "SF");
+    assert_eq!(
+        sf.num_mapped, n_fwd as u64,
+        "SF: only forward-strand single-end reads should map (was 0 before #1057 fix)"
+    );
+    mass_conserved(&sf, "SF");
+
+    // SR (reverse single-end): accepts only the reverse reads (the reporter's case).
+    let sr = run(&sam, &tmp.path().join("sr"), "SR");
+    assert_eq!(
+        sr.num_mapped, n_rev as u64,
+        "SR: only reverse-strand single-end reads should map (was 0 before #1057 fix)"
+    );
+    mass_conserved(&sr, "SR");
 }


### PR DESCRIPTION
Fixes #1057 — single-end transcriptomic BAM/SAM records dropped under stranded library types (`SF`/`SR`), reported as "0 fragments mapped".

## Root cause
In alignment mode, `frag_format`'s single-record branch (`crates/salmon-align/src/lib.rs`) classified **every** lone record as a paired-end orphan:

```rust
let status = if r.is_read1 { PairedEndLeft } else { PairedEndRight };
```

It consulted only the `0x40` first-segment flag and never `0x1` ("template has multiple segments" / paired). A genuine single-end read carries **neither** `0x40` nor `0x80`, so `is_read1` was `false` and it was mislabeled `PairedEndRight`.

`compatible_single()` for `PairedEndRight` can only satisfy paired strandedness (`SA`/`AS`), never single-end `S`/`A` — so under `SF`/`SR` every single-end alignment was discarded. `U` worked only because `es == U` short-circuits to compatible. This matches the report exactly (records with flag `0x10`, no `0x1`/`0x40`/`0x80`, e.g. from mudskipper genome→transcriptome projection).

## Fix
- Store the `0x1` (`is_segmented`) flag on `FragRecord` as `is_paired`.
- In the single-record branch, classify `!is_paired` → `MateStatus::SingleEnd`, falling back to `PairedEndLeft`/`PairedEndRight` (by `0x40`) only for a real paired-read orphan.

This mirrors salmon's `hitType` and the already-correct genome-projection (`genome_project.rs:471`) and RAD-input (`rad.rs:102`) paths. It also propagates through `--writeRad` (SingleEnd → the `SINGLE` RAD tag) so single-end BAM→RAD is tagged correctly too.

## Behavior after fix
Strand filters now respect single-end orientation instead of dropping everything. End-to-end on a synthetic single-end transcriptomic SAM (48 reverse + 12 forward records):

| libType | mapped (after fix) | before fix |
|---|---|---|
| `SR` | **48** (all reverse) | 0 |
| `SF` | **12** (all forward) | 0 |
| `U`  | **60** (all) | 60 |

Clean `quant.sf`, no "0 fragments mapped" error.

## Tests
Added regression tests:
- `single_end_record_is_single_end_and_strand_filters_apply` — a `0x1`-unset record classifies `SingleEnd`; `SF` accepts forward / `SR` accepts reverse / `U` accepts both.
- `paired_orphan_keeps_left_right_status` — a `0x1`-set lone record stays `PairedEndLeft`/`PairedEndRight` (unchanged).

`cargo fmt --all --check`, `clippy -p salmon-align`, and the salmon-align/salmon-core suites are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7JMur5DmDpECddErpi2JS