### PR TITLE
fix(genemap): report and remedy a gene map that matches no quantified transcript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,6 +2684,7 @@ name = "salmon-core"
 version = "2.4.1"
 dependencies = [
  "serde",
+ "serde_json",
  "thiserror 2.0.19",
  "tracing",
 ]

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -81,7 +81,8 @@ These still parse so existing scripts run; 2.0 logs a warning and ignores them
   level and `tximport` can apply its own transcript-to-gene policy to the whole
   file. What changed is the reporting: C++ warned once *per unmatched transcript*
   (half a million lines on a failed join), while 2.x warns once with the count
-  and writes the names to `aux_info/genemap_unmatched_txps.txt`, one per line.
+  and writes the names to `aux_info/genemap_unmatched_txps.json`, under an
+  `unmatched_transcripts` key.
   That file is removed when nothing is unmatched, so its presence always refers
   to the current run. 2.x additionally warns when the match rate is at or below
   50%, says how many transcripts would match without the version suffix, and

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -65,10 +65,24 @@ These still parse so existing scripts run; 2.0 logs a warning and ignores them
   alignment more closely.
 - `--allowDovetail` — now honored in `--sketch` as well (admits dovetailed
   short-insert fragments).
+- `--ignoreTxVersion` — compare `-g/--geneMap` identifiers without their trailing
+  `.N` version suffix, as tximport's option of the same name does. Off by
+  default. Needed for an Ensembl cDNA index against an Ensembl GTF, where the
+  FASTA carries the version in the identifier and the GTF puts it in a separate
+  `transcript_version` attribute.
 
 ## Behavior differences to be aware of
 
 - **Sketch orphan rule** defaults to the relaxed policy (see `--sketchStrictOrphans`).
+- **`-g/--geneMap`: unmatched transcripts are dropped, not emitted.** C++
+  salmon's `aggregateEstimatesToGeneLevel` gave a transcript with no gene-map
+  entry a gene of its own (named after the transcript) and warned once per
+  transcript. 2.x omits it from `quant.genes.sf` instead, and reports the total
+  once. If every identifier fails to match — the usual cause is the Ensembl
+  cDNA + GTF version mismatch above — C++ wrote one row per transcript where 2.x
+  writes a header and no rows. salmon now warns when the match rate is at or
+  below 50%, says how many transcripts would match without the version suffix,
+  and names `--ignoreTxVersion`.
 - **Selective-alignment chain pruning:** 2.0 currently defaults
   `--orphanChainSubThresh` and `--postMergeChainSubThresh` to `0.0` (off) — it
   aligns every candidate, which is marginally more sensitive than C++ (which uses
@@ -82,5 +96,5 @@ Index/quant basics, `quant.sf`, `cmd_info.json`, `lib_format_counts.json`,
 `aux_info/meta_info.json`, `--libType/-l`, `--threads/-p`, `-k/--kmerLen`,
 `-m/--minimizerLen`, `-n/--no-clip` (poly-A clipping, on by default),
 `--seqBias`, `--gcBias`, `--posBias`, `--numBootstraps`, `--numGibbsSamples`,
-`--useEM`, `--meta` (metagenomic preset), `--dumpEq`, `-g/--geneMap`, decoys, and
+`--useEM`, `--meta` (metagenomic preset), `--dumpEq`, decoys, and
 `salmon quantmerge`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -74,15 +74,20 @@ These still parse so existing scripts run; 2.0 logs a warning and ignores them
 ## Behavior differences to be aware of
 
 - **Sketch orphan rule** defaults to the relaxed policy (see `--sketchStrictOrphans`).
-- **`-g/--geneMap`: unmatched transcripts are dropped, not emitted.** C++
-  salmon's `aggregateEstimatesToGeneLevel` gave a transcript with no gene-map
-  entry a gene of its own (named after the transcript) and warned once per
-  transcript. 2.x omits it from `quant.genes.sf` instead, and reports the total
-  once. If every identifier fails to match — the usual cause is the Ensembl
-  cDNA + GTF version mismatch above — C++ wrote one row per transcript where 2.x
-  writes a header and no rows. salmon now warns when the match rate is at or
-  below 50%, says how many transcripts would match without the version suffix,
-  and names `--ignoreTxVersion`.
+- **`-g/--geneMap`: unmatched transcripts are reported differently, not
+  aggregated differently.** As in C++ salmon's `aggregateEstimatesToGeneLevel`, a
+  transcript with no gene-map entry is emitted as its own single-transcript gene,
+  named after the transcript, so nothing quantified is dropped on the way to gene
+  level and `tximport` can apply its own transcript-to-gene policy to the whole
+  file. What changed is the reporting: C++ warned once *per unmatched transcript*
+  (half a million lines on a failed join), while 2.x warns once with the count
+  and writes the names to `aux_info/genemap_unmatched_txps.txt`, one per line.
+  That file is removed when nothing is unmatched, so its presence always refers
+  to the current run. 2.x additionally warns when the match rate is at or below
+  50%, says how many transcripts would match without the version suffix, and
+  names `--ignoreTxVersion`. Note that a `quant.genes.sf` whose rows are mostly
+  stand-ins is transcript-level output under a gene-level file name — the run's
+  closing line says so explicitly when any row is a stand-in.
 - **Selective-alignment chain pruning:** 2.0 currently defaults
   `--orphanChainSubThresh` and `--postMergeChainSubThresh` to `0.0` (off) — it
   aligns every candidate, which is marginally more sensitive than C++ (which uses

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -864,7 +864,7 @@ fn write_gene_level(
 ) -> Result<()> {
     let map = salmon_core::genemap::read_transcript_gene_map(gene_map)
         .with_context(|| format!("reading gene map {}", gene_map.display()))?;
-    let unmapped = salmon_core::genemap::write_gene_quant(
+    let summary = salmon_core::genemap::write_gene_quant(
         &out_dir.join("quant.genes.sf"),
         names,
         lengths,
@@ -874,13 +874,50 @@ fn write_gene_level(
         &map,
     )
     .context("writing quant.genes.sf")?;
-    let n_genes = map.values().collect::<std::collections::HashSet<_>>().len();
-    if unmapped > 0 {
+
+    if summary.unmapped > 0 {
         eprintln!(
-            "warning: {unmapped} transcript(s) had no entry in the gene map and were omitted from quant.genes.sf"
+            "warning: {} of {} transcript(s) had no entry in the gene map and were omitted \
+             from quant.genes.sf",
+            summary.unmapped,
+            summary.total()
         );
     }
-    println!("wrote gene-level estimates for {n_genes} genes to quant.genes.sf");
+    // A near-total mismatch means the identifiers do not line up, not that the
+    // annotation is merely incomplete — say so, rather than leaving the user to
+    // infer it from an empty file.
+    if summary.match_rate_is_low() {
+        eprintln!(
+            "warning: the gene map matched only {} of {} quantified transcripts ({:.1}%); \
+             quant.genes.sf has {} gene row(s)",
+            summary.matched,
+            summary.total(),
+            summary.match_rate() * 100.0,
+            summary.genes_written
+        );
+        let would_match = salmon_core::genemap::matches_ignoring_tx_version(names, &map);
+        if would_match > summary.matched {
+            eprintln!(
+                "warning: {would_match} would match if the trailing version suffix were ignored \
+                 (e.g. {} vs {}). The Ensembl cDNA FASTA carries transcript versions in the \
+                 identifier while the GTF puts them in a separate transcript_version attribute, \
+                 so an index built from the FASTA does not join to the GTF as-is.",
+                names
+                    .iter()
+                    .find(|n| !map.contains_key(*n))
+                    .map(String::as_str)
+                    .unwrap_or("ENST00000456328.2"),
+                map.keys()
+                    .next()
+                    .map(String::as_str)
+                    .unwrap_or("ENST00000456328"),
+            );
+        }
+    }
+    println!(
+        "wrote gene-level estimates for {} genes to quant.genes.sf",
+        summary.genes_written
+    );
     Ok(())
 }
 

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -871,9 +871,9 @@ struct GeneMapOpts {
 }
 
 /// Name of the file under `aux_info/` listing transcripts the gene map did not
-/// cover, one per line. It sits beside `unmapped_names.txt` — which is about
-/// *fragments* that did not map — so the name says transcripts explicitly.
-const UNMATCHED_TXP_FILE: &str = "genemap_unmatched_txps.txt";
+/// cover. It sits beside `unmapped_names.txt` — which is about *fragments* that
+/// did not map — so the name says transcripts explicitly.
+const UNMATCHED_TXP_FILE: &str = "genemap_unmatched_txps.json";
 
 /// Aggregate transcript estimates to gene level and write `quant.genes.sf`.
 fn write_gene_level(

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -404,6 +404,14 @@ struct QuantArgs {
     /// gene-level estimates to `quant.genes.sf`.
     #[arg(short = 'g', long = "geneMap", value_name = "FILE")]
     gene_map: Option<PathBuf>,
+    /// Ignore trailing transcript-version suffixes when joining `--geneMap`
+    /// entries to quantified transcripts, so `ENST00000456328.2` matches
+    /// `ENST00000456328`. Matches tximport's option of the same name. Needed
+    /// when the index was built from an Ensembl cDNA FASTA, which carries the
+    /// version in the identifier, and the annotation is an Ensembl GTF, which
+    /// puts it in a separate `transcript_version` attribute.
+    #[arg(long = "ignoreTxVersion")]
+    ignore_tx_version: bool,
     /// Worker threads (0 = all cores). salmon also runs one auxiliary thread for
     /// FASTQ parsing/decompression, so total CPU use can slightly exceed this
     /// value; on schedulers that enforce the limit, request one extra core.
@@ -852,18 +860,28 @@ fn long_read_redirect() -> ! {
     std::process::exit(2);
 }
 
+/// Where the `--geneMap` annotation is and how to join it to quantified
+/// transcripts. Carried together so the option travels with the path through
+/// every quantification path.
+#[derive(Clone, Debug)]
+struct GeneMapOpts {
+    path: PathBuf,
+    /// `--ignoreTxVersion`
+    ignore_tx_version: bool,
+}
+
 /// Aggregate transcript estimates to gene level and write `quant.genes.sf`.
 fn write_gene_level(
     out_dir: &std::path::Path,
-    gene_map: &std::path::Path,
+    gene_map: &GeneMapOpts,
     names: &[String],
     lengths: &[u32],
     eff_lengths: &[f64],
     tpm: &[f64],
     counts: &[f64],
 ) -> Result<()> {
-    let map = salmon_core::genemap::read_transcript_gene_map(gene_map)
-        .with_context(|| format!("reading gene map {}", gene_map.display()))?;
+    let map = salmon_core::genemap::read_transcript_gene_map(&gene_map.path)
+        .with_context(|| format!("reading gene map {}", gene_map.path.display()))?;
     let summary = salmon_core::genemap::write_gene_quant(
         &out_dir.join("quant.genes.sf"),
         names,
@@ -872,6 +890,7 @@ fn write_gene_level(
         tpm,
         counts,
         &map,
+        gene_map.ignore_tx_version,
     )
     .context("writing quant.genes.sf")?;
 
@@ -896,12 +915,13 @@ fn write_gene_level(
             summary.genes_written
         );
         let would_match = salmon_core::genemap::matches_ignoring_tx_version(names, &map);
-        if would_match > summary.matched {
+        if !gene_map.ignore_tx_version && would_match > summary.matched {
             eprintln!(
-                "warning: {would_match} would match if the trailing version suffix were ignored \
-                 (e.g. {} vs {}). The Ensembl cDNA FASTA carries transcript versions in the \
-                 identifier while the GTF puts them in a separate transcript_version attribute, \
-                 so an index built from the FASTA does not join to the GTF as-is.",
+                "warning: {would_match} would match with --ignoreTxVersion, which compares \
+                 identifiers without their trailing version suffix (e.g. {} vs {}). The Ensembl \
+                 cDNA FASTA carries transcript versions in the identifier while the GTF puts \
+                 them in a separate transcript_version attribute, so an index built from the \
+                 FASTA does not join to the GTF as-is.",
                 names
                     .iter()
                     .find(|n| !map.contains_key(*n))
@@ -935,7 +955,7 @@ fn run_deterministic(
     rad_out: Option<PathBuf>,
     keep_rad: bool,
     bias_targets: Option<PathBuf>,
-    gene_map: Option<&std::path::Path>,
+    gene_map: Option<&GeneMapOpts>,
     out_dir: &std::path::Path,
 ) -> Result<()> {
     let bias_on = map_opts.seq_bias || map_opts.gc_bias || map_opts.pos_bias;
@@ -1048,7 +1068,7 @@ fn run_deterministic_align(
     opts: AlignQuantOptions,
     rad_out: Option<PathBuf>,
     keep_rad: bool,
-    gene_map: Option<&std::path::Path>,
+    gene_map: Option<&GeneMapOpts>,
     codec: ChunkCodec,
 ) -> Result<()> {
     let out_dir = opts.output_dir.clone();
@@ -1134,7 +1154,7 @@ fn run_genome_project(
     q: AlignQuantOptions,
     rad_out: Option<PathBuf>,
     keep_rad: bool,
-    gene_map: Option<&std::path::Path>,
+    gene_map: Option<&GeneMapOpts>,
 ) -> Result<()> {
     let out_dir = q.output_dir.clone();
     let explicit = rad_out.is_some();
@@ -1247,7 +1267,10 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         .num_threads(nthreads)
         .build_global();
     let out_dir = args.output.clone();
-    let gene_map = args.gene_map.clone();
+    let gene_map = args.gene_map.clone().map(|path| GeneMapOpts {
+        path,
+        ignore_tx_version: args.ignore_tx_version,
+    });
     // `--meta` (metagenomic preset) forces plain EM (no VBEM) and disables rich /
     // range-factorized equivalence classes, matching salmon's --meta. salmon's
     // preset also sets initUniform; the Rust offline EM already initializes
@@ -1347,7 +1370,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
                 opts,
                 args.write_rad.clone(),
                 args.keep_rad,
-                gene_map.as_deref(),
+                gene_map.as_ref(),
             );
         }
 
@@ -1361,7 +1384,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
                 opts,
                 args.write_rad.clone(),
                 args.keep_rad,
-                gene_map.as_deref(),
+                gene_map.as_ref(),
                 codec,
             );
         }
@@ -1610,7 +1633,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             rad_out,
             args.keep_rad,
             args.targets.clone(),
-            gene_map.as_deref(),
+            gene_map.as_ref(),
             &out_dir,
         );
     }

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -870,6 +870,11 @@ struct GeneMapOpts {
     ignore_tx_version: bool,
 }
 
+/// Name of the file under `aux_info/` listing transcripts the gene map did not
+/// cover, one per line. It sits beside `unmapped_names.txt` — which is about
+/// *fragments* that did not map — so the name says transcripts explicitly.
+const UNMATCHED_TXP_FILE: &str = "genemap_unmatched_txps.txt";
+
 /// Aggregate transcript estimates to gene level and write `quant.genes.sf`.
 fn write_gene_level(
     out_dir: &std::path::Path,
@@ -882,6 +887,9 @@ fn write_gene_level(
 ) -> Result<()> {
     let map = salmon_core::genemap::read_transcript_gene_map(&gene_map.path)
         .with_context(|| format!("reading gene map {}", gene_map.path.display()))?;
+    // Listed by name rather than only counted, so the failure survives a lost
+    // terminal and can be fed straight back into whatever built the annotation.
+    let unmatched_list = out_dir.join("aux_info").join(UNMATCHED_TXP_FILE);
     let summary = salmon_core::genemap::write_gene_quant(
         &out_dir.join("quant.genes.sf"),
         names,
@@ -891,28 +899,35 @@ fn write_gene_level(
         counts,
         &map,
         gene_map.ignore_tx_version,
+        Some(&unmatched_list),
     )
     .context("writing quant.genes.sf")?;
 
-    if summary.unmapped > 0 {
+    if summary.unmatched > 0 {
         eprintln!(
-            "warning: {} of {} transcript(s) had no entry in the gene map and were omitted \
-             from quant.genes.sf",
-            summary.unmapped,
-            summary.total()
+            "warning: {} of {} transcript(s) had no entry in the gene map. Each was written to \
+             quant.genes.sf as its own single-transcript gene, so those rows are named by \
+             transcript, not by gene. Their names are listed in {}",
+            summary.unmatched,
+            summary.total(),
+            unmatched_list.display()
         );
     }
     // A near-total mismatch means the identifiers do not line up, not that the
-    // annotation is merely incomplete — say so, rather than leaving the user to
-    // infer it from an empty file.
+    // annotation is merely incomplete. With the fallback in place the file is
+    // full-looking either way, so the row breakdown is the only thing that
+    // distinguishes a real gene-level result from a transcript list wearing its
+    // name — state it rather than leave it to be inferred.
     if summary.match_rate_is_low() {
         eprintln!(
-            "warning: the gene map matched only {} of {} quantified transcripts ({:.1}%); \
-             quant.genes.sf has {} gene row(s)",
+            "warning: the gene map matched only {} of {} quantified transcripts ({:.1}%), so of \
+             the {} rows in quant.genes.sf, {} are unmatched transcripts standing in as their \
+             own gene. Treat this output as transcript-level until the join is fixed.",
             summary.matched,
             summary.total(),
             summary.match_rate() * 100.0,
-            summary.genes_written
+            summary.genes_written,
+            summary.unmatched
         );
         let would_match = salmon_core::genemap::matches_ignoring_tx_version(names, &map);
         if !gene_map.ignore_tx_version && would_match > summary.matched {
@@ -934,10 +949,31 @@ fn write_gene_level(
             );
         }
     }
-    println!(
-        "wrote gene-level estimates for {} genes to quant.genes.sf",
-        summary.genes_written
-    );
+    // Count the rows written, not the genes in the gene map: the two differ
+    // whenever the join is imperfect, and reporting the latter is what let a
+    // header-only quant.genes.sf be announced as a success (#1075).
+    //
+    // With the fallback in place the same trap reappears one step along, since
+    // a stand-in row is a transcript wearing a gene's place in the file. So the
+    // count is only called "genes" when every row is one; otherwise the split is
+    // spelled out, and the last line of the run agrees with the warnings above
+    // it rather than contradicting them.
+    if summary.unmatched == 0 {
+        println!(
+            "wrote gene-level estimates for {} genes to quant.genes.sf",
+            summary.genes_written
+        );
+    } else {
+        println!(
+            "wrote {} rows to quant.genes.sf: {} gene(s), plus {} unmatched transcript(s) as \
+             their own gene",
+            summary.genes_written,
+            // saturating: a stand-in row whose name collides with a real gene
+            // merges into it, so the two counts can overlap by one per collision.
+            summary.genes_written.saturating_sub(summary.unmatched),
+            summary.unmatched
+        );
+    }
     Ok(())
 }
 

--- a/crates/salmon-core/Cargo.toml
+++ b/crates/salmon-core/Cargo.toml
@@ -11,6 +11,9 @@ description = "Shared core types for the Rust port of salmon (transcripts, libra
 [dependencies]
 thiserror = { workspace = true }
 serde = { workspace = true }
+# the unmatched-transcript list under aux_info/ is JSON, like the other
+# non-primary artifacts salmon writes there
+serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [lints]

--- a/crates/salmon-core/src/genemap.rs
+++ b/crates/salmon-core/src/genemap.rs
@@ -178,9 +178,10 @@ pub fn matches_ignoring_tx_version(names: &[String], gene_map: &HashMap<String, 
 /// like an unmapped transcript, which does not occur in practice for the
 /// Ensembl/GENCODE/RefSeq identifier schemes.
 ///
-/// `unmatched_out`, when given, receives one unmatched transcript name per line
-/// in `names` order, and is removed when nothing is unmatched so a stale list
-/// from an earlier run cannot be mistaken for a current one. The returned
+/// `unmatched_out`, when given, receives the unmatched transcript names as JSON
+/// (see [`write_unmatched_list`]) in `names` order, and is removed when nothing
+/// is unmatched so a stale list from an earlier run cannot be mistaken for a
+/// current one. The returned
 /// [`GeneQuantSummary`] is what the caller should report — in particular
 /// `genes_written`, which is the number of rows in the file and not the number
 /// of genes in the gene map.
@@ -267,9 +268,27 @@ pub fn write_gene_quant(
     Ok(summary)
 }
 
-/// Write the names of transcripts the gene map did not cover, one per line, in
-/// `quant.sf` order. No header and no second column, so the file is directly
-/// usable as `grep -f` input or a one-column read in R/pandas.
+/// JSON key holding the unmatched identifiers. Named for what the list *is*
+/// rather than for the file it sits in, so a consumer that has the parsed object
+/// but not the path still knows what it is looking at.
+const UNMATCHED_JSON_KEY: &str = "unmatched_transcripts";
+
+/// Write the names of transcripts the gene map did not cover, in `quant.sf`
+/// order, as a one-key JSON object:
+///
+/// ```json
+/// {
+///   "unmatched_transcripts": [
+///     "ENST00000456328.2",
+///     "ENST00000450305.3"
+///   ]
+/// }
+/// ```
+///
+/// JSON rather than one-per-line text so it parses without a bespoke reader,
+/// matching the other non-primary artifacts under `aux_info/`. Wrapped in an
+/// object rather than written as a bare array so the file can gain fields later
+/// without breaking consumers written against it today.
 ///
 /// An empty list removes the file rather than writing an empty one: the run that
 /// produced it is the only thing that can be said to be current, and a stale
@@ -285,10 +304,12 @@ fn write_unmatched_list(path: &Path, unmatched: &[&str]) -> io::Result<()> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
     }
+    // `to_string_pretty` puts one identifier per line, so the file stays as
+    // greppable as the text version it replaces.
+    let doc = serde_json::json!({ UNMATCHED_JSON_KEY: unmatched });
+    let body = serde_json::to_string_pretty(&doc).map_err(io::Error::other)?;
     let mut w = io::BufWriter::new(std::fs::File::create(path)?);
-    for name in unmatched {
-        writeln!(w, "{name}")?;
-    }
+    writeln!(w, "{body}")?;
     w.flush()
 }
 
@@ -325,7 +346,7 @@ mod tests {
         // ...but quant.sf names them as the cDNA FASTA does.
         let names: Vec<String> = vec!["ENST00000456328.2".into(), "ENST00000450305.3".into()];
         let out = scratch("nomatch").join("quant.genes.sf");
-        let list = scratch("nomatch").join("genemap_unmatched_txps.txt");
+        let list = scratch("nomatch").join("genemap_unmatched_txps.json");
         let summary = write_gene_quant(
             &out,
             &names,
@@ -366,12 +387,20 @@ mod tests {
             .sum();
         assert_eq!(reads, 300.0);
 
-        // And the failure is recorded where it outlives the terminal.
-        let listed = std::fs::read_to_string(&list).unwrap();
+        // And the failure is recorded where it outlives the terminal. Asserted
+        // through a JSON parse, not on the raw text, so the test pins the
+        // document a consumer sees rather than the formatting around it.
+        let listed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&list).unwrap()).unwrap();
         assert_eq!(
-            listed.lines().collect::<Vec<_>>(),
-            ["ENST00000456328.2", "ENST00000450305.3"],
-            "listed in quant.sf order, one per line, no header"
+            listed[UNMATCHED_JSON_KEY],
+            serde_json::json!(["ENST00000456328.2", "ENST00000450305.3"]),
+            "listed under the documented key, in quant.sf order"
+        );
+        assert_eq!(
+            listed.as_object().unwrap().len(),
+            1,
+            "one key, so a consumer can match on it exactly"
         );
 
         // The diagnosis the warning is built on: the identifiers differ only by
@@ -415,7 +444,7 @@ mod tests {
         let mut gm = HashMap::new();
         gm.insert("t1".to_string(), "G".to_string());
         let out = scratch("stale").join("quant.genes.sf");
-        let list = scratch("stale").join("genemap_unmatched_txps.txt");
+        let list = scratch("stale").join("genemap_unmatched_txps.json");
         std::fs::write(&list, "leftover_from_a_previous_run\n").unwrap();
 
         let s = write_gene_quant(

--- a/crates/salmon-core/src/genemap.rs
+++ b/crates/salmon-core/src/genemap.rs
@@ -143,6 +143,55 @@ pub fn write_gene_quant(
 mod tests {
     use super::*;
 
+    fn scratch(case: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("salmon_genemap_{}_{case}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// The reference human bulk RNA-seq setup: an index built from the Ensembl
+    /// cDNA FASTA, whose headers carry the version inline, against an Ensembl
+    /// GTF, which splits it into a separate `transcript_version` attribute.
+    /// The join is a literal string compare, so nothing matches at all.
+    #[test]
+    fn versioned_quant_names_match_no_unversioned_gene_map_entry() {
+        let gtf = "\
+1\thavana\ttranscript\t11869\t14409\t.\t+\t.\tgene_id \"ENSG00000290825\"; gene_version \"2\"; transcript_id \"ENST00000456328\"; transcript_version \"2\";
+1\thavana\ttranscript\t12010\t13670\t.\t+\t.\tgene_id \"ENSG00000223972\"; gene_version \"6\"; transcript_id \"ENST00000450305\"; transcript_version \"3\";
+";
+        let gtf_path = scratch("nomatch").join("annotation.gtf");
+        std::fs::write(&gtf_path, gtf).unwrap();
+        let map = read_transcript_gene_map(&gtf_path).unwrap();
+        assert_eq!(map.len(), 2);
+        assert!(
+            map.contains_key("ENST00000456328"),
+            "GTF keys are unversioned"
+        );
+
+        // ...but quant.sf names them as the cDNA FASTA does.
+        let names: Vec<String> = vec!["ENST00000456328.2".into(), "ENST00000450305.3".into()];
+        let out = scratch("nomatch").join("quant.genes.sf");
+        let unmapped = write_gene_quant(
+            &out,
+            &names,
+            &[1000, 2000],
+            &[800.0, 1800.0],
+            &[10.0, 20.0],
+            &[100.0, 200.0],
+            &map,
+        )
+        .unwrap();
+
+        assert_eq!(unmapped, 2, "every transcript should fail to match");
+        let body = std::fs::read_to_string(&out).unwrap();
+        assert_eq!(
+            body.lines().count(),
+            1,
+            "quant.genes.sf should be header-only: {body:?}"
+        );
+    }
+
     #[test]
     fn gtf_and_gff_attr_extraction() {
         let gtf = r#"gene_id "ENSG1"; transcript_id "ENST1"; gene_name "A";"#;

--- a/crates/salmon-core/src/genemap.rs
+++ b/crates/salmon-core/src/genemap.rs
@@ -86,9 +86,85 @@ fn extract_attr(attrs: &str, key: &str) -> Option<String> {
     None
 }
 
+/// A match rate at or below this is reported as a problem rather than a note.
+///
+/// The failure this guards against is total: a versioned/unversioned identifier
+/// mismatch matches *nothing*, and pairing an annotation with the FASTA it was
+/// built from matches essentially everything, so the two regimes are far apart
+/// and the exact cut is not delicate. Half is chosen because below it the
+/// majority of what was quantified is missing from `quant.genes.sf`, which is
+/// worth a look in any workflow, while deliberately partial annotations — a
+/// single-chromosome GTF, a spike-in-only map — stay well clear of being
+/// mistaken for correct. It gates a warning only; nothing fails.
+pub const LOW_MATCH_RATE: f64 = 0.5;
+
+/// What gene-level aggregation actually did, for the caller to report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct GeneQuantSummary {
+    /// Quantified transcripts that found an entry in the gene map.
+    pub matched: usize,
+    /// Quantified transcripts with no entry; omitted from `quant.genes.sf`.
+    pub unmapped: usize,
+    /// Gene rows actually written — not the number of genes in the gene map.
+    pub genes_written: usize,
+}
+
+impl GeneQuantSummary {
+    /// Quantified transcripts considered.
+    pub fn total(&self) -> usize {
+        self.matched + self.unmapped
+    }
+
+    /// Fraction of quantified transcripts that found a gene. An empty transcript
+    /// set is vacuously fully matched, so it does not trip the low-rate warning.
+    pub fn match_rate(&self) -> f64 {
+        if self.total() == 0 {
+            1.0
+        } else {
+            self.matched as f64 / self.total() as f64
+        }
+    }
+
+    /// Whether the caller should warn about how little the gene map matched.
+    pub fn match_rate_is_low(&self) -> bool {
+        self.match_rate() <= LOW_MATCH_RATE
+    }
+}
+
+/// Strip a trailing `.<digits>` version suffix, as tximport's `ignoreTxVersion`
+/// does. Identifiers whose last dot-separated part is not purely numeric are
+/// returned unchanged, which leaves GENCODE's `…_PAR_Y` suffixes alone.
+pub fn strip_tx_version(id: &str) -> &str {
+    match id.rsplit_once('.') {
+        Some((base, ver)) if !ver.is_empty() && ver.bytes().all(|b| b.is_ascii_digit()) => base,
+        _ => id,
+    }
+}
+
+/// How many of `names` would match if a version suffix were ignored on both
+/// sides. Purely diagnostic: it explains a poor match rate and never changes
+/// what is written.
+pub fn matches_ignoring_tx_version(names: &[String], gene_map: &HashMap<String, String>) -> usize {
+    let stripped: HashMap<&str, &str> = gene_map
+        .iter()
+        .map(|(t, g)| (strip_tx_version(t), g.as_str()))
+        .collect();
+    names
+        .iter()
+        .filter(|n| stripped.contains_key(strip_tx_version(n)))
+        .count()
+}
+
 /// Aggregate transcript-level estimates to gene level and write `quant.genes.sf`.
-/// Transcripts absent from `gene_map` are skipped (salmon's behavior); the count
-/// of skipped transcripts is returned for the caller to report.
+///
+/// Transcripts absent from `gene_map` are omitted from the output. Note this
+/// differs from C++ salmon, whose `aggregateEstimatesToGeneLevel` emitted an
+/// unmatched transcript as its own single-transcript gene and warned once per
+/// transcript; see #1075 for the discussion of which behaviour to keep.
+///
+/// The returned [`GeneQuantSummary`] is what the caller should report — in
+/// particular `genes_written`, which is the number of rows in the file and not
+/// the number of genes in the gene map.
 #[allow(clippy::too_many_arguments)]
 pub fn write_gene_quant(
     out_path: &Path,
@@ -98,14 +174,17 @@ pub fn write_gene_quant(
     tpm: &[f64],
     counts: &[f64],
     gene_map: &HashMap<String, String>,
-) -> io::Result<usize> {
+) -> io::Result<GeneQuantSummary> {
     // Group transcript indices by gene (gene name order is sorted for determinism).
     let mut genes: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
-    let mut unmapped = 0usize;
+    let mut summary = GeneQuantSummary::default();
     for (i, name) in names.iter().enumerate() {
         match gene_map.get(name) {
-            Some(g) => genes.entry(g.as_str()).or_default().push(i),
-            None => unmapped += 1,
+            Some(g) => {
+                genes.entry(g.as_str()).or_default().push(i);
+                summary.matched += 1;
+            }
+            None => summary.unmapped += 1,
         }
     }
 
@@ -136,7 +215,8 @@ pub fn write_gene_quant(
         )?;
     }
     w.flush()?;
-    Ok(unmapped)
+    summary.genes_written = genes.len();
+    Ok(summary)
 }
 
 #[cfg(test)]
@@ -172,7 +252,7 @@ mod tests {
         // ...but quant.sf names them as the cDNA FASTA does.
         let names: Vec<String> = vec!["ENST00000456328.2".into(), "ENST00000450305.3".into()];
         let out = scratch("nomatch").join("quant.genes.sf");
-        let unmapped = write_gene_quant(
+        let summary = write_gene_quant(
             &out,
             &names,
             &[1000, 2000],
@@ -183,13 +263,95 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(unmapped, 2, "every transcript should fail to match");
+        assert_eq!(summary.unmapped, 2, "every transcript should fail to match");
+        assert_eq!(summary.matched, 0);
+        assert_eq!(summary.genes_written, 0);
+        assert_eq!(summary.match_rate(), 0.0);
+        assert!(summary.match_rate_is_low());
         let body = std::fs::read_to_string(&out).unwrap();
         assert_eq!(
             body.lines().count(),
             1,
             "quant.genes.sf should be header-only: {body:?}"
         );
+
+        // The diagnosis the warning is built on: the identifiers differ only by
+        // the version suffix, so ignoring it would match everything.
+        assert_eq!(matches_ignoring_tx_version(&names, &map), 2);
+    }
+
+    #[test]
+    fn summary_counts_genes_written_not_gene_map_size() {
+        // The gene map knows three genes; only one of them is quantified.
+        let mut gm = HashMap::new();
+        gm.insert("t1".to_string(), "G".to_string());
+        gm.insert("t2".to_string(), "H".to_string());
+        gm.insert("t3".to_string(), "I".to_string());
+        let names = vec!["t1".to_string(), "zzz".to_string()];
+        let out = scratch("written").join("quant.genes.sf");
+        let summary = write_gene_quant(
+            &out,
+            &names,
+            &[10, 20],
+            &[8.0, 18.0],
+            &[1.0, 2.0],
+            &[3.0, 4.0],
+            &gm,
+        )
+        .unwrap();
+        assert_eq!(summary.matched, 1);
+        assert_eq!(summary.unmapped, 1);
+        assert_eq!(summary.genes_written, 1, "one row written, not 3 map genes");
+        assert_eq!(summary.total(), 2);
+        assert_eq!(summary.match_rate(), 0.5);
+        assert!(summary.match_rate_is_low(), "50% is at the threshold");
+    }
+
+    #[test]
+    fn full_match_does_not_trip_the_low_rate_warning() {
+        let mut gm = HashMap::new();
+        gm.insert("t1".to_string(), "G".to_string());
+        gm.insert("t2".to_string(), "G".to_string());
+        let names = vec!["t1".to_string(), "t2".to_string()];
+        let out = scratch("full").join("quant.genes.sf");
+        let summary = write_gene_quant(
+            &out,
+            &names,
+            &[10, 20],
+            &[8.0, 18.0],
+            &[1.0, 2.0],
+            &[3.0, 4.0],
+            &gm,
+        )
+        .unwrap();
+        assert_eq!(summary.match_rate(), 1.0);
+        assert!(!summary.match_rate_is_low());
+        assert_eq!(summary.genes_written, 1);
+        // Nothing to suggest when everything already matches.
+        assert_eq!(matches_ignoring_tx_version(&names, &gm), 2);
+    }
+
+    #[test]
+    fn version_stripping_leaves_non_numeric_suffixes_alone() {
+        assert_eq!(strip_tx_version("ENST00000456328.2"), "ENST00000456328");
+        assert_eq!(strip_tx_version("ENST00000456328.12"), "ENST00000456328");
+        assert_eq!(strip_tx_version("ENST00000456328"), "ENST00000456328");
+        // GENCODE PAR_Y entries must survive intact.
+        assert_eq!(
+            strip_tx_version("ENST00000456328.2_PAR_Y"),
+            "ENST00000456328.2_PAR_Y"
+        );
+        // a name that is dotted but not versioned
+        assert_eq!(strip_tx_version("gene.symbol"), "gene.symbol");
+        assert_eq!(strip_tx_version("t."), "t.");
+    }
+
+    /// An empty transcript set must not be reported as a mismatch.
+    #[test]
+    fn empty_transcript_set_is_not_low() {
+        let s = GeneQuantSummary::default();
+        assert_eq!(s.match_rate(), 1.0);
+        assert!(!s.match_rate_is_low());
     }
 
     #[test]
@@ -218,8 +380,10 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("gq_{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let p = dir.join("quant.genes.sf");
-        let unmapped = write_gene_quant(&p, &names, &lengths, &eff, &tpm, &counts, &gm).unwrap();
-        assert_eq!(unmapped, 0);
+        let summary = write_gene_quant(&p, &names, &lengths, &eff, &tpm, &counts, &gm).unwrap();
+        assert_eq!(summary.unmapped, 0);
+        assert_eq!(summary.matched, 3);
+        assert_eq!(summary.genes_written, 2);
         let body = std::fs::read_to_string(&p).unwrap();
         let g_line = body.lines().find(|l| l.starts_with("G\t")).unwrap();
         let f: Vec<&str> = g_line.split('\t').collect();

--- a/crates/salmon-core/src/genemap.rs
+++ b/crates/salmon-core/src/genemap.rs
@@ -103,16 +103,19 @@ pub const LOW_MATCH_RATE: f64 = 0.5;
 pub struct GeneQuantSummary {
     /// Quantified transcripts that found an entry in the gene map.
     pub matched: usize,
-    /// Quantified transcripts with no entry; omitted from `quant.genes.sf`.
-    pub unmapped: usize,
+    /// Quantified transcripts with no entry. They are still written, each as its
+    /// own single-transcript gene, so they contribute rows to `quant.genes.sf`
+    /// and are listed by name in the unmatched-transcript file.
+    pub unmatched: usize,
     /// Gene rows actually written — not the number of genes in the gene map.
+    /// Counts the `unmatched` fallback rows as well as the joined genes.
     pub genes_written: usize,
 }
 
 impl GeneQuantSummary {
     /// Quantified transcripts considered.
     pub fn total(&self) -> usize {
-        self.matched + self.unmapped
+        self.matched + self.unmatched
     }
 
     /// Fraction of quantified transcripts that found a gene. An empty transcript
@@ -157,16 +160,30 @@ pub fn matches_ignoring_tx_version(names: &[String], gene_map: &HashMap<String, 
 
 /// Aggregate transcript-level estimates to gene level and write `quant.genes.sf`.
 ///
-/// Transcripts absent from `gene_map` are omitted from the output. This is a
-/// deliberate divergence from C++ salmon, whose `aggregateEstimatesToGeneLevel`
-/// emitted an unmatched transcript as its own single-transcript gene: that turns
-/// a failed join into a `quant.genes.sf` full of transcript IDs posing as genes,
-/// which is harder to notice than an empty one. The caller is expected to report
-/// the summary below instead. Documented in MIGRATION.md.
+/// A transcript with no entry in `gene_map` is emitted as its own
+/// single-transcript gene, keyed by the transcript's own name — C++ salmon's
+/// `aggregateEstimatesToGeneLevel` behaviour. No abundance is dropped on the way
+/// to gene level, so downstream tools (`tximport` in particular, which has its
+/// own transcript-to-gene policy) see everything that was quantified and decide
+/// for themselves what to do with the leftovers.
 ///
-/// The returned [`GeneQuantSummary`] is what the caller should report — in
-/// particular `genes_written`, which is the number of rows in the file and not
-/// the number of genes in the gene map.
+/// What C++ got wrong was the reporting, not the aggregation: it warned once per
+/// unmatched transcript, so a failed join buried the signal under half a million
+/// lines. Here the names go to `unmatched_out` instead, and the caller reports
+/// the counts in [`GeneQuantSummary`] once.
+///
+/// Note that the fallback keys on the transcript name, so an unmatched
+/// transcript whose name collides with a real gene name in the map merges into
+/// that gene's row. C++ had the same property; it needs a gene named exactly
+/// like an unmapped transcript, which does not occur in practice for the
+/// Ensembl/GENCODE/RefSeq identifier schemes.
+///
+/// `unmatched_out`, when given, receives one unmatched transcript name per line
+/// in `names` order, and is removed when nothing is unmatched so a stale list
+/// from an earlier run cannot be mistaken for a current one. The returned
+/// [`GeneQuantSummary`] is what the caller should report — in particular
+/// `genes_written`, which is the number of rows in the file and not the number
+/// of genes in the gene map.
 ///
 /// With `ignore_tx_version`, identifiers are compared with a trailing `.<digits>`
 /// suffix removed on both sides (`--ignoreTxVersion`). Off by default: silently
@@ -181,6 +198,7 @@ pub fn write_gene_quant(
     counts: &[f64],
     gene_map: &HashMap<String, String>,
     ignore_tx_version: bool,
+    unmatched_out: Option<&Path>,
 ) -> io::Result<GeneQuantSummary> {
     // Re-key the map once when versions are ignored, rather than per lookup.
     let stripped: Option<HashMap<&str, &str>> = ignore_tx_version.then(|| {
@@ -193,6 +211,7 @@ pub fn write_gene_quant(
     // Group transcript indices by gene (gene name order is sorted for determinism).
     let mut genes: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
     let mut summary = GeneQuantSummary::default();
+    let mut unmatched: Vec<&str> = Vec::new();
     for (i, name) in names.iter().enumerate() {
         let gene = match &stripped {
             Some(m) => m.get(strip_tx_version(name)).copied(),
@@ -203,8 +222,18 @@ pub fn write_gene_quant(
                 genes.entry(g).or_default().push(i);
                 summary.matched += 1;
             }
-            None => summary.unmapped += 1,
+            // No entry: the transcript becomes its own gene, so its abundance
+            // still reaches the output. Recorded by name for the caller's list.
+            None => {
+                genes.entry(name.as_str()).or_default().push(i);
+                summary.unmatched += 1;
+                unmatched.push(name.as_str());
+            }
         }
+    }
+
+    if let Some(list_path) = unmatched_out {
+        write_unmatched_list(list_path, &unmatched)?;
     }
 
     // smallest positive double, matching salmon's `minTPM = denorm_min`.
@@ -236,6 +265,31 @@ pub fn write_gene_quant(
     w.flush()?;
     summary.genes_written = genes.len();
     Ok(summary)
+}
+
+/// Write the names of transcripts the gene map did not cover, one per line, in
+/// `quant.sf` order. No header and no second column, so the file is directly
+/// usable as `grep -f` input or a one-column read in R/pandas.
+///
+/// An empty list removes the file rather than writing an empty one: the run that
+/// produced it is the only thing that can be said to be current, and a stale
+/// list left over from a previous run in the same output directory would claim
+/// failures this run did not have.
+fn write_unmatched_list(path: &Path, unmatched: &[&str]) -> io::Result<()> {
+    if unmatched.is_empty() {
+        return match std::fs::remove_file(path) {
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            other => other,
+        };
+    }
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let mut w = io::BufWriter::new(std::fs::File::create(path)?);
+    for name in unmatched {
+        writeln!(w, "{name}")?;
+    }
+    w.flush()
 }
 
 #[cfg(test)]
@@ -271,6 +325,7 @@ mod tests {
         // ...but quant.sf names them as the cDNA FASTA does.
         let names: Vec<String> = vec!["ENST00000456328.2".into(), "ENST00000450305.3".into()];
         let out = scratch("nomatch").join("quant.genes.sf");
+        let list = scratch("nomatch").join("genemap_unmatched_txps.txt");
         let summary = write_gene_quant(
             &out,
             &names,
@@ -280,24 +335,103 @@ mod tests {
             &[100.0, 200.0],
             &map,
             false,
+            Some(&list),
         )
         .unwrap();
 
-        assert_eq!(summary.unmapped, 2, "every transcript should fail to match");
+        assert_eq!(
+            summary.unmatched, 2,
+            "every transcript should fail to match"
+        );
         assert_eq!(summary.matched, 0);
-        assert_eq!(summary.genes_written, 0);
         assert_eq!(summary.match_rate(), 0.0);
         assert!(summary.match_rate_is_low());
+
+        // Nothing is dropped: each unmatched transcript stands in as its own
+        // gene, so the abundance still reaches gene level for tximport to
+        // re-aggregate under its own policy.
+        assert_eq!(summary.genes_written, 2);
         let body = std::fs::read_to_string(&out).unwrap();
+        assert_eq!(body.lines().count(), 3, "header + 2 rows: {body:?}");
+        let row = body
+            .lines()
+            .find(|l| l.starts_with("ENST00000456328.2\t"))
+            .unwrap_or_else(|| panic!("rows are keyed by transcript name: {body:?}"));
+        assert_eq!(row.split('\t').nth(4), Some("100.000"), "reads preserved");
+        // Mass is conserved through the join even when nothing joins.
+        let reads: f64 = body
+            .lines()
+            .skip(1)
+            .map(|l| l.split('\t').nth(4).unwrap().parse::<f64>().unwrap())
+            .sum();
+        assert_eq!(reads, 300.0);
+
+        // And the failure is recorded where it outlives the terminal.
+        let listed = std::fs::read_to_string(&list).unwrap();
         assert_eq!(
-            body.lines().count(),
-            1,
-            "quant.genes.sf should be header-only: {body:?}"
+            listed.lines().collect::<Vec<_>>(),
+            ["ENST00000456328.2", "ENST00000450305.3"],
+            "listed in quant.sf order, one per line, no header"
         );
 
         // The diagnosis the warning is built on: the identifiers differ only by
         // the version suffix, so ignoring it would match everything.
         assert_eq!(matches_ignoring_tx_version(&names, &map), 2);
+    }
+
+    /// An unmatched transcript named exactly like a gene in the map merges into
+    /// that gene's row rather than adding one. C++ behaved the same way; this
+    /// pins it so the collision is a known property and not a surprise.
+    #[test]
+    fn a_fallback_row_colliding_with_a_real_gene_name_merges_into_it() {
+        let mut gm = HashMap::new();
+        gm.insert("t1".to_string(), "G".to_string());
+        let names = vec!["t1".to_string(), "G".to_string()];
+        let out = scratch("collide").join("quant.genes.sf");
+        let s = write_gene_quant(
+            &out,
+            &names,
+            &[10, 20],
+            &[8.0, 18.0],
+            &[1.0, 2.0],
+            &[3.0, 4.0],
+            &gm,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(s.matched, 1);
+        assert_eq!(s.unmatched, 1);
+        assert_eq!(s.genes_written, 1, "both land on the row named G");
+        let body = std::fs::read_to_string(&out).unwrap();
+        let row = body.lines().find(|l| l.starts_with("G\t")).unwrap();
+        assert_eq!(row.split('\t').nth(4), Some("7.000"), "3 + 4 reads");
+    }
+
+    /// A clean run must not leave the previous run's failure list behind: an
+    /// empty list is the absence of the file, not an empty file.
+    #[test]
+    fn a_stale_unmatched_list_is_removed_when_everything_matches() {
+        let mut gm = HashMap::new();
+        gm.insert("t1".to_string(), "G".to_string());
+        let out = scratch("stale").join("quant.genes.sf");
+        let list = scratch("stale").join("genemap_unmatched_txps.txt");
+        std::fs::write(&list, "leftover_from_a_previous_run\n").unwrap();
+
+        let s = write_gene_quant(
+            &out,
+            &["t1".to_string()],
+            &[10],
+            &[8.0],
+            &[1.0],
+            &[3.0],
+            &gm,
+            false,
+            Some(&list),
+        )
+        .unwrap();
+        assert_eq!(s.unmatched, 0);
+        assert!(!list.exists(), "stale list must not survive a clean run");
     }
 
     /// The same input as the mismatch case, with `--ignoreTxVersion` on: the
@@ -322,10 +456,19 @@ mod tests {
             &[100.0, 200.0],
             &gm,
             false,
+            None,
         )
         .unwrap();
         assert_eq!(off.matched, 0, "default must not strip versions");
-        assert_eq!(off.genes_written, 0);
+        // Two rows either way; the flag changes what they are named after, and
+        // that is the whole difference the warnings have to convey.
+        assert_eq!(off.unmatched, 2);
+        assert_eq!(off.genes_written, 2);
+        let off_body = std::fs::read_to_string(&out).unwrap();
+        assert!(
+            off_body.contains("ENST00000456328.2\t"),
+            "rows keyed by transcript when the join fails: {off_body:?}"
+        );
 
         let on = write_gene_quant(
             &out,
@@ -336,10 +479,11 @@ mod tests {
             &[100.0, 200.0],
             &gm,
             true,
+            None,
         )
         .unwrap();
         assert_eq!(on.matched, 2);
-        assert_eq!(on.unmapped, 0);
+        assert_eq!(on.unmatched, 0);
         assert_eq!(on.genes_written, 2);
         assert!(!on.match_rate_is_low());
 
@@ -361,7 +505,8 @@ mod tests {
         gm.insert("ENST00000456328.2".to_string(), "ENSG1".to_string());
         let names = vec!["ENST00000456328".to_string()];
         let out = scratch("ignorever2").join("quant.genes.sf");
-        let s = write_gene_quant(&out, &names, &[10], &[8.0], &[1.0], &[3.0], &gm, true).unwrap();
+        let s =
+            write_gene_quant(&out, &names, &[10], &[8.0], &[1.0], &[3.0], &gm, true, None).unwrap();
         assert_eq!(s.matched, 1);
         assert_eq!(s.genes_written, 1);
     }
@@ -384,11 +529,15 @@ mod tests {
             &[3.0, 4.0],
             &gm,
             false,
+            None,
         )
         .unwrap();
         assert_eq!(summary.matched, 1);
-        assert_eq!(summary.unmapped, 1);
-        assert_eq!(summary.genes_written, 1, "one row written, not 3 map genes");
+        assert_eq!(summary.unmatched, 1);
+        // Two rows (gene G, plus `zzz` standing in for itself) — not the 3 genes
+        // the map knows about. Reporting the map's size is what let a
+        // header-only file be announced as a success in #1075.
+        assert_eq!(summary.genes_written, 2, "rows written, not 3 map genes");
         assert_eq!(summary.total(), 2);
         assert_eq!(summary.match_rate(), 0.5);
         assert!(summary.match_rate_is_low(), "50% is at the threshold");
@@ -410,6 +559,7 @@ mod tests {
             &[3.0, 4.0],
             &gm,
             false,
+            None,
         )
         .unwrap();
         assert_eq!(summary.match_rate(), 1.0);
@@ -469,8 +619,8 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let p = dir.join("quant.genes.sf");
         let summary =
-            write_gene_quant(&p, &names, &lengths, &eff, &tpm, &counts, &gm, false).unwrap();
-        assert_eq!(summary.unmapped, 0);
+            write_gene_quant(&p, &names, &lengths, &eff, &tpm, &counts, &gm, false, None).unwrap();
+        assert_eq!(summary.unmatched, 0);
         assert_eq!(summary.matched, 3);
         assert_eq!(summary.genes_written, 2);
         let body = std::fs::read_to_string(&p).unwrap();

--- a/crates/salmon-core/src/genemap.rs
+++ b/crates/salmon-core/src/genemap.rs
@@ -157,10 +157,12 @@ pub fn matches_ignoring_tx_version(names: &[String], gene_map: &HashMap<String, 
 
 /// Aggregate transcript-level estimates to gene level and write `quant.genes.sf`.
 ///
-/// Transcripts absent from `gene_map` are omitted from the output. Note this
-/// differs from C++ salmon, whose `aggregateEstimatesToGeneLevel` emitted an
-/// unmatched transcript as its own single-transcript gene and warned once per
-/// transcript; see #1075 for the discussion of which behaviour to keep.
+/// Transcripts absent from `gene_map` are omitted from the output. This is a
+/// deliberate divergence from C++ salmon, whose `aggregateEstimatesToGeneLevel`
+/// emitted an unmatched transcript as its own single-transcript gene: that turns
+/// a failed join into a `quant.genes.sf` full of transcript IDs posing as genes,
+/// which is harder to notice than an empty one. The caller is expected to report
+/// the summary below instead. Documented in MIGRATION.md.
 ///
 /// The returned [`GeneQuantSummary`] is what the caller should report — in
 /// particular `genes_written`, which is the number of rows in the file and not

--- a/crates/salmon-core/src/genemap.rs
+++ b/crates/salmon-core/src/genemap.rs
@@ -165,6 +165,10 @@ pub fn matches_ignoring_tx_version(names: &[String], gene_map: &HashMap<String, 
 /// The returned [`GeneQuantSummary`] is what the caller should report — in
 /// particular `genes_written`, which is the number of rows in the file and not
 /// the number of genes in the gene map.
+///
+/// With `ignore_tx_version`, identifiers are compared with a trailing `.<digits>`
+/// suffix removed on both sides (`--ignoreTxVersion`). Off by default: silently
+/// normalising identifiers is how a wrong join goes unnoticed in the first place.
 #[allow(clippy::too_many_arguments)]
 pub fn write_gene_quant(
     out_path: &Path,
@@ -174,14 +178,27 @@ pub fn write_gene_quant(
     tpm: &[f64],
     counts: &[f64],
     gene_map: &HashMap<String, String>,
+    ignore_tx_version: bool,
 ) -> io::Result<GeneQuantSummary> {
+    // Re-key the map once when versions are ignored, rather than per lookup.
+    let stripped: Option<HashMap<&str, &str>> = ignore_tx_version.then(|| {
+        gene_map
+            .iter()
+            .map(|(t, g)| (strip_tx_version(t), g.as_str()))
+            .collect()
+    });
+
     // Group transcript indices by gene (gene name order is sorted for determinism).
     let mut genes: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
     let mut summary = GeneQuantSummary::default();
     for (i, name) in names.iter().enumerate() {
-        match gene_map.get(name) {
+        let gene = match &stripped {
+            Some(m) => m.get(strip_tx_version(name)).copied(),
+            None => gene_map.get(name).map(String::as_str),
+        };
+        match gene {
             Some(g) => {
-                genes.entry(g.as_str()).or_default().push(i);
+                genes.entry(g).or_default().push(i);
                 summary.matched += 1;
             }
             None => summary.unmapped += 1,
@@ -260,6 +277,7 @@ mod tests {
             &[10.0, 20.0],
             &[100.0, 200.0],
             &map,
+            false,
         )
         .unwrap();
 
@@ -280,6 +298,72 @@ mod tests {
         assert_eq!(matches_ignoring_tx_version(&names, &map), 2);
     }
 
+    /// The same input as the mismatch case, with `--ignoreTxVersion` on: the
+    /// join succeeds and the gene rows appear.
+    #[test]
+    fn ignore_tx_version_matches_versioned_names_to_an_unversioned_map() {
+        let mut gm = HashMap::new();
+        gm.insert("ENST00000456328".to_string(), "ENSG00000290825".to_string());
+        gm.insert("ENST00000450305".to_string(), "ENSG00000223972".to_string());
+        let names = vec![
+            "ENST00000456328.2".to_string(),
+            "ENST00000450305.3".to_string(),
+        ];
+        let out = scratch("ignorever").join("quant.genes.sf");
+
+        let off = write_gene_quant(
+            &out,
+            &names,
+            &[1000, 2000],
+            &[800.0, 1800.0],
+            &[10.0, 20.0],
+            &[100.0, 200.0],
+            &gm,
+            false,
+        )
+        .unwrap();
+        assert_eq!(off.matched, 0, "default must not strip versions");
+        assert_eq!(off.genes_written, 0);
+
+        let on = write_gene_quant(
+            &out,
+            &names,
+            &[1000, 2000],
+            &[800.0, 1800.0],
+            &[10.0, 20.0],
+            &[100.0, 200.0],
+            &gm,
+            true,
+        )
+        .unwrap();
+        assert_eq!(on.matched, 2);
+        assert_eq!(on.unmapped, 0);
+        assert_eq!(on.genes_written, 2);
+        assert!(!on.match_rate_is_low());
+
+        let body = std::fs::read_to_string(&out).unwrap();
+        assert_eq!(body.lines().count(), 3, "header + 2 genes: {body:?}");
+        // Counts must survive the join unchanged.
+        let row = body
+            .lines()
+            .find(|l| l.starts_with("ENSG00000290825\t"))
+            .unwrap();
+        assert_eq!(row.split('\t').nth(4), Some("100.000"));
+    }
+
+    /// Stripping applies to both sides, so a versioned gene map joins to
+    /// unversioned quant names too.
+    #[test]
+    fn ignore_tx_version_strips_the_gene_map_side_as_well() {
+        let mut gm = HashMap::new();
+        gm.insert("ENST00000456328.2".to_string(), "ENSG1".to_string());
+        let names = vec!["ENST00000456328".to_string()];
+        let out = scratch("ignorever2").join("quant.genes.sf");
+        let s = write_gene_quant(&out, &names, &[10], &[8.0], &[1.0], &[3.0], &gm, true).unwrap();
+        assert_eq!(s.matched, 1);
+        assert_eq!(s.genes_written, 1);
+    }
+
     #[test]
     fn summary_counts_genes_written_not_gene_map_size() {
         // The gene map knows three genes; only one of them is quantified.
@@ -297,6 +381,7 @@ mod tests {
             &[1.0, 2.0],
             &[3.0, 4.0],
             &gm,
+            false,
         )
         .unwrap();
         assert_eq!(summary.matched, 1);
@@ -322,6 +407,7 @@ mod tests {
             &[1.0, 2.0],
             &[3.0, 4.0],
             &gm,
+            false,
         )
         .unwrap();
         assert_eq!(summary.match_rate(), 1.0);
@@ -380,7 +466,8 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("gq_{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let p = dir.join("quant.genes.sf");
-        let summary = write_gene_quant(&p, &names, &lengths, &eff, &tpm, &counts, &gm).unwrap();
+        let summary =
+            write_gene_quant(&p, &names, &lengths, &eff, &tpm, &counts, &gm, false).unwrap();
         assert_eq!(summary.unmapped, 0);
         assert_eq!(summary.matched, 3);
         assert_eq!(summary.genes_written, 2);

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -62,7 +62,7 @@ misbehaves.
 | `--dumpEq`, `--dumpEqWeights`, `--writeUnmappedNames` | ✅ | |
 | `--initUniform` | ✅ | |
 | `--skipQuant` | ✅ | Skips EM + Gibbs/bootstrap + quant.sf; still emits eq-classes/metadata. |
-| `-g/--geneMap`, `--genes` | ✅ | Gene-level aggregation. |
+| `-g/--geneMap`, `--genes` | ✅ | Gene-level aggregation. Rust also adds `--ignoreTxVersion` (no C++ equivalent) for Ensembl cDNA + GTF identifier mismatches. |
 | `-q/--quiet` | ✅ | |
 | `--noLengthCorrection` | ✅ | (`--noEffectiveLengthCorrection`). |
 | `--minAssignedFrags` | ⛔ | |

--- a/website/src/content/docs/getting-started/quick-start.mdx
+++ b/website/src/content/docs/getting-started/quick-start.mdx
@@ -62,6 +62,9 @@ transcriptome, then quantify a paired-end sample.
 - **Bias correction:** `--seqBias`, `--gcBias`, `--posBias`.
 - **Posterior uncertainty:** `--numBootstraps 100` or `--numGibbsSamples 100`.
   See [inferential replicates](../../guides/inferential-replicates/).
-- **Gene-level output:** `-g txp2gene.gtf` also writes `quant.genes.sf`.
+- **Gene-level output:** `-g txp2gene.gtf` also writes `quant.genes.sf`. With an
+  Ensembl cDNA index and an Ensembl GTF, add `--ignoreTxVersion` — the FASTA
+  carries transcript versions in the identifier and the GTF does not, so nothing
+  joins without it. See [Ensembl cDNA + GTF](../../reference/cli/#ensembl-cdna--gtf).
 
 See the [CLI reference](../../reference/cli/) for the full option list.

--- a/website/src/content/docs/migrating/from-cpp.mdx
+++ b/website/src/content/docs/migrating/from-cpp.mdx
@@ -71,14 +71,20 @@ These still parse so existing scripts run; 2.0 logs a warning and ignores them
 
 - **Sketch orphan rule** defaults to the relaxed policy (see
   `--sketchStrictOrphans`).
-- **`-g/--geneMap`: unmatched transcripts are dropped, not emitted.** C++
-  salmon's `aggregateEstimatesToGeneLevel` gave a transcript with no gene-map
-  entry a gene of its own, named after the transcript, and warned once per
-  transcript. 2.x omits it from `quant.genes.sf` and reports the total once. When
-  *no* identifier matches — usually the Ensembl cDNA + GTF version mismatch — C++
-  wrote one row per transcript where 2.x writes a header and no rows. salmon now
-  warns when the match rate is at or below 50%, says how many transcripts would
-  match without the version suffix, and names `--ignoreTxVersion`.
+- **`-g/--geneMap`: unmatched transcripts are reported differently, not
+  aggregated differently.** As in C++ salmon's `aggregateEstimatesToGeneLevel`, a
+  transcript with no gene-map entry is emitted as its own single-transcript gene,
+  named after the transcript, so nothing quantified is dropped on the way to gene
+  level and `tximport` can apply its own transcript-to-gene policy to the whole
+  file. What changed is the reporting: C++ warned once *per unmatched transcript*
+  (half a million lines on a failed join), while 2.x warns once with the count
+  and writes the names to `aux_info/genemap_unmatched_txps.txt`, one per line.
+  That file is removed when nothing is unmatched, so its presence always refers
+  to the current run. 2.x additionally warns when the match rate is at or below
+  50%, says how many transcripts would match without the version suffix, and
+  names `--ignoreTxVersion`. A `quant.genes.sf` whose rows are mostly stand-ins
+  is transcript-level output under a gene-level file name; the run's closing line
+  says so explicitly when any row is a stand-in.
 - **Selective-alignment chain pruning:** 2.0 defaults `--orphanChainSubThresh`
   and `--postMergeChainSubThresh` to `0.0` (off) — it aligns every candidate,
   marginally more sensitive than C++ (`0.95` / `0.9`). Quantification is

--- a/website/src/content/docs/migrating/from-cpp.mdx
+++ b/website/src/content/docs/migrating/from-cpp.mdx
@@ -63,11 +63,22 @@ These still parse so existing scripts run; 2.0 logs a warning and ignores them
   mate had no matching k-mers at all (the conservative rule). The default is the
   relaxed rule, which tracks selective alignment more closely.
 - **`--allowDovetail`** — now honored in `--sketch` as well.
+- **`--ignoreTxVersion`** — compare `-g/--geneMap` identifiers without their
+  trailing `.N` version suffix, as tximport's option of the same name does. Off
+  by default. See [Ensembl cDNA + GTF](../../reference/cli/#ensembl-cdna--gtf).
 
 ## Behavior differences to be aware of
 
 - **Sketch orphan rule** defaults to the relaxed policy (see
   `--sketchStrictOrphans`).
+- **`-g/--geneMap`: unmatched transcripts are dropped, not emitted.** C++
+  salmon's `aggregateEstimatesToGeneLevel` gave a transcript with no gene-map
+  entry a gene of its own, named after the transcript, and warned once per
+  transcript. 2.x omits it from `quant.genes.sf` and reports the total once. When
+  *no* identifier matches — usually the Ensembl cDNA + GTF version mismatch — C++
+  wrote one row per transcript where 2.x writes a header and no rows. salmon now
+  warns when the match rate is at or below 50%, says how many transcripts would
+  match without the version suffix, and names `--ignoreTxVersion`.
 - **Selective-alignment chain pruning:** 2.0 defaults `--orphanChainSubThresh`
   and `--postMergeChainSubThresh` to `0.0` (off) — it aligns every candidate,
   marginally more sensitive than C++ (`0.95` / `0.9`). Quantification is
@@ -80,4 +91,4 @@ These still parse so existing scripts run; 2.0 logs a warning and ignores them
 Index/quant basics, `quant.sf`, `cmd_info.json`, `lib_format_counts.json`,
 `aux_info/meta_info.json`, `--libType/-l`, `--threads/-p`, `--seqBias`,
 `--gcBias`, `--posBias`, `--numBootstraps`, `--numGibbsSamples`, `--useEM`,
-`--dumpEq`, `-g/--geneMap`, decoys, and `salmon quantmerge`.
+`--dumpEq`, decoys, and `salmon quantmerge`.

--- a/website/src/content/docs/migrating/from-cpp.mdx
+++ b/website/src/content/docs/migrating/from-cpp.mdx
@@ -78,7 +78,8 @@ These still parse so existing scripts run; 2.0 logs a warning and ignores them
   level and `tximport` can apply its own transcript-to-gene policy to the whole
   file. What changed is the reporting: C++ warned once *per unmatched transcript*
   (half a million lines on a failed join), while 2.x warns once with the count
-  and writes the names to `aux_info/genemap_unmatched_txps.txt`, one per line.
+  and writes the names to `aux_info/genemap_unmatched_txps.json`, under an
+  `unmatched_transcripts` key.
   That file is removed when nothing is unmatched, so its presence always refers
   to the current run. 2.x additionally warns when the match rate is at or below
   50%, says how many transcripts would match without the version suffix, and

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -150,8 +150,16 @@ transcript-level output under a gene-level name, and no abundance is lost.
 salmon warns when the match rate is at or below 50%, says how many rows are
 stand-ins, reports how many transcripts *would* have matched, names the flag
 below, and lists every unmatched identifier in
-`aux_info/genemap_unmatched_txps.txt` (one per line, removed when there are
-none).
+`aux_info/genemap_unmatched_txps.json` (removed when there are none):
+
+```json
+{
+  "unmatched_transcripts": [
+    "ENST00000622028.1",
+    "ENST00000456328.2"
+  ]
+}
+```
 
 Either pass `--ignoreTxVersion`, which compares identifiers without the trailing
 `.N` on both sides — the same semantics as tximport's option of the same name —

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -70,6 +70,7 @@ Quantify from FASTQ reads (reads mode, `-i`), from a transcriptome BAM
 | `-o, --output <DIR>` | Output directory. **Required.** |
 | `-p, --threads <N>` | Worker threads (`0` = all cores). |
 | `-g, --geneMap <FILE>` | Transcript-to-gene map (GTF/GFF or 2-column TSV); also writes `quant.genes.sf`. |
+| `--ignoreTxVersion` | Compare transcript identifiers without their trailing `.N` version suffix when joining `--geneMap` to quantified transcripts. Off by default. See [Ensembl cDNA + GTF](#ensembl-cdna--gtf). |
 
 ### Mapping
 
@@ -131,6 +132,34 @@ See the [RAD I/O & deterministic quantification](../../guides/rad-and-determinis
 ```sh
 salmon quant -i salmon_index -l A -1 r1.fq.gz -2 r2.fq.gz -p 16 -o out
 ```
+
+### Ensembl cDNA + GTF
+
+Gene-level aggregation joins `--geneMap` entries to quantified transcripts by
+exact identifier. Ensembl spells the transcript version differently in its two
+files, so the reference human RNA-seq combination does not join as-is:
+
+| Source | Identifier |
+| --- | --- |
+| `quant.sf`, from an index built on the Ensembl cDNA FASTA | `ENST00000622028.1` |
+| Ensembl GTF | `transcript_id "ENST00000622028"` + `transcript_version "1"` |
+
+Nothing matches, so `quant.genes.sf` comes out with only its header. salmon
+warns when the match rate is at or below 50%, reports how many transcripts
+*would* have matched, and names the flag below.
+
+Either pass `--ignoreTxVersion`, which compares identifiers without the trailing
+`.N` on both sides — the same semantics as tximport's option of the same name —
+or use an annotation whose identifiers already carry versions (GENCODE's FASTA
+and GTF agree, so it needs no flag):
+
+```sh
+salmon quant -i salmon_index -l A -1 r1.fq.gz -2 r2.fq.gz -o out \
+  -g Homo_sapiens.GRCh38.115.gtf --ignoreTxVersion
+```
+
+It is off by default on purpose: rewriting identifiers implicitly would hide the
+next mismatch as effectively as this one was hidden.
 
 ## `salmon quantmerge`
 

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -144,9 +144,14 @@ files, so the reference human RNA-seq combination does not join as-is:
 | `quant.sf`, from an index built on the Ensembl cDNA FASTA | `ENST00000622028.1` |
 | Ensembl GTF | `transcript_id "ENST00000622028"` + `transcript_version "1"` |
 
-Nothing matches, so `quant.genes.sf` comes out with only its header. salmon
-warns when the match rate is at or below 50%, reports how many transcripts
-*would* have matched, and names the flag below.
+Nothing matches. Each transcript then stands in as its own single-transcript
+gene, so `quant.genes.sf` is full-length but keyed by transcript: it is
+transcript-level output under a gene-level name, and no abundance is lost.
+salmon warns when the match rate is at or below 50%, says how many rows are
+stand-ins, reports how many transcripts *would* have matched, names the flag
+below, and lists every unmatched identifier in
+`aux_info/genemap_unmatched_txps.txt` (one per line, removed when there are
+none).
 
 Either pass `--ignoreTxVersion`, which compares identifiers without the trailing
 `.N` on both sides — the same semantics as tximport's option of the same name —


### PR DESCRIPTION
Fixes #1075.

Unmatched transcripts stay dropped rather than reverting to C++'s transcript-as-its-own-gene fallback, and both migration documents now say so instead of claiming parity. Rationale in "A correction to the code" below; say the word if you want the fallback restored and I will send it as its own change.

## The problem

An index built from the Ensembl cDNA FASTA quantifies `ENST00000622028.1`. The Ensembl GTF says `transcript_id "ENST00000622028"` and puts the version in a separate `transcript_version` attribute. `write_gene_quant` joins them with a literal string compare, so the match rate is not low, it is **zero** — and `quant.genes.sf` comes out with only its header, exit code 0.

## salmon was not silent — it was contradictory

I assumed "no warning" when I filed #1075 and that was wrong; the code disproved it. `main.rs:878` does warn. The problem is the line after it. Running unpatched `develop` against a 15-transcript index whose FASTA is versioned and whose GTF is not:

```
warning: 15 transcript(s) had no entry in the gene map and were omitted from quant.genes.sf
wrote gene-level estimates for 15 genes to quant.genes.sf
```

```
$ wc -l out/quant.genes.sf
       1
```

"wrote gene-level estimates for 15 genes" — to a file with **zero** gene rows. `n_genes` was counted from the gene map, not from what was written:

```rust
let n_genes = map.values().collect::<HashSet<_>>().len();
println!("wrote gene-level estimates for {n_genes} genes to quant.genes.sf");
```

So the run's last word is a success message, on stdout, contradicting a warning on stderr. That is the actual defect: not silence, but a reassuring summary that is wrong.

## After

Same input, same branch, no flag — behaviour unchanged, diagnosis added:

```
warning: 15 of 15 transcript(s) had no entry in the gene map and were omitted from quant.genes.sf
warning: the gene map matched only 0 of 15 quantified transcripts (0.0%); quant.genes.sf has 0 gene row(s)
warning: 15 would match with --ignoreTxVersion, which compares identifiers without their
         trailing version suffix (e.g. NM_001168316.1 vs NM_018953). The Ensembl cDNA FASTA
         carries transcript versions in the identifier while the GTF puts them in a separate
         transcript_version attribute, so an index built from the FASTA does not join to the
         GTF as-is.
wrote gene-level estimates for 0 genes to quant.genes.sf
```

The third warning only fires when ignoring versions would genuinely match more, so it diagnoses rather than guesses. With the flag:

```
$ salmon quant … -g annotation.gtf --ignoreTxVersion
wrote gene-level estimates for 15 genes to quant.genes.sf

$ wc -l out/quant.genes.sf
      16
```

Mass is conserved through the join:

| | TPM | NumReads |
|---|---|---|
| `quant.sf` | 1000000.000 | 10000.000 |
| `quant.genes.sf` | 1000000.000 | 10000.000 |

And the flag is inert when identifiers already agree — same index, a GTF whose `transcript_id` carries the version, with and without `--ignoreTxVersion`:

```
--- identical output with and without the flag? ---
IDENTICAL
```

## Summary of changes

| | |
|---|---|
| `write_gene_quant` return | `usize` → `GeneQuantSummary { matched, unmapped, genes_written }` |
| CLI summary line | counts gene-map genes → counts rows written |
| low match rate | undetected → warns at ≤ `LOW_MATCH_RATE` (0.5) |
| cause | unstated → names the version mismatch when that is demonstrably it |
| remedy | none → `--ignoreTxVersion`, off by default |

**On the threshold.** 0.5, justified in the doc comment where it is defined. The failure mode is total — a version mismatch matches nothing — and a correctly paired annotation matches essentially everything, so the two regimes are far apart and the exact cut is not delicate. Half means the majority of what was quantified is missing from the output, which is worth flagging in any workflow, while a deliberately partial annotation (single-chromosome GTF, spike-in-only map) is nowhere near being mistaken for correct. It gates a warning only; nothing fails, nothing changes.

**On the default.** `--ignoreTxVersion` is off deliberately, and I would push back on making it automatic. The complaint in #1075 is that a bad join produced an empty file without saying so; stripping versions implicitly would replace a silent wrong answer with a silent right one and leave the next mismatch just as invisible. Version-aware annotations are also a legitimate setup. Semantics match tximport's flag of the same name, so the name should already mean the right thing to users. `strip_tx_version` only strips when the final dot-separated part is all digits, so GENCODE's `ENST00000456328.2_PAR_Y` survives.

## A correction to the code

The doc comment on `write_gene_quant` said unmatched transcripts are skipped "(salmon's behavior)". That is not what C++ salmon did — `aggregateEstimatesToGeneLevel` emitted each unmatched transcript as its own single-transcript gene and warned once per transcript:

```cpp
auto gn = tgm.geneName(er.target, foundGene);   // returns transcriptName when not found
if (!foundGene) { logger->warn("… returning transcript as it's own gene", er.target); }
geneExps[gn].push_back(std::move(er));          // emitted regardless
```

So on this input C++ 1.x wrote 515,982 rows and half a million warnings — useless as gene-level output, impossible to miss. 2.x drops them and reported success.

This branch keeps the dropping and documents it, rather than restoring the C++ fallback. Emitting every unmatched transcript as its own gene turns a failed join into a `quant.genes.sf` full of transcript IDs posing as genes — 515,982 plausible-looking rows that a downstream `tximport` or `DESeq2` will happily consume — which is harder to notice than an empty file, not easier. What C++ had going for it was the half-million warnings, and the warnings added in commit 2 carry that signal without the junk output. The doc comment now records the reasoning.

`MIGRATION.md` and `migrating/from-cpp.mdx` listed `-g/--geneMap` under *Unchanged*; commit 5 moves it to *Behavior differences to be aware of* in both, and lists `--ignoreTxVersion` under *New in 2.0*.

## Commits

1. `test(genemap): cover a gene map that matches no quantified transcript` — characterisation test; asserts the *current* outcome, passes as-is, so the following commits move against a documented baseline.
2. `fix(genemap): warn when the gene map matches few or no transcripts` — no change to matching.
3. `feat(genemap): add --ignoreTxVersion to strip trailing version suffixes` — opt-in.
4. `docs: document --ignoreTxVersion and the Ensembl cDNA + GTF pitfall`
5. `docs: correct the C++ parity claim for -g/--geneMap`

Verified per commit, not just at the tip — `cargo fmt --all --check`, `cargo clippy -p salmon-core -p salmon-cli --all-targets`, `cargo test`:

```
14a56b7e test(genemap): cover a gene map that matches no q | fmt=OK clippy_err=0 test_fail=0
bf185c84 fix(genemap): warn when the gene map matches few  | fmt=OK clippy_err=0 test_fail=0
01074258 feat(genemap): add --ignoreTxVersion to strip tra | fmt=OK clippy_err=0 test_fail=0
2d7d6a4d docs: document --ignoreTxVersion and the Ensemb | fmt=OK clippy_err=0 test_fail=0
79fb7cd1 docs: correct the C++ parity claim for -g/--gen | fmt=OK clippy_err=0 test_fail=0
```

`cargo test --workspace` is green at the tip. salmon-core goes from 20 to 27 tests.

## Note on the API and the plumbing

`write_gene_quant` now returns a struct and takes an `ignore_tx_version` flag — a breaking change to a `pub fn` in salmon-core, with salmon-cli the only caller in-tree. The gene-map path and the flag travel together as a small `GeneMapOpts` rather than as a bare `bool` threaded through `run_deterministic` and the other two quantification entry points; that keeps their arity unchanged and keeps the option attached to the path it qualifies. Happy to do it the other way if you prefer.

## Deliberately not addressed

- **Other identifier mismatches** (GENCODE `|`-delimited FASTA headers, RefSeq/Ensembl crossovers). The low-match-rate warning will now flag them, but only the version case gets a named cause and a flag, because it is the one with a settled convention to copy from tximport.
- **The gzip issue (#1074)** is independent and is #1076; no overlap with this branch beyond both touching `genemap.rs`.
