### PR TITLE
perf(quant): take the fragment-length snapshot once per batch

### DIFF
--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -514,10 +514,20 @@ fn record_discrete(sh: &Shared, maps: &[ScoredMapping], acc: &salmon_model::Disc
 ///
 /// Counting, library detection, and FLD training always run; `log_fm` is the
 /// current minibatch's forgetting mass (used only when `use_online`).
+///
+/// `fld_pmf`/`fld_cmf` are the batch's fragment-length snapshot pair, taken once
+/// by the caller (see the batch loops). They are passed in rather than read here
+/// because the snapshot only changes at `refresh_online`, which runs at the batch
+/// boundary — so re-reading it per fragment would re-acquire two `RwLock`s and
+/// bump two `Arc` refcounts, on cache lines every worker shares, to obtain a value
+/// that provably cannot have changed.
+#[allow(clippy::too_many_arguments)]
 fn record(
     sh: &Shared,
     maps: &[ScoredMapping],
     log_fm: f64,
+    fld_pmf: &[f64],
+    fld_cmf: &[f64],
     seqbias: Option<&mut (SBModel, SBModel)>,
     gcbias: Option<&mut GcFragModel>,
     posbias: Option<&mut (Vec<SimplePosBias>, Vec<SimplePosBias>)>,
@@ -578,9 +588,25 @@ fn record(
     // num_mapped`. C++ salmon likewise counts a fragment as mapped only once it
     // has a compatible mapping.
     sh.num_mapped.fetch_add(1, Ordering::Relaxed);
-    // Classify the fragment as orphan when its best compatible mapping has only
-    // one mate of a pair placed (PairedEndLeft / PairedEndRight). Single-end
-    // libraries never count as orphan here.
+    // Classify the fragment as orphan when only one mate of a pair was placed
+    // (PairedEndLeft / PairedEndRight). Single-end libraries never count as
+    // orphan here.
+    //
+    // Reading `compat[0]` is sound because every surviving mapping of a fragment
+    // carries the SAME status, so the first is as good as any:
+    //   * selective alignment: `map_read_pair_into` drops all orphans as soon as
+    //     one non-decoy concordant pair survives, and `finalize_mappings_counted_into`
+    //     never emits decoy mappings — so the set is either all-paired or
+    //     all-orphan;
+    //   * sketch: `map_read_pair_sketch_into` derives one `status` from the
+    //     fragment's `map_type` and stamps it on every accepted hit.
+    // Note `compat` is ordered by transcript id (finalize sorts by `tid`), not by
+    // score, so this must not be read as "the best mapping" — it is "the status
+    // this fragment mapped with", which is well defined.
+    debug_assert!(
+        compat.iter().all(|(m, _)| m.status == compat[0].0.status),
+        "a fragment's surviving mappings must share one status"
+    );
     if matches!(
         compat[0].0.status,
         MateStatus::PairedEndLeft | MateStatus::PairedEndRight
@@ -588,20 +614,18 @@ fn record(
         sh.num_orphan.fetch_add(1, Ordering::Relaxed);
     }
 
-    // Capture ONE immutable FLD snapshot pair (PMF + CMF) for this fragment — a
-    // pair of cheap `Arc` clones, no per-fragment allocation — and share it
-    // between the online posterior and the persistent eq-class weight. Indexing
-    // the same snapshot for every mapping guarantees that transcripts sharing a
-    // fragment length (in particular exact-duplicate transcripts) receive an
-    // identical fragment-length probability even if another thread refreshes the
-    // shared snapshot meanwhile. Reading the live FLD per mapping (racing atomic
-    // loads on a concurrently-updated distribution) returned slightly different
-    // values for the same length and let the VBEM α<1 prior break duplicate
-    // symmetry. Mirrors C++ salmon's per-worker `LogCMFCache`. Empty until the
-    // first online refresh (the pre-burn-in window, where the FLD term is not
-    // folded in anyway).
-    let fld_pmf = sh.fld.online_snapshot();
-    let fld_cmf = sh.fld.online_cmf_snapshot();
+    // `fld_pmf`/`fld_cmf` are ONE immutable FLD snapshot pair (PMF + CMF), taken
+    // once per batch by the caller and shared here between the online posterior
+    // and the persistent eq-class weight. Indexing the same snapshot for every
+    // mapping guarantees that transcripts sharing a fragment length (in
+    // particular exact-duplicate transcripts) receive an identical
+    // fragment-length probability even if another thread refreshes the shared
+    // snapshot meanwhile. Reading the live FLD per mapping (racing atomic loads
+    // on a concurrently-updated distribution) returned slightly different values
+    // for the same length and let the VBEM α<1 prior break duplicate symmetry.
+    // Mirrors C++ salmon's per-worker `LogCMFCache`. Empty until the first online
+    // refresh (the pre-burn-in window, where the FLD term is not folded in
+    // anyway).
 
     // Per-fragment bias-collection weights. With online (dual-phase) inference
     // these are abundance-aware posteriors `softmax(mass_t + log w_t)`, which
@@ -646,8 +670,8 @@ fn record(
                             sh.model_single_frag_prob,
                             sh.paired_lib,
                             sh.no_frag_length_dist,
-                            &fld_pmf,
-                            &fld_cmf,
+                            fld_pmf,
+                            fld_cmf,
                         );
                         let log_cov = if *w > 0.0 { w.ln() } else { f64::NEG_INFINITY };
                         (m.tid, log_cov + start_pos_prob + log_frag_prob)
@@ -762,8 +786,8 @@ fn record(
                 sh.model_single_frag_prob,
                 sh.paired_lib,
                 sh.no_frag_length_dist,
-                &fld_pmf,
-                &fld_cmf,
+                fld_pmf,
+                fld_cmf,
             )
         })
         .collect();
@@ -931,6 +955,15 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         } else {
             0.0
         };
+        // One FLD snapshot pair for the whole batch. The shared snapshot is only
+        // replaced by `refresh_online`, which runs at the batch boundary, so a
+        // per-fragment re-read would take two `RwLock`s and bump two `Arc`
+        // refcounts — on cache lines shared by every worker — to fetch a value
+        // that cannot have changed. Taking it here also makes the per-fragment
+        // view *more* stable than before: previously a concurrent refresh could
+        // land between two fragments of the same batch.
+        let fld_pmf = sh.fld.online_snapshot();
+        let fld_cmf = sh.fld.online_cmf_snapshot();
         // Reused across the batch's reads (the `*_into` calls clear it), so the
         // per-fragment result Vec isn't reallocated per read.
         let mut maps: Vec<ScoredMapping> = Vec::new();
@@ -1021,6 +1054,8 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     &sh,
                     &maps,
                     log_fm,
+                    &fld_pmf,
+                    &fld_cmf,
                     seqbias.as_mut(),
                     gcbias.as_mut(),
                     posbias.as_mut(),
@@ -1085,6 +1120,9 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         } else {
             0.0
         };
+        // One FLD snapshot pair for the whole batch (see the paired-end loop).
+        let fld_pmf = sh.fld.online_snapshot();
+        let fld_cmf = sh.fld.online_cmf_snapshot();
         // Reused across the batch's reads (the `*_into` calls clear it).
         let mut maps: Vec<ScoredMapping> = Vec::new();
         for rec in records {
@@ -1142,6 +1180,8 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     &sh,
                     &maps,
                     log_fm,
+                    &fld_pmf,
+                    &fld_cmf,
                     seqbias.as_mut(),
                     gcbias.as_mut(),
                     posbias.as_mut(),


### PR DESCRIPTION
Part of #1092. Fixes #1078.

**This PR is justified on determinism and code structure, not on throughput. Measured at scale, it makes no measurable throughput difference at any thread count.** The numbers are below.

### What it changes

`record()` runs once per fragment and began by taking its own fragment-length snapshot:

```rust
let fld_pmf = sh.fld.online_snapshot();
let fld_cmf = sh.fld.online_cmf_snapshot();
```

Both fields are `RwLock<Arc<Vec<f64>>>`, so that is two lock acquisitions and two `Arc` refcount round trips per fragment, on cache lines shared by every worker.

The snapshot is only replaced by `refresh_online()`, which runs once per mini-batch in `on_batch_complete`, so it is invariant across a batch. This takes it once at the top of each batch loop and passes it in.

### The semantic change, stated plainly

This is **not** a pure reordering of the same arithmetic. Previously a fragment late in a batch could pick up a snapshot that another thread had refreshed mid-batch; now every fragment in a batch uses the batch-start snapshot. **Fragments therefore use a uniformly staler FLD than before.** That changes what the fragment-length term means for a given fragment.

Consequently `quant.sf` is byte-identical to develop at `-p 1` **and nowhere else**. At higher thread counts there is a systematic shift, measured by the maintainers at 222–243 max TPM difference at `-p 32` against a 21–37 noise floor — small in context (r = 0.999986) and in the better direction, but real and not noise.

### Why it is still worth doing

It strengthens the invariant the per-fragment snapshot was introduced for in `4a25b3db` ("consistent FLD reads so duplicate transcripts stay symmetric"), rather than weakening it: previously two fragments in the same batch could see different snapshots, and now they cannot.

That shows up directly as reproducibility. Run-to-run spread of each binary against **itself**, 4 interleaved reps, max TPM difference over 207,249 transcripts:

| p | develop | this PR |
| --- | --- | --- |
| 1 | 0.000 | 0.000 |
| 8 | 9.656 | 7.284 |
| 16 | **42.296** | **7.094** |

**6.0x tighter at `-p 16`.** The maintainers independently measured 7x at `-p 32` on different hardware.

### Throughput: no change

Interleaved, 4 rounds, median wall clock against develop. 10M read pairs from ERR188044, GRCh38 cDNA release-110 (207,249 transcripts), 16-core Apple Silicon:

| p | develop | this PR | delta |
| --- | --- | --- | --- |
| 1 | 222.77s | 222.84s | +0.03% |
| 8 | 35.21s | 36.92s | +4.9% |
| 16 | 28.07s | 27.27s | −2.8% |

The p=8 and p=16 figures swing in both directions depending on which rounds are used (rounds 3–4, machine settled: +0.3% and −5.0%), which means they measure the machine, not the code. User CPU tracks wall throughout. Peak RSS flat.

**The original rationale for this PR — six atomic read-modify-writes per fragment collapsing to six per batch — does not materialise as throughput.** It was asserted from first principles and the measurement does not support it. Maintainer measurement at `-p 32` agrees.

A ~3.5% `-p 1` regression was observed by the maintainers on x86-64; it does not reproduce on arm64 (+0.03% wall, +0.07% user, interleaved). A plausible mechanism for the asymmetry: `record` gained two `&[f64]` parameters, and a slice is two registers where `&Arc<Vec<f64>>` is one, so this adds four register-equivalents to a per-fragment call — which x86-64 SysV (six register args) feels and AArch64 (eight) may absorb. Bundling the pair into one `&FldSnapshot` would restore a single register if that is worth closing off.

### Benchmark methodology

All timings interleave the binaries, rotating every round. A first blocked sweep (develop, then this PR, then #1099 back to back) produced an apparent +13%/+21% regression for whichever ran last, entirely from thermal drift; interleaving removed it completely.

Byte-comparison alone cannot settle parity here, because **develop is not run-to-run deterministic at fixed thread count** in the default path — see the noise-floor table above. Every cross-binary number is reported against that measured floor.
