### PR TITLE
perf(eqclass,infer): stop copying the largest structures needlessly

### DIFF
--- a/crates/salmon-eqclass/src/lib.rs
+++ b/crates/salmon-eqclass/src/lib.rs
@@ -429,12 +429,12 @@ impl EquivalenceClassBuilder {
     /// class *indices* — which the EM uses everywhere — are identical on every
     /// run, no matter what order the threads happened to insert them in.
     pub fn finish(self) -> CollapsedEqClasses {
-        let mut classes: Vec<(TranscriptGroup, TGValue)> = Vec::with_capacity(self.map.len());
-        // Drain the concurrent map into a plain vector. Iteration order of a
-        // hash map is arbitrary, hence the sort on the next line.
-        self.map
-            .iter()
-            .for_each(|e| classes.push((e.key().clone(), e.value().clone())));
+        // Move the entries out of the concurrent map rather than cloning them.
+        // `self` is owned here, so the map is dropped either way; cloning would
+        // deep-copy every `txps`/`bins`/`acc` vector and hold two full copies of
+        // the largest structure in the run at once. Iteration order of a hash map
+        // is arbitrary, hence the sort on the next line.
+        let mut classes: Vec<(TranscriptGroup, TGValue)> = self.map.into_iter().collect();
         classes.sort_by(|a, b| a.0.txps.cmp(&b.0.txps));
         // Materialize f64 weights from each class's order-independent fixed-point
         // accumulator (the sort above already makes the class *order* stable).

--- a/crates/salmon-eqclass/src/lib.rs
+++ b/crates/salmon-eqclass/src/lib.rs
@@ -432,9 +432,20 @@ impl EquivalenceClassBuilder {
         // Move the entries out of the concurrent map rather than cloning them.
         // `self` is owned here, so the map is dropped either way; cloning would
         // deep-copy every `txps`/`bins`/`acc` vector and hold two full copies of
-        // the largest structure in the run at once. Iteration order of a hash map
-        // is arbitrary, hence the sort on the next line.
-        let mut classes: Vec<(TranscriptGroup, TGValue)> = self.map.into_iter().collect();
+        // the largest structure in the run at once.
+        //
+        // Reserve first: `dashmap`'s owning iterator implements neither
+        // `size_hint` nor `ExactSizeIterator`, so `collect` would report `(0,
+        // None)` and grow this vector from empty by doubling — a realloc and a
+        // memcpy of every element at each step, plus a transient ~1.5x peak at
+        // the last one. At 144 bytes per entry that is the same cost this change
+        // removes from `PackedEqClasses::from_collapsed`. `len` has to be read
+        // before `into_iter` consumes the map.
+        //
+        // Iteration order of a hash map is arbitrary, hence the sort below.
+        let num_classes = self.map.len();
+        let mut classes: Vec<(TranscriptGroup, TGValue)> = Vec::with_capacity(num_classes);
+        classes.extend(self.map);
         classes.sort_by(|a, b| a.0.txps.cmp(&b.0.txps));
         // Materialize f64 weights from each class's order-independent fixed-point
         // accumulator (the sort above already makes the class *order* stable).

--- a/crates/salmon-infer/src/packed.rs
+++ b/crates/salmon-infer/src/packed.rs
@@ -68,10 +68,30 @@ impl PackedEqClasses {
     /// ([`update_eff_lengths`](salmon_eqclass::CollapsedEqClasses::update_eff_lengths)).
     pub fn from_collapsed(eq: &CollapsedEqClasses, num_txps: usize) -> Self {
         let n = eq.classes.len();
-        let mut labels = Vec::new();
+        // Size the flat arrays up front. Growing them from empty costs a
+        // reallocation plus a full copy at every doubling, and leaves a transient
+        // peak of ~1.5x the final size while both buffers are live. The exact
+        // total is one cheap pass over the class list (it only reads `Vec::len`).
+        let total_labels: usize = eq
+            .classes
+            .iter()
+            .filter(|(g, _)| g.valid)
+            .map(|(g, _)| g.txps.len())
+            .sum();
+        // The CSR offsets below are `u32`. Past `u32::MAX` incidences the `as u32`
+        // cast would wrap silently and `class()` would hand the optimizer slices
+        // belonging to other classes — wrong abundances with no diagnostic. Fail
+        // loudly instead.
+        assert!(
+            total_labels <= u32::MAX as usize,
+            "equivalence-class CSR needs {total_labels} incidences, which exceeds \
+             the u32 offset limit ({}); please report this input",
+            u32::MAX
+        );
+        let mut labels = Vec::with_capacity(total_labels);
         let mut starts = Vec::with_capacity(n + 1);
-        let mut combined = Vec::new();
-        let mut weights = Vec::new();
+        let mut combined = Vec::with_capacity(total_labels);
+        let mut weights = Vec::with_capacity(total_labels);
         let mut counts = Vec::with_capacity(n);
         // The first class starts at offset 0; every later entry is appended after
         // that class's data has been copied in.


### PR DESCRIPTION
Part of #1092 (performance / memory audit). Two independent allocation fixes on the equivalence-class path, no behavioural change.

### `EquivalenceClassBuilder::finish` cloned a map it already owns

`finish` takes `self` by value, so the concurrent map is dropped either way. It nonetheless cloned every key and value out of it, and those clones are deep: `TranscriptGroup` owns two `Vec<u32>`, and `TGValue` owns the `Vec<u128>` fixed-point accumulator, which is still live at that point.

The effect was two full copies of the largest structure in the run held simultaneously, plus a heap allocation and a memcpy per class per vector. `DashMap` implements `IntoIterator`, so the entries can simply be moved. Fixes #1079.

### `PackedEqClasses::from_collapsed` did not reserve

`labels`, `combined` and `weights` grew from empty to tens of millions of elements: a reallocation and full copy at every doubling, plus a transient peak of roughly 1.5x the final size while both buffers are live. `starts` was already reserved correctly, which shows the intent; the other three were missed. The exact total is one cheap pass over the class list (it only reads `Vec::len`). Fixes #1080.

### CSR offsets could truncate silently

While in `from_collapsed`: the offsets are `u32` and `starts.push(labels.len() as u32)` wrapped silently past `u32::MAX` incidences. After that `class()` hands the optimizer slices belonging to *other* classes — wrong abundances, no panic, no warning, no diagnostic of any kind.

4.29 billion incidences is ~17 GB of `labels`, so this is not a small-index concern; it is reachable on a heavily multi-mapping library against a large decoy-aware index, which is exactly where nobody would think to suspect arithmetic. This adds an assertion so the limit fails loudly instead of producing plausible nonsense. Widening `starts` to `u64` would remove the ceiling rather than report it, and is a reasonable follow-up if you would prefer that. Fixes #1088.

### Verification

- `cargo test --workspace` passes; `cargo clippy --workspace --all-targets` adds no warnings; `cargo fmt` clean.
- Built against `develop` and compared to a `develop` baseline binary on `sample_data`: `quant.sf` byte-identical for plain, `--seqBias --gcBias --posBias`, and `--softclip` runs; `meta_info.json` (modulo timing) and `lib_format_counts.json` identical.

Caveat worth stating: `sample_data` has 15 transcripts, so the parity check confirms the code paths agree, not that the memory behaviour holds at transcriptome scale. The memory claims here are structural (fewer copies of the same data), not measured. I have not benchmarked peak RSS on a human-scale index.
