### PR TITLE
fix(rad): --fldPolicy, and warn when a baked FLD makes --fldMean/--fldSD ineffective

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -46,6 +46,64 @@ use salmon_model::FragmentLengthDistribution;
 
 const SALMON_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Where the fragment-length distribution comes from when quantifying a RAD
+/// (`--fldPolicy`).
+///
+/// salmon's own RAD writer always bakes its FLD into the header so a requant
+/// reproduces the writing run exactly. That default is right for reproduction
+/// but leaves no way to ask a different question of the same file, which is
+/// what the other two variants restore.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FldPolicy {
+    /// Use the FLD baked into the RAD header when present (exact parity with
+    /// the run that wrote the file); otherwise derive it, or fall back to the
+    /// prior for single-end libraries. The default.
+    #[default]
+    Baked,
+    /// Ignore any baked FLD and re-derive it from this RAD's uniquely-mapped
+    /// proper pairs, seeded by `--fldMean`/`--fldSD`.
+    Derive,
+    /// Ignore both the baked FLD and the observations; use `--fldMean`/`--fldSD`
+    /// alone. This is the only setting under which those flags fully determine
+    /// the distribution, so it is the one to use for a fragment-length
+    /// sensitivity analysis.
+    Prior,
+}
+
+/// Which fragment-length prior flags the user supplied explicitly, as opposed
+/// to inheriting their defaults.
+///
+/// salmon cannot warn "your `--fldMean` was ignored" without knowing the user
+/// actually typed it — every run has *some* value for these.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ExplicitFldArgs {
+    pub mean: bool,
+    pub sd: bool,
+    pub max: bool,
+}
+
+impl ExplicitFldArgs {
+    /// True when at least one fragment-length prior flag was supplied.
+    pub fn any(self) -> bool {
+        self.mean || self.sd || self.max
+    }
+
+    /// The supplied flags, formatted for a message: `--fldMean/--fldSD`.
+    pub fn names(self) -> String {
+        let mut names = Vec::new();
+        if self.mean {
+            names.push("--fldMean");
+        }
+        if self.sd {
+            names.push("--fldSD");
+        }
+        if self.max {
+            names.push("--fldMax");
+        }
+        names.join("/")
+    }
+}
+
 /// Options for alignment-based quantification.
 #[derive(Debug, Clone)]
 pub struct AlignQuantOptions {
@@ -94,6 +152,14 @@ pub struct AlignQuantOptions {
     pub fld_mean: f64,
     pub fld_sd: f64,
     pub fld_max: usize,
+    /// RAD-input mode: where the fragment-length distribution comes from
+    /// (`--fldPolicy`). Ignored outside `--rad`, which has no baked FLD to
+    /// prefer.
+    pub fld_policy: FldPolicy,
+    /// which of `--fldMean`/`--fldSD`/`--fldMax` the user actually supplied.
+    /// Used only to warn when a baked FLD makes them ineffective, so that a
+    /// default-valued run stays quiet.
+    pub explicit_fld_args: ExplicitFldArgs,
     /// online-phase forgetting factor (`--forgettingFactor`, salmon default 0.65)
     pub forgetting_factor: f64,
     /// initialize the EM uniformly instead of with the online-estimate-blended
@@ -160,6 +226,8 @@ impl AlignQuantOptions {
             fld_mean: 250.0,
             fld_sd: 25.0,
             fld_max: 1000,
+            fld_policy: FldPolicy::default(),
+            explicit_fld_args: ExplicitFldArgs::default(),
             forgetting_factor: 0.65,
             init_uniform: false,
             sig_digits: 3,
@@ -196,6 +264,10 @@ pub struct AlignQuantResult {
     pub num_eq_classes: usize,
     pub frag_len_mean: f64,
     pub frag_len_sd: f64,
+    /// where the fragment-length distribution came from; reported as
+    /// `frag_length_source` in `meta_info.json` so a result's FLD provenance
+    /// stays auditable after the run
+    pub frag_len_source: salmon_model::FragLengthSource,
     pub length_classes: Vec<u32>,
     pub frag_len_dist: Vec<f64>,
     pub start_time: String,
@@ -1827,6 +1899,7 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
         num_eq_classes,
         frag_len_mean: fld.mean(),
         frag_len_sd: fld.sd(),
+        frag_len_source: salmon_model::FragLengthSource::Alignments,
         length_classes,
         frag_len_dist: fld.log_pmf().iter().map(|lp| lp.exp()).collect(),
         start_time,
@@ -1878,6 +1951,9 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         frag_dist_length: usize,
         frag_length_mean: f64,
         frag_length_sd: f64,
+        /// provenance of the two fields above: whether they came from observed
+        /// data or from the `--fldMean`/`--fldSD` prior (see `FragLengthSource`)
+        frag_length_source: &'static str,
         seq_bias_correct: bool,
         gc_bias_correct: bool,
         pos_bias_correct: bool,
@@ -1936,6 +2012,7 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         frag_dist_length: res.frag_len_dist.len(),
         frag_length_mean: res.frag_len_mean,
         frag_length_sd: res.frag_len_sd,
+        frag_length_source: res.frag_len_source.as_str(),
         seq_bias_correct: opts.seq_bias,
         gc_bias_correct: opts.gc_bias,
         pos_bias_correct: opts.pos_bias,
@@ -2161,5 +2238,44 @@ mod tests {
         let read2 = vec![frag(true, false, true)];
         let (_, _, status) = frag_format(&read2, &[0]);
         assert_eq!(status, MateStatus::PairedEndRight);
+    }
+
+    /// The warning in #1062 must name exactly the flags the user typed, so it
+    /// never claims a value was ignored that the user never supplied.
+    #[test]
+    fn explicit_fld_args_report_only_supplied_flags() {
+        assert!(!ExplicitFldArgs::default().any());
+        assert_eq!(ExplicitFldArgs::default().names(), "");
+
+        let mean_only = ExplicitFldArgs {
+            mean: true,
+            ..Default::default()
+        };
+        assert!(mean_only.any());
+        assert_eq!(mean_only.names(), "--fldMean");
+
+        let all = ExplicitFldArgs {
+            mean: true,
+            sd: true,
+            max: true,
+        };
+        assert_eq!(all.names(), "--fldMean/--fldSD/--fldMax");
+
+        let sd_max = ExplicitFldArgs {
+            mean: false,
+            sd: true,
+            max: true,
+        };
+        assert_eq!(sd_max.names(), "--fldSD/--fldMax");
+    }
+
+    /// Baked is the default, so an ordinary requant keeps reproducing the run
+    /// that wrote the RAD unless the user opts out.
+    #[test]
+    fn fld_policy_defaults_to_baked() {
+        assert_eq!(FldPolicy::default(), FldPolicy::Baked);
+        let opts = AlignQuantOptions::new("x.rad".into(), "out".into());
+        assert_eq!(opts.fld_policy, FldPolicy::Baked);
+        assert!(!opts.explicit_fld_args.any());
     }
 }

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -58,11 +58,14 @@ use salmon_eqclass::{
     NAIVE_NO_FMT,
 };
 use salmon_model::{
-    DiscreteFld, FragmentLengthDistribution, GcFragModel, GcStore, SBModel, SimplePosBias,
+    DiscreteFld, FragLengthSource, FragmentLengthDistribution, GcFragModel, GcStore, SBModel,
+    SimplePosBias,
 };
 use salmon_rad::{RadInputProfile, SalmonBulkRecord};
 
-use crate::{asctime_now, logsumexp, AlignQuantOptions, AlignQuantResult};
+use crate::{
+    asctime_now, logsumexp, AlignQuantOptions, AlignQuantResult, ExplicitFldArgs, FldPolicy,
+};
 
 /// Floor for abundances feeding the bias-collection posterior (avoid `ln(0)`).
 const BIAS_MIN_ALPHA: f64 = 1e-8;
@@ -369,11 +372,65 @@ fn ref_lengths_from_tags(prelude: &RadPrelude, file_tag_map: &TagMap) -> Result<
     Ok(v)
 }
 
+/// Warn that a baked fragment-length distribution has made explicitly-supplied
+/// `--fldMean`/`--fldSD`/`--fldMax` ineffective (issue #1062).
+///
+/// Accepting those flags and then provably ignoring them is how a
+/// fragment-length sensitivity analysis silently becomes a no-op: every run
+/// produces byte-identical output, and nothing in the logs or `meta_info.json`
+/// says why. Naming the ignored flags and the remedy costs nothing and makes
+/// that failure impossible to miss.
+///
+/// Stays quiet when the user supplied none of them, so an ordinary requant —
+/// which inherits their defaults — is not nagged about flags it never used.
+fn warn_baked_fld_overrides(
+    explicit: &ExplicitFldArgs,
+    baked: &FragmentLengthDistribution,
+    source: FragLengthSource,
+) {
+    if !explicit.any() {
+        return;
+    }
+    // `derive` is only a real alternative for a paired-end RAD; single-end data
+    // has no fragment lengths to re-derive from, so offering it there would send
+    // the user straight back to the prior branch by a longer route.
+    let (provenance, remedy) = if source == FragLengthSource::RadBakedPrior {
+        (
+            "That distribution was baked by a single-end run, so it is itself an \
+             --fldMean/--fldSD prior rather than observed fragment lengths.",
+            "Pass `--fldPolicy prior` to use your values instead.",
+        )
+    } else {
+        (
+            "That distribution was observed by the run that wrote the RAD.",
+            "Pass `--fldPolicy prior` to use your values instead, or \
+             `--fldPolicy derive` to re-derive the distribution from this RAD's \
+             own fragment lengths.",
+        )
+    };
+    tracing::warn!(
+        "{} had no effect: this RAD carries a baked fragment-length distribution \
+         (mean={:.3}, sd={:.3}), which takes precedence. {} {}",
+        explicit.names(),
+        baked.mean(),
+        baked.sd(),
+        provenance,
+        remedy
+    );
+}
+
 /// Load a fragment-length distribution baked into the RAD header by salmon's
 /// writer, if present (the `baked_flags` byte has the FLD bit set and a non-empty
-/// `frag_length_dist` log-PMF tag exists). Returns `None` for piscem RAD or a
-/// salmon RAD written with `--skipQuant`, in which case the caller derives the FLD
-/// from unique fragments instead.
+/// `frag_length_dist` log-PMF tag exists).
+///
+/// Returns `None` only for RAD salmon did not write — piscem or third-party.
+/// salmon's writer bakes the FLD unconditionally (`--skipQuant` suppresses the
+/// *abundances*, not the FLD), so every salmon RAD takes this path and the
+/// caller's `--fldMean`/`--fldSD` go unused unless `--fldPolicy` says otherwise.
+///
+/// For a single-end write run the baked distribution is that run's own prior,
+/// since no fragment lengths existed to observe; the caller distinguishes this
+/// via the baked library format.
 fn load_baked_fld(file_tag_map: &TagMap) -> Option<FragmentLengthDistribution> {
     use libradicl::rad_types::TagValue;
     let flags = match file_tag_map.get(salmon_rad::BAKED_FLAGS_TAG) {
@@ -1058,25 +1115,49 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     let nthreads = rayon::current_num_threads().max(1);
 
     // Fixed fragment-length distribution, acquired BEFORE eq-class assembly so the
-    // per-fragment weights (and hence the whole pass) are deterministic. Priority:
-    //   1. a salmon RAD that baked its FLD into the header — use it directly (one
-    //      pass, exact parity with the run that wrote the file);
+    // per-fragment weights (and hence the whole pass) are deterministic.
+    //
+    // Priority under the default `--fldPolicy baked`:
+    //   1. a RAD that baked its FLD into the header — use it directly (one pass,
+    //      exact parity with the run that wrote the file). NB salmon's writer
+    //      bakes the FLD *unconditionally*, `--skipQuant` included, so this is
+    //      every salmon-written RAD; only piscem/third-party RAD reach step 2;
     //   2. otherwise derive it in one order-independent pass from uniquely-mapped
-    //      proper pairs (piscem RAD, or salmon RAD written with `--skipQuant`);
+    //      proper pairs;
     //   3. single-end libraries have no fragment length — use the prior.
-    let fld_baked = load_baked_fld(&file_tag_map);
-    // When the FLD must be derived (piscem / unbaked) AND we need bias correction,
-    // build *naive* eq-classes in that same prepare read, so a rough EM can produce
-    // the up-front abundances that let pass-2 fuse — keeping this case to 2 RAD
-    // reads (prepare + fused quant) rather than 3.
-    let prepare_eqb = (bias_on && !opts.skip_quant && fld_baked.is_none() && paired_lib)
-        .then(NaiveEqBuilder::new);
+    //
+    // `--fldPolicy derive` skips step 1, and `--fldPolicy prior` skips steps 1
+    // and 2, which is what makes `--fldMean`/`--fldSD` meaningful on a RAD that
+    // carries a baked distribution.
+    let fld_baked = match opts.fld_policy {
+        FldPolicy::Baked => load_baked_fld(&file_tag_map),
+        FldPolicy::Derive | FldPolicy::Prior => None,
+    };
+    let derive_fld_pass = fld_baked.is_none() && paired_lib && opts.fld_policy != FldPolicy::Prior;
+    // When the FLD must be derived (piscem / unbaked / `--fldPolicy derive`) AND we
+    // need bias correction, build *naive* eq-classes in that same prepare read, so a
+    // rough EM can produce the up-front abundances that let pass-2 fuse — keeping
+    // this case to 2 RAD reads (prepare + fused quant) rather than 3.
+    let prepare_eqb = (bias_on && !opts.skip_quant && derive_fld_pass).then(NaiveEqBuilder::new);
 
     let mut detected_fmt: Option<LibraryFormat> = None;
-    let fld = if let Some(baked) = fld_baked {
+    let (fld, fld_source) = if let Some(baked) = fld_baked {
+        // A baked FLD written by a single-end run is not observed data: that run
+        // had no fragment lengths to measure, so what it baked is its *own*
+        // `--fldMean`/`--fldSD` prior. Distinguish the two, because it changes
+        // what the number means and how safe it is to override.
+        let baked_single_end = baked_libfmt
+            .map(|f| f.read_type == ReadType::SingleEnd)
+            .unwrap_or(!paired_lib);
+        let source = if baked_single_end {
+            FragLengthSource::RadBakedPrior
+        } else {
+            FragLengthSource::RadBaked
+        };
         tracing::info!("using fragment-length distribution baked in the RAD header");
-        baked
-    } else if paired_lib {
+        warn_baked_fld_overrides(&opts.explicit_fld_args, &baked, source);
+        (baked, source)
+    } else if derive_fld_pass {
         let (f, detected) = match profile {
             RadInputProfile::PiscemBulk => derive_fld::<PiscemBulkReadRecord>(
                 rad_path,
@@ -1096,8 +1177,16 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             )?,
         };
         detected_fmt = detected;
-        f
+        (f, FragLengthSource::RadDerived)
     } else {
+        if opts.fld_policy == FldPolicy::Prior && paired_lib {
+            tracing::info!(
+                "--fldPolicy prior: using the --fldMean/--fldSD prior alone \
+                 (mean={:.3}, sd={:.3}); no fragment lengths were read from the RAD",
+                opts.fld_mean,
+                opts.fld_sd
+            );
+        }
         let mut f = FragmentLengthDistribution::new(
             1.0,
             opts.fld_max,
@@ -1108,7 +1197,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             1,
         );
         f.cache();
-        f
+        (f, FragLengthSource::Prior)
     };
     // Resolve the `-l A` format: baked (authoritative) else auto-detected.
     if auto_lib {
@@ -1522,6 +1611,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         num_eq_classes,
         frag_len_mean: fld.mean(),
         frag_len_sd: fld.sd(),
+        frag_len_source: fld_source,
         length_classes,
         frag_len_dist: fld.log_pmf().iter().map(|lp| lp.exp()).collect(),
         start_time,

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use salmon_align::{quantify_rad, AlignQuantOptions};
+use salmon_align::{quantify_rad, AlignQuantOptions, FldPolicy};
 use salmon_rad::{
     frag_map_type, FragmentChunkBuf, RadHit, RadOutputWriter, RadProfile, SalmonBulkContext,
     FRAG_LEN_UNPAIRED,
@@ -89,6 +89,29 @@ fn opts_for(out: &Path) -> AlignQuantOptions {
     o.fld_mean = 200.0;
     o.fld_sd = 20.0;
     o
+}
+
+/// A RAD whose baked FLD (mean ~500) is deliberately far from the length its
+/// records imply (200), so which distribution a run used is unambiguous.
+/// 200 fragments on `t0`, 300 on `t1`, all unique proper pairs.
+fn write_baked_fld_rad(rad: &Path) {
+    let names = ["t0", "t1"];
+    let lens = [4000u32, 4000];
+    let mut frags: Vec<Vec<(u32, Option<u16>, i32)>> = Vec::new();
+    for (tid, n) in [(0u32, 200), (1, 300)] {
+        for _ in 0..n {
+            frags.push(vec![(tid, Some(200), 0)]);
+        }
+    }
+    // Unnormalized Gaussian centered at 500; `from_log_pmf` normalizes. The
+    // reserved slot length is 1024 (see `write_rad`).
+    let baked: Vec<f64> = (0..1024)
+        .map(|l| {
+            let d = (l as f64 - 500.0) / 20.0;
+            -0.5 * d * d
+        })
+        .collect();
+    write_rad(rad, &names, &lens, RadProfile::Sketch, &frags, Some(&baked));
 }
 
 #[test]
@@ -400,6 +423,117 @@ fn baked_fld_is_used_not_derived() {
         (res.frag_len_mean - 500.0).abs() < 20.0,
         "expected baked FLD mean ~500, got {}",
         res.frag_len_mean
+    );
+}
+
+/// Regression for #1062: with a baked FLD in play, `--fldMean`/`--fldSD` are not
+/// consulted at all, so the run must at least say where its distribution came
+/// from.
+#[test]
+fn baked_fld_is_reported_as_the_frag_length_source() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("maps.rad");
+    let out = tmp.path().join("quant");
+    std::fs::create_dir_all(&out).unwrap();
+    write_baked_fld_rad(&rad);
+
+    let res = quantify_rad(&opts_for(&out), &rad).expect("quantify_rad");
+    assert_eq!(res.frag_len_source.as_str(), "rad_baked");
+}
+
+/// `--fldPolicy derive` must ignore the baked distribution and rebuild one from
+/// the RAD's own fragment lengths. The fixture bakes a mean of ~500 while every
+/// record implies 200, so the two are impossible to confuse.
+#[test]
+fn fld_policy_derive_ignores_the_baked_distribution() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("maps.rad");
+    let out = tmp.path().join("quant");
+    std::fs::create_dir_all(&out).unwrap();
+    write_baked_fld_rad(&rad);
+
+    let mut opts = opts_for(&out);
+    opts.fld_policy = FldPolicy::Derive;
+    let res = quantify_rad(&opts, &rad).expect("quantify_rad");
+
+    assert_eq!(res.frag_len_source.as_str(), "rad_derived");
+    assert!(
+        (res.frag_len_mean - 200.0).abs() < 20.0,
+        "expected the derived FLD (~200), got {}",
+        res.frag_len_mean
+    );
+    // Counts stay exact: the FLD does not affect uniquely-mapped fragments.
+    assert!(
+        (res.counts[0] - 200.0).abs() < 1.0,
+        "t0 = {}",
+        res.counts[0]
+    );
+    assert!(
+        (res.counts[1] - 300.0).abs() < 1.0,
+        "t1 = {}",
+        res.counts[1]
+    );
+}
+
+/// `--fldPolicy prior` must ignore both the baked distribution (mean ~500) and
+/// the records' implied lengths (200), leaving `--fldMean`/`--fldSD` in sole
+/// control — the setting that makes a fragment-length sensitivity analysis
+/// actually perturb the model.
+#[test]
+fn fld_policy_prior_puts_fld_args_in_control() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("maps.rad");
+    let out = tmp.path().join("quant");
+    std::fs::create_dir_all(&out).unwrap();
+    write_baked_fld_rad(&rad);
+
+    let mut opts = opts_for(&out);
+    opts.fld_policy = FldPolicy::Prior;
+    opts.fld_mean = 350.0;
+    opts.fld_sd = 15.0;
+    let res = quantify_rad(&opts, &rad).expect("quantify_rad");
+
+    assert_eq!(res.frag_len_source.as_str(), "prior");
+    assert!(
+        (res.frag_len_mean - 350.0).abs() < 1.0,
+        "expected the supplied prior (350), got {}",
+        res.frag_len_mean
+    );
+}
+
+/// The point of the issue: under the default policy, two runs that differ only
+/// in their fragment-length prior are indistinguishable; under `prior` they are
+/// not. Effective lengths are what the FLD actually drives, so compare those.
+#[test]
+fn fld_policy_prior_makes_different_priors_produce_different_results() {
+    let run = |policy: FldPolicy, mean: f64| {
+        let tmp = tempfile::tempdir().unwrap();
+        let rad = tmp.path().join("maps.rad");
+        let out = tmp.path().join("quant");
+        std::fs::create_dir_all(&out).unwrap();
+        write_baked_fld_rad(&rad);
+        let mut opts = opts_for(&out);
+        opts.fld_policy = policy;
+        opts.fld_mean = mean;
+        opts.fld_sd = 20.0;
+        let res = quantify_rad(&opts, &rad).expect("quantify_rad");
+        (res.eff_lengths.clone(), res.frag_len_mean)
+    };
+
+    let (baked_lo, _) = run(FldPolicy::Baked, 150.0);
+    let (baked_hi, _) = run(FldPolicy::Baked, 450.0);
+    assert_eq!(
+        baked_lo, baked_hi,
+        "baked policy must stay reproducible regardless of the prior"
+    );
+
+    let (prior_lo, mean_lo) = run(FldPolicy::Prior, 150.0);
+    let (prior_hi, mean_hi) = run(FldPolicy::Prior, 450.0);
+    assert!((mean_lo - 150.0).abs() < 1.0, "{mean_lo}");
+    assert!((mean_hi - 450.0).abs() < 1.0, "{mean_hi}");
+    assert_ne!(
+        prior_lo, prior_hi,
+        "prior policy must let --fldMean change the effective lengths"
     );
 }
 

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -20,7 +20,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use salmon_align::{
     project_genome_bam_to_rad, quantify_alignments, quantify_rad, AlignQuantOptions,
-    GenomeProjectOptions,
+    ExplicitFldArgs, FldPolicy, GenomeProjectOptions,
 };
 use salmon_index::{build as build_index, IndexBuildOptions};
 use salmon_quant::{quantify, ChunkCodec, EmAccel, ProgressCounters, QuantOptions};
@@ -167,6 +167,40 @@ impl From<EmAccelArg> for EmAccel {
             EmAccelArg::None => EmAccel::None,
             EmAccelArg::Squarem => EmAccel::Squarem,
             EmAccelArg::Daarem => EmAccel::Daarem,
+        }
+    }
+}
+
+/// Defaults for the fragment-length prior flags. Held here (rather than in
+/// `default_value_t`) so the flags can stay `Option` and salmon can distinguish
+/// a supplied value from an inherited one — the distinction issue #1062 needs in
+/// order to warn only when a value the user actually chose is being ignored.
+const DEFAULT_FLD_MEAN: f64 = 250.0;
+const DEFAULT_FLD_SD: f64 = 25.0;
+const DEFAULT_FLD_MAX: usize = 1000;
+
+/// CLI surface for [`FldPolicy`]: where a RAD requant's fragment-length
+/// distribution comes from.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+enum FldPolicyArg {
+    /// Prefer the distribution baked into the RAD header (exact parity with the
+    /// run that wrote it); otherwise derive it, or fall back to the prior.
+    #[default]
+    Baked,
+    /// Ignore any baked distribution; re-derive it from this RAD's own
+    /// uniquely-mapped proper pairs.
+    Derive,
+    /// Ignore both the baked distribution and the RAD's fragment lengths; use
+    /// `--fldMean`/`--fldSD` alone.
+    Prior,
+}
+
+impl From<FldPolicyArg> for FldPolicy {
+    fn from(p: FldPolicyArg) -> Self {
+        match p {
+            FldPolicyArg::Baked => FldPolicy::Baked,
+            FldPolicyArg::Derive => FldPolicy::Derive,
+            FldPolicyArg::Prior => FldPolicy::Prior,
         }
     }
 }
@@ -557,15 +591,36 @@ struct QuantArgs {
     /// far fewer M-steps but is not byte-identical to the default `none`.
     #[arg(long = "emAccel", value_enum, default_value_t = EmAccelArg::None)]
     em_accel: EmAccelArg,
-    /// Mean of the fragment-length distribution prior.
-    #[arg(long = "fldMean", default_value_t = 250.0)]
-    fld_mean: f64,
-    /// Standard deviation of the fragment-length distribution prior.
-    #[arg(long = "fldSD", default_value_t = 25.0)]
-    fld_sd: f64,
-    /// Maximum fragment length tracked by the fragment-length distribution.
-    #[arg(long = "fldMax", default_value_t = 1000)]
-    fld_max: usize,
+    /// Mean of the fragment-length distribution prior [default: 250].
+    ///
+    /// A prior, not an override: wherever fragment lengths are observed, this
+    /// seeds the distribution with weight 1 and the observations dominate. With
+    /// `--rad` it is ignored entirely unless `--fldPolicy` says otherwise, since
+    /// a salmon RAD carries a baked distribution.
+    // `Option` rather than `default_value_t` so salmon can tell a supplied value
+    // from an inherited one, and warn only when a supplied one is ignored.
+    #[arg(long = "fldMean")]
+    fld_mean: Option<f64>,
+    /// Standard deviation of the fragment-length distribution prior [default: 25].
+    ///
+    /// Same prior semantics as `--fldMean`.
+    #[arg(long = "fldSD")]
+    fld_sd: Option<f64>,
+    /// Maximum fragment length tracked by the fragment-length distribution
+    /// [default: 1000].
+    #[arg(long = "fldMax")]
+    fld_max: Option<usize>,
+    /// Where the fragment-length distribution comes from when quantifying a RAD
+    /// (`--rad` only) [default: baked].
+    ///
+    /// salmon's RAD writer always bakes its fragment-length distribution into
+    /// the header, so by default a requant reproduces the writing run exactly
+    /// and `--fldMean`/`--fldSD` have no effect. Use `derive` to re-derive the
+    /// distribution from the RAD's own fragment lengths, or `prior` to use
+    /// `--fldMean`/`--fldSD` alone — `prior` is the setting that makes a
+    /// fragment-length sensitivity analysis actually vary anything.
+    #[arg(long = "fldPolicy", value_enum, default_value_t = FldPolicyArg::Baked)]
+    fld_policy: FldPolicyArg,
     /// Online-phase forgetting factor in (0.5, 1.0].
     #[arg(short = 'f', long = "forgettingFactor", default_value_t = 0.65)]
     forgetting_factor: f64,
@@ -1179,6 +1234,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             "alignment mode (-a)",
             "the input alignments already are the per-mapping records",
         );
+        warn_unsupported_fld_policy(args.fld_policy, "alignment mode (-a)");
         let mut opts = AlignQuantOptions::new(bam, args.output);
         opts.lib_type = args.lib_type;
         opts.em.use_vbem = use_vbem;
@@ -1195,9 +1251,9 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.em.per_nucleotide_prior = args.per_nucleotide_prior;
         opts.em.accel = args.em_accel.into();
         opts.sig_digits = args.sig_digits;
-        opts.fld_mean = args.fld_mean;
-        opts.fld_sd = args.fld_sd;
-        opts.fld_max = args.fld_max;
+        opts.fld_mean = args.fld_mean.unwrap_or(DEFAULT_FLD_MEAN);
+        opts.fld_sd = args.fld_sd.unwrap_or(DEFAULT_FLD_SD);
+        opts.fld_max = args.fld_max.unwrap_or(DEFAULT_FLD_MAX);
         opts.forgetting_factor = args.forgetting_factor;
         opts.init_uniform = args.init_uniform;
         opts.bias_speed_samp = args.bias_speed_samp;
@@ -1361,9 +1417,17 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.em.per_nucleotide_prior = args.per_nucleotide_prior;
         opts.em.accel = args.em_accel.into();
         opts.sig_digits = args.sig_digits;
-        opts.fld_mean = args.fld_mean;
-        opts.fld_sd = args.fld_sd;
-        opts.fld_max = args.fld_max;
+        opts.fld_mean = args.fld_mean.unwrap_or(DEFAULT_FLD_MEAN);
+        opts.fld_sd = args.fld_sd.unwrap_or(DEFAULT_FLD_SD);
+        opts.fld_max = args.fld_max.unwrap_or(DEFAULT_FLD_MAX);
+        opts.fld_policy = args.fld_policy.into();
+        // Only what the user actually typed, so a plain requant is not warned
+        // about flags it inherited (see `warn_baked_fld_overrides`).
+        opts.explicit_fld_args = ExplicitFldArgs {
+            mean: args.fld_mean.is_some(),
+            sd: args.fld_sd.is_some(),
+            max: args.fld_max.is_some(),
+        };
         opts.skip_quant = args.skip_quant;
         opts.num_bootstraps = args.num_bootstraps;
         opts.num_gibbs_samples = args.num_gibbs_samples;
@@ -1494,9 +1558,10 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.em.accel = args.em_accel.into();
     opts.sig_digits = args.sig_digits;
     opts.max_read_occ = args.max_read_occ;
-    opts.fld_mean = args.fld_mean;
-    opts.fld_sd = args.fld_sd;
-    opts.fld_max = args.fld_max;
+    opts.fld_mean = args.fld_mean.unwrap_or(DEFAULT_FLD_MEAN);
+    opts.fld_sd = args.fld_sd.unwrap_or(DEFAULT_FLD_SD);
+    opts.fld_max = args.fld_max.unwrap_or(DEFAULT_FLD_MAX);
+    warn_unsupported_fld_policy(args.fld_policy, "reads mode");
     opts.forgetting_factor = args.forgetting_factor;
 
     // Deterministic mode: map once to an intermediate RAD, then quantify from it
@@ -1744,6 +1809,20 @@ fn run_debug_map(args: DebugMapArgs) -> Result<()> {
     Ok(())
 }
 
+/// `--fldPolicy` selects between a RAD's baked fragment-length distribution and
+/// recomputing one, so it means nothing where there is no RAD header to read.
+/// Say so rather than accepting it silently.
+fn warn_unsupported_fld_policy(policy: FldPolicyArg, mode: &str) {
+    if policy == FldPolicyArg::default() {
+        return;
+    }
+    tracing::warn!(
+        "--fldPolicy has no effect in {mode}: it chooses whether to use the \
+         fragment-length distribution baked into a RAD header, which only \
+         applies to --rad; ignoring it"
+    );
+}
+
 /// `--writeMappings`/`--writeSam`/`--writeBam` only apply to the read-mapping
 /// path. Rather than ignoring them silently in the alignment and RAD-input
 /// modes, say so — the repo's accept-and-warn policy for flags that are no-ops
@@ -1857,5 +1936,46 @@ mod tests {
                 "{sam_flag} + --bamCompressThreads"
             );
         }
+    }
+
+    /// #1062: salmon can only warn "your --fldMean was ignored" if it can tell a
+    /// supplied value from an inherited default, which is why these are `Option`
+    /// rather than `default_value_t`.
+    #[test]
+    fn fld_prior_args_distinguish_supplied_from_default() {
+        let bare = quant_args(&[]).unwrap();
+        assert_eq!(bare.fld_mean, None);
+        assert_eq!(bare.fld_sd, None);
+        assert_eq!(bare.fld_max, None);
+
+        let given = quant_args(&["--fldMean", "150", "--fldSD", "60"]).unwrap();
+        assert_eq!(given.fld_mean, Some(150.0));
+        assert_eq!(given.fld_sd, Some(60.0));
+        assert_eq!(given.fld_max, None, "--fldMax was not supplied");
+
+        // Supplying the default value explicitly still counts as supplying it:
+        // the user asked for it, so an ignored-value warning is warranted.
+        let explicit_default = quant_args(&["--fldMean", "250"]).unwrap();
+        assert_eq!(explicit_default.fld_mean, Some(DEFAULT_FLD_MEAN));
+    }
+
+    /// The policy must default to `baked` so an ordinary requant keeps
+    /// reproducing the run that wrote the RAD.
+    #[test]
+    fn fld_policy_defaults_to_baked_and_parses_all_variants() {
+        assert_eq!(quant_args(&[]).unwrap().fld_policy, FldPolicyArg::Baked);
+        for (arg, expected) in [
+            ("baked", FldPolicyArg::Baked),
+            ("derive", FldPolicyArg::Derive),
+            ("prior", FldPolicyArg::Prior),
+        ] {
+            let parsed = quant_args(&["--fldPolicy", arg]).unwrap().fld_policy;
+            assert_eq!(parsed, expected, "--fldPolicy {arg}");
+            assert_eq!(FldPolicy::from(parsed), FldPolicy::from(expected));
+        }
+        assert!(
+            quant_args(&["--fldPolicy", "bogus"]).map(|_| ()).is_err(),
+            "unknown policies must be rejected"
+        );
     }
 }

--- a/crates/salmon-model/src/fld.rs
+++ b/crates/salmon-model/src/fld.rs
@@ -579,6 +579,55 @@ impl DiscreteFld {
     }
 }
 
+/// Where a run's fragment-length distribution came from, reported as
+/// `frag_length_source` in `aux_info/meta_info.json`.
+///
+/// `--fldMean`/`--fldSD` are priors, so which of these applies decides whether
+/// they influenced the result at all: they fully determine [`Self::Prior`], seed
+/// [`Self::Reads`]/[`Self::Alignments`]/[`Self::RadDerived`] with weight 1
+/// against the observations, and are not consulted at all for the two baked
+/// variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FragLengthSource {
+    /// Trained during the read-mapping pass (reads mode).
+    Reads,
+    /// Derived from the input alignments (alignment mode, `-a`).
+    Alignments,
+    /// Read from the RAD header, where it was observed by the paired-end run
+    /// that wrote the file.
+    RadBaked,
+    /// Read from the RAD header, but written by a *single-end* run. No fragment
+    /// lengths existed to observe, so the baked distribution is that run's
+    /// `--fldMean`/`--fldSD` prior rather than an empirical distribution.
+    RadBakedPrior,
+    /// Derived at read time from this RAD's uniquely-mapped proper pairs
+    /// (a piscem RAD, or `--fldPolicy derive`).
+    RadDerived,
+    /// The `--fldMean`/`--fldSD` prior alone, with no observations folded in.
+    Prior,
+}
+
+impl FragLengthSource {
+    /// The `meta_info.json` spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Reads => "reads",
+            Self::Alignments => "alignments",
+            Self::RadBaked => "rad_baked",
+            Self::RadBakedPrior => "rad_baked_prior",
+            Self::RadDerived => "rad_derived",
+            Self::Prior => "prior",
+        }
+    }
+
+    /// Whether `--fldMean`/`--fldSD`/`--fldMax` were consulted at all. False
+    /// only for the baked variants, which take the distribution verbatim from
+    /// the RAD header.
+    pub fn uses_fld_prior_args(self) -> bool {
+        !matches!(self, Self::RadBaked | Self::RadBakedPrior)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/salmon-model/src/lib.rs
+++ b/crates/salmon-model/src/lib.rs
@@ -35,6 +35,7 @@ pub mod spline;
 pub use bias::{
     build_expected_pos, corrected_effective_length_full, positional_factor, BiasInputs,
 };
+pub use fld::FragLengthSource;
 pub use fld::{
     ambig_frag_log_prob, smoothed_effective_length, DiscreteFld, FragmentLengthDistribution,
 };

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -274,6 +274,11 @@ pub struct QuantResult {
     /// per-fragment candidate alignments dropped for scoring below threshold,
     /// summed over fragments that nonetheless mapped
     pub num_alignments_below_threshold_for_mapped_fragments_vm: u64,
+    /// where the fragment-length distribution came from; reported as
+    /// `frag_length_source` in `meta_info.json`. Always
+    /// [`FragLengthSource::Reads`] here — reads mode trains the FLD during the
+    /// mapping pass — but carried so every mode reports the field.
+    pub frag_len_source: salmon_model::FragLengthSource,
     pub frag_len_mean: f64,
     /// standard deviation of the observed fragment-length distribution
     pub frag_len_sd: f64,
@@ -1069,6 +1074,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         num_fragments_filtered_vm: num_frags_filtered_vm.load(Ordering::Relaxed),
         num_alignments_below_threshold_for_mapped_fragments_vm: num_below_threshold_vm
             .load(Ordering::Relaxed),
+        frag_len_source: salmon_model::FragLengthSource::Reads,
         frag_len_mean: fld.mean(),
         frag_len_sd: fld.sd(),
         length_classes: salmon_model::compute_length_quantiles(

--- a/crates/salmon-quant/src/output.rs
+++ b/crates/salmon-quant/src/output.rs
@@ -283,6 +283,9 @@ struct MetaInfo {
     frag_dist_length: usize,
     frag_length_mean: f64,
     frag_length_sd: f64,
+    /// provenance of the two fields above: observed data or the
+    /// `--fldMean`/`--fldSD` prior (see `FragLengthSource`)
+    frag_length_source: &'static str,
     seq_bias_correct: bool,
     gc_bias_correct: bool,
     pos_bias_correct: bool,
@@ -360,6 +363,7 @@ fn write_meta_info(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Resul
         frag_dist_length: res.frag_len_dist.len(),
         frag_length_mean: res.frag_len_mean,
         frag_length_sd: res.frag_len_sd,
+        frag_length_source: res.frag_len_source.as_str(),
         seq_bias_correct: opts.seq_bias,
         gc_bias_correct: opts.gc_bias,
         pos_bias_correct: opts.pos_bias,

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -74,7 +74,8 @@ misbehaves.
 | Flag | Status | Notes |
 |------|--------|-------|
 | `--seqBias`, `--gcBias`, `--posBias` | ✅ | |
-| `--fldMean`, `--fldSD`, `--fldMax` | ✅ | |
+| `--fldMean`, `--fldSD`, `--fldMax` | ✅ | Priors. With `--rad` they are ignored unless `--fldPolicy` says otherwise (a salmon RAD bakes its FLD); salmon warns when an explicitly-supplied value is ignored. |
+| `--fldPolicy` | ✅ | `baked` (default) / `derive` / `prior`: where a RAD requant's fragment-length distribution comes from. Rust-port feature; not in this salmon build. |
 | `-f/--forgettingFactor` | ✅ | |
 | `--numAuxModelSamples` | ✅ | Online-phase model-training window. |
 | `--biasSpeedSamp` | ✅ | GC convolution fragment-length stride. |

--- a/website/src/content/docs/guides/rad-and-determinism.mdx
+++ b/website/src/content/docs/guides/rad-and-determinism.mdx
@@ -50,6 +50,50 @@ distribution, then quantifies). Bias correction (`--seqBias`, `--gcBias`,
 `--posBias`), `--numBootstraps`, `--numGibbsSamples`, and `-g/--geneMap` all work
 in RAD mode.
 
+### Fragment-length distribution (`--fldPolicy`)
+
+salmon's RAD writer always bakes its fragment-length distribution into the
+header — including under `--skipQuant`, which suppresses only the baked
+abundances. On read-back that distribution takes precedence, which is what makes
+a requant reproduce the writing run exactly.
+
+The consequence is that **`--fldMean`/`--fldSD`/`--fldMax` have no effect on a
+salmon-produced RAD by default.** They are priors, and a baked distribution
+replaces the prior outright rather than being blended with it. salmon warns when
+you supply one of these flags and a baked distribution supersedes it; a run that
+inherits their defaults stays quiet.
+
+`--fldPolicy` chooses where the distribution comes from:
+
+| Policy | Behavior |
+| --- | --- |
+| `baked` *(default)* | Use the RAD's baked distribution when present. Exact parity with the run that wrote the file. |
+| `derive` | Ignore the baked distribution; rebuild it from this RAD's own uniquely-mapped proper pairs, seeded by `--fldMean`/`--fldSD`. This is what a piscem RAD does automatically. |
+| `prior` | Ignore both the baked distribution and the RAD's fragment lengths; `--fldMean`/`--fldSD` alone determine it. |
+
+Use `prior` for a fragment-length sensitivity analysis — it is the only setting
+under which varying `--fldMean` changes the result:
+
+```sh
+for m in 150 250 350; do
+  salmon quant --rad mappings.rad -t transcripts.fa -l A \
+    --fldPolicy prior --fldMean $m --fldSD 25 -o out_fld_$m
+done
+```
+
+`aux_info/meta_info.json` records which path a run took in `frag_length_source`
+(`rad_baked`, `rad_derived`, or `prior`), so the provenance stays auditable after
+the fact.
+
+#### Single-end RADs
+
+A single-end run has no fragment lengths to measure, so the distribution it bakes
+is simply its own `--fldMean`/`--fldSD` prior. Reading such a RAD back therefore
+inherits *the writing run's* prior, and salmon reports `frag_length_source` as
+`rad_baked_prior` to distinguish this from an observed distribution. If you want
+your own values to apply, pass `--fldPolicy prior` (`derive` has nothing to
+derive from here).
+
 ### piscem interoperability
 
 A RAD produced by `piscem map-bulk` quantifies directly:

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -62,6 +62,7 @@ Quantify from FASTQ reads (reads mode, `-i`), from a transcriptome BAM
 | `--genome <FASTA>` | Genome FASTA (genome mode); enables bias correction by reconstructing transcript sequences from exon slices. |
 | `--juncMissDiscount <f>` | Penalty for an unannotated splice junction in genome projection (default `1.0` = none). |
 | `--rad <RAD>` | RAD mode: quantify a RAD file of mappings (salmon `--writeRad` **or** piscem `map-bulk`/sketch output) directly. No `-i` needed — reference names travel in the RAD header. See [RAD I/O & deterministic quantification](../../guides/rad-and-determinism/). |
+| `--fldPolicy <baked\|derive\|prior>` | `--rad` only: where the fragment-length distribution comes from. `baked` (default) reproduces the run that wrote the RAD; `derive` rebuilds it from the RAD; `prior` puts `--fldMean`/`--fldSD` in sole control. See [RAD I/O & determinism](../../guides/rad-and-determinism/#fragment-length-distribution---fldpolicy). |
 | `-t, --targets <FASTA>` | Transcriptome FASTA (alignment mode). Enables the error model in ordinary alignment mode; supplies reference sequences for bias correction and (with `--errorModel`) the deterministic error model. |
 | `-l, --libType <TYPE>` | Library type (e.g. `IU`, `ISR`, `A` for auto). Default `A`. See [library types](../../guides/library-types/). |
 | `-1/-2, --mates1/2 <FASTQ>…` | Paired-end read files. |

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -81,7 +81,8 @@ Pretty-printed JSON. tximport keys off several fields (`num_bootstraps`,
 | `num_libraries` | int | currently `1` |
 | `library_types` | string[] | detected/declared library type(s) |
 | `frag_dist_length` | int | number of FLD length bins |
-| `frag_length_mean` / `frag_length_sd` | float | observed fragment length stats |
+| `frag_length_mean` / `frag_length_sd` | float | fragment length stats |
+| `frag_length_source` | string | where the distribution above came from: `reads`, `alignments`, `rad_baked`, `rad_baked_prior`, `rad_derived`, or `prior` |
 | `seq_bias_correct` / `gc_bias_correct` / `pos_bias_correct` | bool | bias correction enabled (`--seqBias` / `--gcBias` / `--posBias`) |
 | `mapping_type` | string | `"mapping"` (SA) or `"pseudo"` (sketch) |
 | `keep_duplicates` | bool | index built with `--keepDuplicates` |


### PR DESCRIPTION
Closes #1062.

## The problem

salmon's RAD writer bakes its fragment-length distribution into the header, and the reader prefers it over `--fldMean`/`--fldSD`/`--fldMax`. Preferring it is correct — it reproduces the writing run exactly — but salmon accepted those flags and then provably ignored them. A fragment-length sensitivity analysis could run to completion having perturbed nothing, every output byte-identical, with nothing in the logs or `meta_info.json` explaining why.

Thanks to @Hugo-Polloli for the report, which pinned the precedence to the exact lines in `rad.rs` and came with a clean reproducer.

## Two corrections to the report's scope

**It is broader than reported.** The comment at `rad.rs` claiming `--skipQuant` RADs derive their FLD is wrong: `salmon-quant` bakes the FLD *unconditionally* (`--skipQuant` suppresses only the baked abundances). So this affects **every salmon-written RAD**, and there was no escape hatch at all — not even the `--skipQuant` one the comment implies. Confirmed:

```
baked.rad   (full quant)  -> using fragment-length distribution baked in the RAD header
unbaked.rad (--skipQuant) -> using fragment-length distribution baked in the RAD header
```

**It is narrower in one respect.** `--fldMean`/`--fldSD` are *not* inert on a piscem RAD: `DiscreteFld::finish` seeds the derived distribution with them at weight 1, so they are a genuine (if easily dominated) prior there. That path must not warn.

I also checked the other baked header values — library format is consulted only under `-l A` (an explicit `-l` wins), and score-kind and abundances have no shadowing user flag. The FLD was the only baked value that superseded explicit user options.

## Single-end RADs are a sharper case

A single-end run has no fragment lengths to observe, so what it bakes is simply its own `--fldMean`/`--fldSD` prior. Reading such a RAD back silently inherits *the writing run's* prior as though it were empirical:

| written with | read back as |
| --- | --- |
| `--fldMean 150 --fldSD 20` | mean=150.0000 sd=20.0021 |
| `--fldMean 400 --fldSD 80` | mean=400.0001 sd=80.0002 |

The reader can detect this from the baked library format's read type — no format change needed — so it reports `frag_length_source: rad_baked_prior` and words the warning accordingly.

## What this adds

**`--fldPolicy {baked,derive,prior}`**, default `baked` — behavior unchanged.

| Policy | Behavior |
| --- | --- |
| `baked` *(default)* | Use the RAD's baked distribution. Exact parity with the writing run. |
| `derive` | Ignore it; rebuild from this RAD's own uniquely-mapped proper pairs. |
| `prior` | Ignore both; `--fldMean`/`--fldSD` alone determine it. |

`derive` and `prior` were already-implemented branches, so this mostly exposes existing paths.

**A warning, not an error**, when a baked distribution supersedes explicitly-supplied FLD flags:

```
WARN --fldMean/--fldSD had no effect: this RAD carries a baked fragment-length
distribution (mean=178.056, sd=24.076), which takes precedence. That distribution
was observed by the run that wrote the RAD. Pass `--fldPolicy prior` to use your
values instead, or `--fldPolicy derive` to re-derive the distribution from this
RAD's own fragment lengths.
```

`derive` is offered only for paired-end RADs — single-end data has nothing to re-derive from, so suggesting it would route the user back to the prior by a longer path. Detecting "explicitly supplied" means the three FLD flags become `Option` with defaults applied in `main.rs`, so a run that merely inherits them is not nagged.

**`frag_length_source` in `meta_info.json`**, across every mode, so provenance stays auditable after the fact:

```
reads       -> reads          rad baked  -> rad_baked
align -a    -> alignments     rad derive -> rad_derived
                              rad prior  -> prior
```

`--fldPolicy` warns and is ignored in reads and `-a` modes, which have no RAD header to read.

## Verification

The issue's exact reproducer now warns on both runs and reports `source=rad_baked`. Sensitivity analysis works under the new policy:

```
--fldPolicy prior --fldMean 150 -> mean=150.000 source=prior
--fldPolicy prior --fldMean 400 -> mean=400.000 source=prior
quant.sf DIFFERS
```

Tests: 4 new RAD-input tests (provenance, `derive` ignores the baked mean of ~500 in favor of the records' implied 200, `prior` puts the supplied values in control, and differing priors produce differing effective lengths only under `prior`), plus unit tests for the explicit-arg tracking and CLI parsing. `cargo test --workspace --release` — 27 test binaries, zero failures. `cargo fmt --check` clean; clippy clean on the touched crates (the three remaining `salmon-model` warnings are pre-existing on `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5jNNvJnFRiu2eC1JZAu2T