### PR TITLE
fix(rad): drain the queue before workers exit (silent zero/partial counts)

### DIFF
--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -533,21 +533,31 @@ where
         for _ in 0..nthreads.max(1) {
             let queue = queue.clone();
             let done = done.clone();
-            s.spawn(move || loop {
-                if let Some(mc) = queue.pop() {
-                    for chunk in mc.iter() {
-                        for rec in &chunk.reads {
-                            let assigned = process_rad_fragment(&rec.placements(), cfg);
-                            num_processed.fetch_add(1, Ordering::Relaxed);
-                            if assigned {
-                                num_mapped.fetch_add(1, Ordering::Relaxed);
+            s.spawn(move || {
+                // Set once `done` is observed; see the drain comment below.
+                let mut draining = false;
+                loop {
+                    if let Some(mc) = queue.pop() {
+                        for chunk in mc.iter() {
+                            for rec in &chunk.reads {
+                                let assigned = process_rad_fragment(&rec.placements(), cfg);
+                                num_processed.fetch_add(1, Ordering::Relaxed);
+                                if assigned {
+                                    num_mapped.fetch_add(1, Ordering::Relaxed);
+                                }
                             }
                         }
+                    } else if draining {
+                        break;
+                    } else if done.load(Ordering::Acquire) {
+                        // `done` observed after an empty pop. The producer pushes
+                        // every meta-chunk before storing the flag, so anything it
+                        // enqueued between our failed pop and that store is still
+                        // waiting. Sweep once more before exiting.
+                        draining = true;
+                    } else {
+                        std::hint::spin_loop();
                     }
-                } else if done.load(Ordering::Acquire) {
-                    break;
-                } else {
-                    std::hint::spin_loop();
                 }
             });
         }
@@ -599,52 +609,62 @@ where
             let queue = queue.clone();
             let done = done.clone();
             let acc = &acc;
-            s.spawn(move || loop {
-                if let Some(mc) = queue.pop() {
-                    for chunk in mc.iter() {
-                        for rec in &chunk.reads {
-                            let pls = rec.placements();
-                            // Naive (kallisto-style) eq for the rough seed EM: the
-                            // compatible transcripts, orientation-tagged (so library-
-                            // incompatible placements can be dropped once the lib
-                            // type is known), no FLD/score weighting. Built in the
-                            // same read as the FLD counts; order-independent.
-                            if let Some(nb) = naive_eq {
-                                let sig: Vec<NaivePlacement> = pls
-                                    .iter()
-                                    .map(|p| {
-                                        let (obs, is_fw, status) = rad_frag_format(p);
-                                        NaivePlacement {
-                                            tid: p.tid,
-                                            fmt_id: obs
-                                                .map(|f| f.format_id())
-                                                .unwrap_or(NAIVE_NO_FMT),
-                                            is_fw,
-                                            status,
-                                        }
-                                    })
-                                    .collect();
-                                nb.add(sig);
+            s.spawn(move || {
+                // Set once `done` is observed; see the drain comment below.
+                let mut draining = false;
+                loop {
+                    if let Some(mc) = queue.pop() {
+                        for chunk in mc.iter() {
+                            for rec in &chunk.reads {
+                                let pls = rec.placements();
+                                // Naive (kallisto-style) eq for the rough seed EM: the
+                                // compatible transcripts, orientation-tagged (so library-
+                                // incompatible placements can be dropped once the lib
+                                // type is known), no FLD/score weighting. Built in the
+                                // same read as the FLD counts; order-independent.
+                                if let Some(nb) = naive_eq {
+                                    let sig: Vec<NaivePlacement> = pls
+                                        .iter()
+                                        .map(|p| {
+                                            let (obs, is_fw, status) = rad_frag_format(p);
+                                            NaivePlacement {
+                                                tid: p.tid,
+                                                fmt_id: obs
+                                                    .map(|f| f.format_id())
+                                                    .unwrap_or(NAIVE_NO_FMT),
+                                                is_fw,
+                                                status,
+                                            }
+                                        })
+                                        .collect();
+                                    nb.add(sig);
+                                }
+                                // "unique" = exactly one placement; only proper pairs
+                                // carry a meaningful fragment length.
+                                if pls.len() != 1 {
+                                    continue;
+                                }
+                                let p = &pls[0];
+                                if p.status != MateStatus::PairedEndPaired
+                                    || p.frag_len == salmon_rad::FRAG_LEN_UNPAIRED
+                                    || p.frag_len == 0
+                                {
+                                    continue;
+                                }
+                                acc.add(p.frag_len as usize, p.is_fw, p.mate_fw);
                             }
-                            // "unique" = exactly one placement; only proper pairs
-                            // carry a meaningful fragment length.
-                            if pls.len() != 1 {
-                                continue;
-                            }
-                            let p = &pls[0];
-                            if p.status != MateStatus::PairedEndPaired
-                                || p.frag_len == salmon_rad::FRAG_LEN_UNPAIRED
-                                || p.frag_len == 0
-                            {
-                                continue;
-                            }
-                            acc.add(p.frag_len as usize, p.is_fw, p.mate_fw);
                         }
+                    } else if draining {
+                        break;
+                    } else if done.load(Ordering::Acquire) {
+                        // `done` observed after an empty pop. The producer pushes
+                        // every meta-chunk before storing the flag, so anything it
+                        // enqueued between our failed pop and that store is still
+                        // waiting. Sweep once more before exiting.
+                        draining = true;
+                    } else {
+                        std::hint::spin_loop();
                     }
-                } else if done.load(Ordering::Acquire) {
-                    break;
-                } else {
-                    std::hint::spin_loop();
                 }
             });
         }
@@ -952,6 +972,8 @@ where
             let merged = &merged;
             s.spawn(move || {
                 let mut local = BiasLocal::new(seq, gc, pos, cond_gc_bins, gc_bins);
+                // Set once `done` is observed; see the drain comment below.
+                let mut draining = false;
                 loop {
                     if let Some(mc) = queue.pop() {
                         for chunk in mc.iter() {
@@ -959,8 +981,15 @@ where
                                 collect_bias_fragment(&rec.placements(), cfg, &mut local);
                             }
                         }
-                    } else if done.load(Ordering::Acquire) {
+                    } else if draining {
                         break;
+                    } else if done.load(Ordering::Acquire) {
+                        // `done` observed after an empty pop. The producer
+                        // pushes every meta-chunk before storing the flag, so
+                        // anything enqueued between our failed pop and that
+                        // store is still waiting. Sweep once more before
+                        // exiting.
+                        draining = true;
                     } else {
                         std::hint::spin_loop();
                     }
@@ -1020,6 +1049,8 @@ where
             let merged = &merged;
             s.spawn(move || {
                 let mut local = BiasLocal::new(seq, gc, pos, cond_gc_bins, gc_bins);
+                // Set once `done` is observed; see the drain comment below.
+                let mut draining = false;
                 loop {
                     if let Some(mc) = queue.pop() {
                         for chunk in mc.iter() {
@@ -1033,8 +1064,15 @@ where
                                 collect_bias_fragment(&pls, bias_cfg, &mut local);
                             }
                         }
-                    } else if done.load(Ordering::Acquire) {
+                    } else if draining {
                         break;
+                    } else if done.load(Ordering::Acquire) {
+                        // `done` observed after an empty pop. The producer
+                        // pushes every meta-chunk before storing the flag, so
+                        // anything enqueued between our failed pop and that
+                        // store is still waiting. Sweep once more before
+                        // exiting.
+                        draining = true;
                     } else {
                         std::hint::spin_loop();
                     }

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -323,6 +323,77 @@ fn piscem_bulk_input_quantifies() {
     );
 }
 
+/// Regression test for the worker-drain race: a `quantify_rad` run must never
+/// silently return zero (or partial) counts.
+///
+/// `thread_count_invariant` cannot catch this. It asserts only that the three
+/// runs *agree*, so a fault that hits every run looks like a pass — with the
+/// race window forced open, all three returned `processed=0` and the test went
+/// green. This test asserts the absolute total instead, so a lost chunk fails
+/// regardless of how many runs it affects.
+///
+/// The race: libradicl's producer pushes every meta-chunk and only then sets
+/// `done`. A worker whose `pop()` came up empty just before that push would
+/// observe `done` and break, abandoning the queue.
+#[test]
+fn rad_quant_never_loses_fragments() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("maps.rad");
+    let names = ["t0", "t1", "t2"];
+    let lens = [1000u32, 1000, 1000];
+
+    // 487 fragments across enough chunks that the reader has real work to hand
+    // out (write_rad flushes one chunk per 64 records).
+    let mut frags: Vec<Vec<(u32, Option<u16>, i32)>> = Vec::new();
+    for (tid, n) in [(0u32, 137), (1, 211), (2, 89)] {
+        for _ in 0..n {
+            frags.push(vec![(tid, Some(200), 0)]);
+        }
+    }
+    for _ in 0..50 {
+        frags.push(vec![(0, Some(200), 0), (2, Some(200), 0)]);
+    }
+    let total = frags.len() as u64;
+    write_rad(&rad, &names, &lens, RadProfile::Sketch, &frags, None);
+
+    // A single worker is the worst case: with no sibling to drain the queue,
+    // one lost race loses the whole file.
+    for threads in [1usize, 1, 2, 8] {
+        let out = tmp.path().join(format!("q{threads}_{}", rand_suffix()));
+        std::fs::create_dir_all(&out).unwrap();
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .unwrap();
+        let res = pool.install(|| quantify_rad(&opts_for(&out), &rad).unwrap());
+
+        assert_eq!(
+            res.num_processed, total,
+            "-p {threads}: reader dropped fragments ({} of {total})",
+            res.num_processed
+        );
+        assert_eq!(res.num_mapped, total, "-p {threads}: mapped-count mismatch");
+        assert!(
+            res.num_eq_classes > 0,
+            "-p {threads}: no equivalence classes were built"
+        );
+        let sum: f64 = res.counts.iter().sum();
+        assert!(
+            (sum - total as f64).abs() < 1e-6,
+            "-p {threads}: mass not conserved: {sum} vs {total}"
+        );
+    }
+}
+
+/// Distinct output directories across loop iterations that reuse a thread count.
+fn rand_suffix() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
 #[test]
 fn thread_count_invariant() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
`salmon quant --rad` and alignment mode could **silently return zero or partial counts** — an empty `quant.sf`, no error, no warning.

Found while chasing the intermittent aarch64 failure of `rad_input::thread_count_invariant`.

## The race

libradicl's producer pushes **every** meta-chunk into the queue and only then sets `done`. Salmon's workers exited on:

```rust
if let Some(mc) = queue.pop() { … }
else if done.load(Ordering::Acquire) { break }   // ← exits with a full queue
```

A worker whose `pop()` comes up empty in the window *just before* the producer pushes will then observe `done == true` and break, abandoning every chunk. Four worker loops in `rad.rs` had this shape; each now takes one more sweep after first observing `done`.

## Demonstrated, not inferred

Forcing the window open (150 ms sleep between the empty `pop()` and the `done` check), on x86_64, deterministically:

| | `num_processed` | `num_mapped` | `eq_classes` | counts |
|---|---|---|---|---|
| **unfixed** | 0 | 0 | 0 | `[0.0, 0.0, 0.0]` |
| **fixed** | 487 | 487 | 4 | `[167.31, 211.0, 108.69]` |

## It is not a thread-count bug

Despite where the flaky test pointed. The instrumented CI reproduction:

```
[t=1 ] processed=487 mapped=487 eq_classes=4 em_iters=50    counts=[167.31, 211.0, 108.69]
[t=8 ] processed=487 mapped=487 eq_classes=4 em_iters=50    counts=[167.31, 211.0, 108.69]
[t=1b] processed=0   mapped=0   eq_classes=0 em_iters=10000 counts=[0.0, 0.0, 0.0]
```

`t=1` and `t=8` **agree perfectly**; the failure is `t=1b`, the *repeat* of the 1-thread run. Any worker can lose the race — a lone worker just has nobody to cover for it.

This is also distinct from #1056, which addresses f64 non-associativity in the M-step reduction. That produces last-bit differences; it cannot turn 487 into 0.

## The existing test could not catch this

`thread_count_invariant` asserts only that three runs **agree**. With the window forced open, all three returned zero and **the test passed**. The CI flakiness that surfaced this was the *lucky* partial case.

So the new test asserts absolute correctness — `num_processed == 487`, mass conserved, at `-p` 1/1/2/8 — and I verified it fails on unfixed code with the race forced:

```
assertion `left == right` failed: -p 1: reader dropped fragments (0 of 487)
```

A regression test that cannot fail proves nothing.

## Upstream is not at fault

| | verdict |
|---|---|
| libradicl library | ✅ never pops from the queue itself — no instance of this |
| libradicl examples (×2) | ❌ both use the racy shape |
| alevin-fry (×4 sites) | ✅ all guard with `\|\| !q.is_empty()` |
| salmon (×4 sites) | ❌ this PR |

Reporting the examples upstream separately, with a proposal for a drain-safe iterator so consumers stop hand-rolling the contract.

## Rarity

~1 in 600 whole-binary runs under CI stress on aarch64; never observed on x86_64 outside forced conditions; most likely at low thread counts. Worth noting in the 2.4.1 release notes given the failure is silent.

## Validation

`cargo test --workspace --release`: 27 binaries, 0 failures. `cargo fmt --check` clean. Clippy at the 9 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5jNNvJnFRiu2eC1JZAu2T