### PR TITLE
feat(quant): decode gzipped FASTQ in parallel with rapidgzip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,6 +1650,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50474818739ccab820cd57bca432d6b02d090b47f9e85501d963cd05851f82eb"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidgzip-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8915419d173342f3f9f104024f8f67a378944fdef494958d2ebdd756fe4e8a"
+dependencies = [
+ "crossbeam-deque",
+ "libz-rs-sys",
+]
+
+[[package]]
 name = "rapidhash"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +2789,7 @@ dependencies = [
  "noodles-sam",
  "paraseq",
  "piscem-rs",
+ "rapidgzip-core",
  "rayon",
  "salmon-core",
  "salmon-eqclass",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ xxhash-rust = { version = "0.8", features = ["xxh3", "xxh64"] }
 # compression
 flate2 = "1"
 zstd = "0.13"
+# parallel gzip decoding for FASTQ input (COMBINE-lab port of rapidgzip)
+rapidgzip-core = "0.1"
 # logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -484,6 +484,20 @@ struct QuantArgs {
         conflicts_with = "write_mappings"
     )]
     bam_compress_threads: Option<std::num::NonZeroUsize>,
+    /// Maximum worker threads used to decompress gzipped FASTQ input, which
+    /// salmon decodes in parallel with rapidgzip. The budget covers the whole
+    /// run and is split across the input files, since they are read
+    /// concurrently. The default derives from --threads, bounded by the cores
+    /// this process can run on and capped at 8: one worker already decodes far
+    /// more FASTQ than one mapping thread consumes, so beyond that the cores do
+    /// more good mapping reads. An explicit value is used as given.
+    ///
+    /// Pass 0 to fall back to the single-threaded gzip decoder. Uncompressed
+    /// FASTQ, and gzipped input that is not a regular file (process
+    /// substitution, a FIFO, /dev/stdin), are unaffected: the parallel decoder
+    /// needs positional access to a stable file.
+    #[arg(long = "gzipDecompressThreads")]
+    gzip_decompress_threads: Option<usize>,
     /// Write per-fragment mappings to a RAD file at this path. Sketch or
     /// selective-alignment profile is chosen automatically from the mapping
     /// mode. Quantification still runs; add --skipQuant to map only. The file is
@@ -1487,6 +1501,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.write_mappings = args.write_mappings;
     opts.write_bam = args.write_bam;
     opts.bam_compress_threads = args.bam_compress_threads;
+    opts.gzip_decompress_threads = args.gzip_decompress_threads;
     opts.write_rad = args.write_rad;
     opts.seq_bias = args.seq_bias;
     opts.gc_bias = args.gc_bias;
@@ -1913,6 +1928,25 @@ mod tests {
             .map(|_| ())
             .expect_err("0 compression workers is not a valid pool size");
         assert_eq!(zero.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    /// `--gzipDecompressThreads` is unset by default (the budget is derived
+    /// from `--threads`), and unlike `--bamCompressThreads` it accepts 0 —
+    /// that is the documented opt-out into the serial gzip decoder, not an
+    /// empty worker pool.
+    #[test]
+    fn gzip_decompress_threads_is_optional_and_accepts_zero() {
+        let derived = quant_args(&[]).unwrap();
+        assert_eq!(
+            derived.gzip_decompress_threads, None,
+            "unset must stay None so the derived default applies"
+        );
+
+        let explicit = quant_args(&["--gzipDecompressThreads", "4"]).unwrap();
+        assert_eq!(explicit.gzip_decompress_threads, Some(4));
+
+        let off = quant_args(&["--gzipDecompressThreads", "0"]).unwrap();
+        assert_eq!(off.gzip_decompress_threads, Some(0));
     }
 
     /// Without `--writeBam` there is nothing to compress, so the flag is a

--- a/crates/salmon-quant/Cargo.toml
+++ b/crates/salmon-quant/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 flate2 = { workspace = true }
+rapidgzip-core = { workspace = true }
 rayon = { workspace = true }
 crossbeam-channel = { workspace = true }
 noodles-bgzf = "0.49"

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -89,6 +89,13 @@ pub struct QuantOptions {
     /// compression just keeps up with record production; set it only to
     /// benchmark or to compensate for unusually slow/fast storage.
     pub bam_compress_threads: Option<std::num::NonZeroUsize>,
+    /// worker budget for the parallel gzip decoder used on `.gz` FASTQ input
+    /// (`--gzipDecompressThreads`). `None` derives it from `num_threads`
+    /// bounded by the available cores; `Some(0)` falls back to the serial
+    /// `flate2` decoder. The budget is a whole-run ceiling and is split across
+    /// the input files, which paraseq reads concurrently. See
+    /// [`gz_worker_budget`].
+    pub gzip_decompress_threads: Option<usize>,
     /// write per-fragment mappings to this RAD file (`--writeRad`); sketch or
     /// selective-alignment profile is chosen from `sketch`. Quantification still
     /// runs; combine with `skip_quant` to map only.
@@ -199,6 +206,7 @@ impl QuantOptions {
             write_mappings: None,
             write_bam: None,
             bam_compress_threads: None,
+            gzip_decompress_threads: None,
             write_rad: None,
             deterministic_fld: false,
             seq_bias: false,
@@ -591,9 +599,20 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             }
         );
         if opts.is_paired() {
-            run_paired(&opts.mates1, &opts.mates2, &mut proc, nthreads)?;
+            run_paired(
+                &opts.mates1,
+                &opts.mates2,
+                &mut proc,
+                nthreads,
+                opts.gzip_decompress_threads,
+            )?;
         } else {
-            run_single(&opts.unmated, &mut proc, nthreads)?;
+            run_single(
+                &opts.unmated,
+                &mut proc,
+                nthreads,
+                opts.gzip_decompress_threads,
+            )?;
         }
     }
     // `--deterministic`: replace the (untrained) online FLD with one built ONCE,
@@ -1177,21 +1196,99 @@ fn dump_eq_classes(
     Ok(())
 }
 
-/// Open a (optionally gzipped) read file as a boxed reader.
-fn open_reader(path: &Path) -> Result<Box<dyn std::io::Read + Send>> {
-    let f = std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
-    if path.extension().and_then(|e| e.to_str()) == Some("gz") {
-        Ok(Box::new(MultiGzDecoder::new(f)))
-    } else {
-        Ok(Box::new(f))
-    }
+/// Ceiling on the derived whole-run gzip worker budget.
+///
+/// rapidgzip creates workers lazily and retires them under consumer
+/// backpressure, so this is a cap and not an allocation, but there is no point
+/// raising it: one worker decodes far more FASTQ than one mapping thread
+/// consumes, so past a handful of workers decompression has already stopped
+/// being the bottleneck and the remaining cores do more good mapping reads.
+const MAX_DERIVED_GZ_THREADS: usize = 8;
+
+/// Cores this process can actually run on, falling back to 1.
+fn available_cpus() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
 }
 
-fn run_single(paths: &[PathBuf], proc: &mut QuantProcessor, nthreads: usize) -> Result<()> {
+/// Per-file worker budget for the parallel gzip decoder.
+///
+/// `setting` is [`QuantOptions::gzip_decompress_threads`]: `None` derives the
+/// budget, `Some(0)` disables the parallel decoder entirely. The whole-run
+/// budget is split across `n_files` because paraseq opens every input file up
+/// front and decodes them concurrently, so a per-file ceiling would multiply by
+/// the number of files.
+///
+/// The derived budget is the mapping thread count bounded by `cpus`, the cores
+/// this process can actually run on: `--threads` is a request, not a promise,
+/// and paraseq itself caps its mapping pool at the core count, so deriving from
+/// an oversized `--threads` would hand the decoder workers that have no core to
+/// run on and would only contend with mapping. An explicit `setting` is taken
+/// as given — it is the knob for deliberately overriding this.
+fn gz_worker_budget(setting: Option<usize>, nthreads: usize, cpus: usize, n_files: usize) -> usize {
+    let total = match setting {
+        Some(0) => return 0,
+        Some(n) => n,
+        None => nthreads.min(cpus).clamp(1, MAX_DERIVED_GZ_THREADS),
+    };
+    (total / n_files.max(1)).max(1)
+}
+
+/// Open a (optionally gzipped) read file as a boxed reader.
+///
+/// A `.gz` input is decoded by rapidgzip's parallel decoder with at most
+/// `gz_threads` workers. That decoder needs positional (`pread`) access to a
+/// stable file, so it is used only for regular files: process substitution,
+/// FIFOs and `/dev/stdin` fall back to the serial [`MultiGzDecoder`], as does
+/// any input whose framing rapidgzip rejects up front — flate2 then produces
+/// the same error it always did for genuinely malformed input. Failures found
+/// mid-stream (a bad CRC or member footer) surface as read errors and cannot
+/// fall back; pass `--gzipDecompressThreads 0` to take the serial path for the
+/// whole run.
+fn open_reader(path: &Path, gz_threads: usize) -> Result<Box<dyn std::io::Read + Send>> {
+    if path.extension().and_then(|e| e.to_str()) != Some("gz") {
+        let f = std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+        return Ok(Box::new(f));
+    }
+
+    let is_regular_file = std::fs::metadata(path).is_ok_and(|m| m.is_file());
+    if gz_threads > 0 && is_regular_file {
+        match rapidgzip_core::Decoder::builder()
+            .decoder_threads(gz_threads)
+            .build()
+            .map_err(anyhow::Error::from)
+            .and_then(|d| d.open(path).map_err(anyhow::Error::from))
+        {
+            Ok(reader) => {
+                tracing::debug!(
+                    "decoding {} with rapidgzip ({gz_threads} worker(s))",
+                    path.display()
+                );
+                return Ok(Box::new(reader));
+            }
+            Err(e) => tracing::debug!(
+                "rapidgzip declined {}: {e}; falling back to serial gzip",
+                path.display()
+            ),
+        }
+    }
+
+    let f = std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    Ok(Box::new(MultiGzDecoder::new(f)))
+}
+
+fn run_single(
+    paths: &[PathBuf],
+    proc: &mut QuantProcessor,
+    nthreads: usize,
+    gz_setting: Option<usize>,
+) -> Result<()> {
+    let gz_threads = gz_worker_budget(gz_setting, nthreads, available_cpus(), paths.len());
     let mut readers = Vec::with_capacity(paths.len());
     for p in paths {
         readers.push(
-            reader_with_batch_size(open_reader(p)?)
+            reader_with_batch_size(open_reader(p, gz_threads)?)
                 .map_err(|e| anyhow::anyhow!("opening {}: {e}", p.display()))?,
         );
     }
@@ -1208,19 +1305,26 @@ fn run_paired(
     mates2: &[PathBuf],
     proc: &mut QuantProcessor,
     nthreads: usize,
+    gz_setting: Option<usize>,
 ) -> Result<()> {
     anyhow::ensure!(
         mates1.len() == mates2.len(),
         "mates1 and mates2 must have the same number of files"
     );
+    let gz_threads = gz_worker_budget(
+        gz_setting,
+        nthreads,
+        available_cpus(),
+        mates1.len() + mates2.len(),
+    );
     let mut readers = Vec::with_capacity(mates1.len() * 2);
     for (a, b) in mates1.iter().zip(mates2.iter()) {
         readers.push(
-            reader_with_batch_size(open_reader(a)?)
+            reader_with_batch_size(open_reader(a, gz_threads)?)
                 .map_err(|e| anyhow::anyhow!("opening {}: {e}", a.display()))?,
         );
         readers.push(
-            reader_with_batch_size(open_reader(b)?)
+            reader_with_batch_size(open_reader(b, gz_threads)?)
                 .map_err(|e| anyhow::anyhow!("opening {}: {e}", b.display()))?,
         );
     }
@@ -1230,4 +1334,100 @@ fn run_paired(
         .process_parallel_paired(proc, nthreads, None)
         .map_err(|e| anyhow::anyhow!("mapping failed: {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{gz_worker_budget, open_reader, MAX_DERIVED_GZ_THREADS};
+    use std::io::{Read, Write};
+
+    #[test]
+    fn gz_budget_is_split_across_concurrently_read_files() {
+        // Derived from the mapping threads, then divided: paraseq decodes every
+        // input file at once, so a per-file ceiling would multiply by the file
+        // count and oversubscribe the machine.
+        assert_eq!(gz_worker_budget(None, 8, 16, 2), 4);
+        assert_eq!(gz_worker_budget(None, 8, 16, 1), 8);
+        // Never below one worker, however many files there are.
+        assert_eq!(gz_worker_budget(None, 2, 16, 8), 1);
+        // The derived budget is capped, and never exceeds the cores the process
+        // can actually run on however large --threads is.
+        assert_eq!(gz_worker_budget(None, 64, 16, 1), MAX_DERIVED_GZ_THREADS);
+        assert_eq!(gz_worker_budget(None, 64, 4, 1), 4);
+        assert_eq!(gz_worker_budget(None, 8, 1, 1), 1);
+        // An explicit budget is taken as given: neither cap applies.
+        assert_eq!(gz_worker_budget(Some(32), 4, 4, 1), 32);
+        // 0 is the opt-out into the serial decoder.
+        assert_eq!(gz_worker_budget(Some(0), 8, 16, 1), 0);
+    }
+
+    /// Both decoders must yield the same bytes, including across the member
+    /// boundary of a concatenated (multi-member) gzip file — the shape produced
+    /// by `cat lane1.fq.gz lane2.fq.gz`.
+    #[test]
+    fn parallel_and_serial_gzip_decode_identically() {
+        let dir = tempfile::tempdir().unwrap();
+        let plain: Vec<u8> = (0..2000)
+            .flat_map(|i| format!("@r{i}\nACGTACGTAC\n+\nIIIIIIIIII\n").into_bytes())
+            .collect();
+        let (first, second) = plain.split_at(plain.len() / 2);
+
+        let path = dir.path().join("reads.fq.gz");
+        let mut out = std::fs::File::create(&path).unwrap();
+        for member in [first, second] {
+            let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::new(1));
+            enc.write_all(member).unwrap();
+            out.write_all(&enc.finish().unwrap()).unwrap();
+        }
+        out.flush().unwrap();
+        drop(out);
+
+        let read_all = |threads| {
+            let mut buf = Vec::new();
+            open_reader(&path, threads)
+                .unwrap()
+                .read_to_end(&mut buf)
+                .unwrap();
+            buf
+        };
+        assert_eq!(read_all(0), plain, "serial decode");
+        assert_eq!(read_all(4), plain, "parallel decode");
+    }
+
+    /// A gzipped input that is not a regular file has no positional access, so
+    /// it must fall back to the serial decoder instead of failing.
+    #[cfg(unix)]
+    #[test]
+    fn non_regular_gzip_input_falls_back_to_serial() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("reads.fq.gz");
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("run mkfifo");
+        assert!(status.success());
+        assert!(std::fs::metadata(&fifo).unwrap().file_type().is_fifo());
+
+        let plain = b"@r0\nACGT\n+\nIIII\n".to_vec();
+        let writer = {
+            let fifo = fifo.clone();
+            let plain = plain.clone();
+            std::thread::spawn(move || {
+                let f = std::fs::OpenOptions::new().write(true).open(fifo).unwrap();
+                let mut enc = flate2::write::GzEncoder::new(f, flate2::Compression::new(1));
+                enc.write_all(&plain).unwrap();
+                enc.finish().unwrap();
+            })
+        };
+
+        let mut buf = Vec::new();
+        open_reader(&fifo, 4)
+            .unwrap()
+            .read_to_end(&mut buf)
+            .unwrap();
+        writer.join().unwrap();
+        assert_eq!(buf, plain);
+    }
 }

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -633,3 +633,68 @@ fn pseudoalignment_quantification_tracks_truth() {
         );
     }
 }
+
+/// Gzip `src` into `dst` as two concatenated members split at a record
+/// boundary, the shape produced by `cat lane1.fq.gz lane2.fq.gz`.
+fn gzip_as_two_members(src: &Path, dst: &Path) {
+    use std::io::Write;
+
+    let plain = std::fs::read(src).unwrap();
+    let lines: Vec<&[u8]> = plain.split_inclusive(|&b| b == b'\n').collect();
+    let split_line = (lines.len() / 2) / 4 * 4; // keep whole 4-line records
+    let split = lines[..split_line].iter().map(|l| l.len()).sum::<usize>();
+
+    let mut out = std::fs::File::create(dst).unwrap();
+    for member in [&plain[..split], &plain[split..]] {
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::new(1));
+        enc.write_all(member).unwrap();
+        out.write_all(&enc.finish().unwrap()).unwrap();
+    }
+    out.flush().unwrap();
+}
+
+/// Gzipped FASTQ input must quantify exactly like the uncompressed input, and
+/// the parallel (rapidgzip) and serial (flate2) decoders must agree, since the
+/// decoder only changes how the bytes arrive. Mapping stays single-threaded so
+/// any difference has to come from decompression.
+#[test]
+fn gzipped_reads_quantify_identically_to_plain_reads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2, _truth) = simulate(tmp.path());
+
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let r1gz = tmp.path().join("reads_1.fq.gz");
+    let r2gz = tmp.path().join("reads_2.fq.gz");
+    gzip_as_two_members(&r1, &r1gz);
+    gzip_as_two_members(&r2, &r2gz);
+
+    let quant = |tag: &str, m1: &Path, m2: &Path, gz_threads: Option<usize>| {
+        let mut opts = QuantOptions::new(idx_dir.clone(), tmp.path().join(tag));
+        opts.mates1 = vec![m1.to_path_buf()];
+        opts.mates2 = vec![m2.to_path_buf()];
+        opts.lib_type = "IU".to_string();
+        opts.num_threads = 1;
+        opts.gzip_decompress_threads = gz_threads;
+        quantify(&opts).expect("quantify")
+    };
+
+    let plain = quant("plain", &r1, &r2, None);
+    assert!(plain.num_mapped > 0, "fixture mapped nothing");
+
+    for (tag, gz_threads) in [("gz_parallel", None), ("gz_serial", Some(0))] {
+        let got = quant(tag, &r1gz, &r2gz, gz_threads);
+        assert_eq!(got.num_mapped, plain.num_mapped, "{tag}: num_mapped");
+        assert_eq!(got.names, plain.names, "{tag}: transcript names");
+        for (name, (a, b)) in plain
+            .names
+            .iter()
+            .zip(got.counts.iter().zip(plain.counts.iter()))
+        {
+            assert!((a - b).abs() < 1e-9, "{tag}: {name} count {a} != {b}");
+        }
+    }
+}

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -53,6 +53,7 @@ misbehaves.
 |------|--------|-------|
 | `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. |
 | `--bamCompressThreads` | ✅ | BGZF compression pool for `--writeBam`; defaults to ~1 worker per 3 mapping threads (max 8), balancing measured deflate throughput against record production. Rust-port feature; not in this salmon build. |
+| `--gzipDecompressThreads` | ✅ | Worker budget for the parallel gzip decoder (rapidgzip) on `.gz` FASTQ input; whole-run budget split across the concurrently-read input files, defaulting to `--threads`, bounded by the cores the process can run on and capped at 8. `0` selects the serial flate2 decoder, which is also the automatic fallback for gzipped input that is not a regular file. Rust-port feature; not in this salmon build. |
 | `--useEM` | ✅ | VBEM is the default; `--useEM` selects plain EM. |
 | `--meta` | ✅ | Metagenomic preset: plain EM, no range-factorized eq-classes, uniform init (the Rust EM already inits uniformly). Overrides `--useEM`/`--rangeFactorizationBins`. |
 | `--useVBOpt` | 🔁 | VBEM is already the default. |

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -69,6 +69,7 @@ Quantify from FASTQ reads (reads mode, `-i`), from a transcriptome BAM
 | `-r, --unmatedReads <FASTQ>…` | Single-end read files. |
 | `-o, --output <DIR>` | Output directory. **Required.** |
 | `-p, --threads <N>` | Worker threads (`0` = all cores). |
+| `--gzipDecompressThreads <N>` | Worker budget for the parallel gzip decoder ([rapidgzip](https://github.com/COMBINE-lab/rapidgzip-rust)) used on `.gz` FASTQ input. The budget covers the whole run and is split across the input files, which are read concurrently; it defaults to `--threads`, bounded by the cores the process can run on and capped at 8. Pass `0` for the single-threaded decoder. Gzipped input that is not a regular file (process substitution, a FIFO, `/dev/stdin`) always takes the single-threaded path, since the parallel decoder needs positional access to a stable file. |
 | `-g, --geneMap <FILE>` | Transcript-to-gene map (GTF/GFF or 2-column TSV); also writes `quant.genes.sf`. |
 
 ### Mapping


### PR DESCRIPTION
## What

Reads-mode FASTQ input is gunzipped by flate2's `MultiGzDecoder`, one serial inflate stream per file. On a many-core run that decoder becomes the producer bottleneck well before the mapping threads saturate.

This routes `.gz` FASTQ through [`rapidgzip-core`](https://github.com/COMBINE-lab/rapidgzip-rust) (0.1), the COMBINE-lab Rust port of rapidgzip. It decodes gzip, concatenated members and BGZF across a worker pool and returns a `Read + Send` stream that paraseq owns directly, so nothing downstream changes. Every member is still CRC- and size-verified.

## Thread budget

`--gzipDecompressThreads <N>` (new). The budget is a **whole-run** ceiling split across the input files, since paraseq opens them all up front and decodes them concurrently; a per-file ceiling would multiply by the file count.

Unset, it derives from `--threads`, bounded by the cores the process can actually run on, and capped at 8: one worker decodes far more FASTQ than one mapping thread consumes, so past that the cores do more good mapping reads. rapidgzip creates workers lazily and retires them under consumer backpressure, so the value is a cap and not an allocation. An explicit value is used as given.

`--gzipDecompressThreads 0` selects the old serial decoder for the whole run.

## Fallback

The parallel decoder needs positional (`pread`) access to a stable file, so it is used only for regular files. Gzipped input that is not a regular file (process substitution, a FIFO, `/dev/stdin`) falls back to `MultiGzDecoder`, as does input whose framing rapidgzip rejects up front, which lets flate2 produce the same error it always did for malformed input. Failures found mid-stream (bad CRC or member footer) surface as read errors and cannot fall back.

Uncompressed FASTQ and every non-reads path (alignment mode, RAD, reference FASTA, SAM.gz) are untouched.

## Tests

- `gz_budget_is_split_across_concurrently_read_files` — budget derivation: split across files, floor of 1, cap at 8, bounded by cores, explicit value passed through, 0 = opt out.
- `parallel_and_serial_gzip_decode_identically` — both decoders yield identical bytes across a concatenated (multi-member) gzip boundary.
- `non_regular_gzip_input_falls_back_to_serial` — a FIFO decodes instead of failing.
- `gzipped_reads_quantify_identically_to_plain_reads` (end-to-end) — plain, rapidgzip and flate2 runs of the same fixture give identical `num_mapped` and per-transcript counts; mapping is single-threaded so any difference could only come from decompression.
- `gzip_decompress_threads_is_optional_and_accepts_zero` — CLI parsing, including that 0 is accepted here (unlike `--bamCompressThreads`).

`cargo fmt`, `cargo clippy --workspace --all-targets` and `cargo test --workspace` are clean.

## Docs

`--gzipDecompressThreads` documented in `website/.../reference/cli.mdx` and `docs/cli-flag-status.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)