### PR TITLE
chore(deps): migrate to rand 0.10 / rand_pcg 0.10 / rand_distr 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,17 +1156,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -1813,7 +1802,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.10.2",
+ "rand",
  "simba",
  "typenum",
 ]
@@ -2152,7 +2141,7 @@ dependencies = [
  "cfg-if",
  "ensure_simd",
  "mem_dbg",
- "rand 0.10.2",
+ "rand",
  "wide",
 ]
 
@@ -2347,15 +2336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,17 +2426,6 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -2467,23 +2436,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -2493,21 +2449,21 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.8.7",
+ "rand",
 ]
 
 [[package]]
 name = "rand_pcg"
-version = "0.3.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2765,7 +2721,7 @@ name = "salmon-infer"
 version = "2.3.4"
 dependencies = [
  "criterion 0.8.2",
- "rand 0.8.7",
+ "rand",
  "rand_distr",
  "rand_pcg",
  "rayon",
@@ -3092,7 +3048,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.10.2",
+ "rand",
  "thiserror 2.0.19",
 ]
 
@@ -3161,7 +3117,7 @@ dependencies = [
  "log",
  "mem_dbg",
  "num-primitive",
- "rand 0.10.2",
+ "rand",
  "rayon",
  "rdst",
  "succinctly",
@@ -3561,12 +3517,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,9 @@ ahash = "0.8"
 # numerics
 statrs = "0.19"
 # rng (PCG, matching salmon's pcg usage)
-rand = "0.8"
-rand_pcg = "0.3"
-rand_distr = "0.4"
+rand = "0.10"
+rand_pcg = "0.10"
+rand_distr = "0.6"
 # hashing
 xxhash-rust = { version = "0.8", features = ["xxh3", "xxh64"] }
 # compression


### PR DESCRIPTION
The last deferred dependency group. **Stacked on #1068** — merge that first, then this retargets to `develop` cleanly.

```
rand        0.8 -> 0.10
rand_pcg    0.3 -> 0.10
rand_distr  0.4 -> 0.6
```

**No code changes.** The three move together because `rand_distr` 0.6 needs `rand_core` 0.10; bumping `rand_pcg`/`rand_distr` alone leaves `Rng` coming from rand_core 0.6 and fails to compile, which is what made this look invasive when it was first deferred. With all three aligned, `Pcg64Mcg::seed_from_u64` and `Distribution::sample` work exactly as written.

Collapses `rand` from three versions in the tree (0.8.7, 0.9.5, 0.10.2) to one.

## Output is unchanged, including the RNG-backed paths

| output | result |
|---|---|
| `quant.sf` (point estimate) | **byte-identical** |
| `bootstraps.gz` | **byte-identical** |
| Gibbs samples | **identical to ~1 ULP** |

Seeding survives because `rand_core`'s `seed_from_u64` is byte-identical between 0.6 and 0.10 — same PCG32 expansion, same `MUL`/`INC` constants, same output function — so a given seed still produces the same PCG stream.

## The Gibbs result needs care, because a byte comparison misreads it

The Gibbs files *do* differ, which initially looked like `rand_distr`'s `Gamma` sampler drawing a different stream — and I reported it that way before measuring. Measuring the magnitude shows otherwise, over 256 samples × 15 transcripts:

```
max |Δ|          = 1.8e-12
max relative Δ   = 7.4e-16          (~1 ULP for f64)
differing values = 1730 / 3840      (last bit or two)
```

A different random stream would give O(1) differences, not O(1e-16). What changed is arithmetic ordering inside the sampler, not the draws.

Posterior statistics are correspondingly unchanged — per-transcript means and SDs agree to displayed precision:

```
transcript         mean(old)   mean(new)  Δmean/sd    sd(old)    sd(new)
NM_022658            4872.56     4872.56     0.000      50.31      50.31
NM_174914            1370.50     1370.50     0.000      62.92      62.92
NM_173860             961.02      961.02     0.000      30.42      30.42
...  (all 15 transcripts: Δmean/sd = 0.000)
```

against a Monte-Carlo standard error of 0.062 SD at n=256.

**So no release-note caveat is needed** — the exact-reproducibility property of bootstrap and Gibbs output is preserved, not merely its statistical properties.

## Validation

`cargo test --workspace --release`: 27 binaries, 0 failures. `cargo fmt --check` clean. Clippy at the 9 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5jNNvJnFRiu2eC1JZAu2T