### PR TITLE
perf(infer): build the packed CSR layout once per run

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -1782,9 +1782,16 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
     // The packed CSR layout is built once and reused by the EM, the post-bias
     // re-run and bootstrap / Gibbs (see the reads-mode driver for the rationale).
     // `weights` is Gibbs-only, so it is populated only when Gibbs will run.
-    let want_gibbs = !opts.skip_quant && opts.num_bootstraps == 0 && opts.num_gibbs_samples > 0;
+    // One resolution of which posterior method (if any) this run will use; the
+    // packed layout and the dispatch below both read it, so the precedence is
+    // stated once rather than restated at each site.
+    let posterior = salmon_infer::PosteriorMethod::resolve(
+        opts.skip_quant,
+        opts.num_bootstraps,
+        opts.num_gibbs_samples,
+    );
     let mut packed =
-        salmon_infer::PackedEqClasses::from_collapsed_with(&collapsed, num_refs, want_gibbs);
+        salmon_infer::PackedEqClasses::from_collapsed_for(&collapsed, num_refs, posterior);
     // `--initUniform` forces the plain uniform EM start; otherwise warm-start
     // from the online-estimate-blended init.
     let mut em = if opts.skip_quant {

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -63,7 +63,7 @@ use salmon_core::{
     ReadType,
 };
 use salmon_eqclass::{range_factorize_bins, EquivalenceClassBuilder, TranscriptGroup};
-use salmon_infer::{optimize, optimize_with_init, EmOptions};
+use salmon_infer::EmOptions;
 use salmon_model::FragmentLengthDistribution;
 
 const SALMON_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -1779,6 +1779,12 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             .map(|&p| p * frac_observed + uniform_prior * (1.0 - frac_observed))
             .collect()
     });
+    // The packed CSR layout is built once and reused by the EM, the post-bias
+    // re-run and bootstrap / Gibbs (see the reads-mode driver for the rationale).
+    // `weights` is Gibbs-only, so it is populated only when Gibbs will run.
+    let want_gibbs = !opts.skip_quant && opts.num_bootstraps == 0 && opts.num_gibbs_samples > 0;
+    let mut packed =
+        salmon_infer::PackedEqClasses::from_collapsed_with(&collapsed, num_refs, want_gibbs);
     // `--initUniform` forces the plain uniform EM start; otherwise warm-start
     // from the online-estimate-blended init.
     let mut em = if opts.skip_quant {
@@ -1791,12 +1797,12 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             dropped_mass: 0.0,
         }
     } else if opts.init_uniform {
-        optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths))
+        salmon_infer::optimize_packed_with_init(&packed, &opts.em, true, None, Some(&eff_lengths))
     } else {
-        optimize_with_init(
-            &collapsed,
-            num_refs,
+        salmon_infer::optimize_packed_with_init(
+            &packed,
             &opts.em,
+            true,
             init_alphas.as_deref(),
             Some(&eff_lengths),
         )
@@ -1825,7 +1831,15 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             opts.no_bias_length_threshold,
         );
         collapsed.update_eff_lengths(&eff_lengths);
-        em = optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths));
+        // Only the combined weights changed; patch them in place.
+        packed.refresh_combined(&collapsed);
+        em = salmon_infer::optimize_packed_with_init(
+            &packed,
+            &opts.em,
+            true,
+            None,
+            Some(&eff_lengths),
+        );
     }
     let inference_truncated_mass = em.dropped_mass;
     let (em_iters, em_converged) = (em.iters, em.converged);
@@ -1880,7 +1894,6 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
     // layout is identical to reads mode — alignment mode simply feeds it from the
     // BAM-derived eq-classes — so the same `salmon_infer` samplers apply. Bootstrap
     // takes precedence over Gibbs, matching reads mode.
-    let packed = salmon_infer::PackedEqClasses::from_collapsed(&collapsed, num_refs);
     let ambig = salmon_infer::ambiguity_counts(&packed);
     let bootstraps: Vec<Vec<f64>> = if opts.skip_quant {
         Vec::new()

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -1391,6 +1391,12 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     //  * otherwise ⇒ first EM, then (if bias) a SECOND RAD read for bias
     //    collection (weighted by that EM or a baked / diagnostic prior) + re-EM.
     let mut bias_dump = salmon_model::dumps::BiasDump::default();
+    // Built once and reused by every EM below plus bootstrap / Gibbs; only
+    // `combined` changes after bias correction, and `refresh_combined` patches
+    // that in place. `weights` is Gibbs-only.
+    let want_gibbs = !opts.skip_quant && opts.num_bootstraps == 0 && opts.num_gibbs_samples > 0;
+    let mut packed =
+        salmon_infer::PackedEqClasses::from_collapsed_with(&collapsed, num_refs, want_gibbs);
     let em = if opts.skip_quant {
         salmon_infer::EmResult {
             alphas: vec![0.0; num_refs],
@@ -1422,9 +1428,16 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             opts.no_bias_length_threshold,
         );
         collapsed.update_eff_lengths(&eff_lengths);
-        salmon_infer::optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths))
+        packed.refresh_combined(&collapsed);
+        salmon_infer::optimize_packed_with_init(&packed, &opts.em, true, None, Some(&eff_lengths))
     } else {
-        let mut em = salmon_infer::optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths));
+        let mut em = salmon_infer::optimize_packed_with_init(
+            &packed,
+            &opts.em,
+            true,
+            None,
+            Some(&eff_lengths),
+        );
         if bias_on {
             // Abundances weighting bias collection: baked prior if present, else
             // this run's (converged) first EM. (Reached only when no up-front
@@ -1490,7 +1503,14 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                 opts.no_bias_length_threshold,
             );
             collapsed.update_eff_lengths(&eff_lengths);
-            em = salmon_infer::optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths));
+            packed.refresh_combined(&collapsed);
+            em = salmon_infer::optimize_packed_with_init(
+                &packed,
+                &opts.em,
+                true,
+                None,
+                Some(&eff_lengths),
+            );
         }
         em
     };
@@ -1524,7 +1544,6 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     let length_classes =
         salmon_model::compute_length_quantiles(&lengths, salmon_model::NUM_LENGTH_CLASSES);
 
-    let packed = salmon_infer::PackedEqClasses::from_collapsed(&collapsed, num_refs);
     let ambig = salmon_infer::ambiguity_counts(&packed);
     let bootstraps: Vec<Vec<f64>> = if opts.skip_quant {
         Vec::new()

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -1394,9 +1394,16 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     // Built once and reused by every EM below plus bootstrap / Gibbs; only
     // `combined` changes after bias correction, and `refresh_combined` patches
     // that in place. `weights` is Gibbs-only.
-    let want_gibbs = !opts.skip_quant && opts.num_bootstraps == 0 && opts.num_gibbs_samples > 0;
+    // One resolution of which posterior method (if any) this run will use; the
+    // packed layout and the dispatch below both read it, so the precedence is
+    // stated once rather than restated at each site.
+    let posterior = salmon_infer::PosteriorMethod::resolve(
+        opts.skip_quant,
+        opts.num_bootstraps,
+        opts.num_gibbs_samples,
+    );
     let mut packed =
-        salmon_infer::PackedEqClasses::from_collapsed_with(&collapsed, num_refs, want_gibbs);
+        salmon_infer::PackedEqClasses::from_collapsed_for(&collapsed, num_refs, posterior);
     let em = if opts.skip_quant {
         salmon_infer::EmResult {
             alphas: vec![0.0; num_refs],

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -565,7 +565,16 @@ struct QuantArgs {
     #[arg(long = "numBootstraps", default_value_t = 0)]
     num_bootstraps: u32,
     /// Number of Gibbs posterior samples (mutually exclusive with bootstraps).
-    #[arg(long = "numGibbsSamples", default_value_t = 0)]
+    ///
+    /// `conflicts_with` makes that exclusivity real. It was previously only
+    /// stated in this doc comment and resolved silently by dispatch order, so
+    /// passing both ran the bootstrap and ignored the Gibbs request without
+    /// saying so.
+    #[arg(
+        long = "numGibbsSamples",
+        default_value_t = 0,
+        conflicts_with = "num_bootstraps"
+    )]
     num_gibbs_samples: u32,
     /// Gibbs thinning factor.
     #[arg(long = "thinningFactor", default_value_t = 16)]

--- a/crates/salmon-infer/src/lib.rs
+++ b/crates/salmon-infer/src/lib.rs
@@ -38,7 +38,7 @@ mod packed;
 pub mod uncertainty;
 
 pub use online::OnlineInference;
-pub use packed::PackedEqClasses;
+pub use packed::{PackedEqClasses, PosteriorMethod};
 pub use uncertainty::{ambiguity_counts, bootstrap, gibbs_sample, GibbsOptions};
 
 /// EM/VBEM acceleration scheme applied on top of the fixed-point map.

--- a/crates/salmon-infer/src/packed.rs
+++ b/crates/salmon-infer/src/packed.rs
@@ -67,6 +67,22 @@ impl PackedEqClasses {
     /// `combined_weights` are already populated
     /// ([`update_eff_lengths`](salmon_eqclass::CollapsedEqClasses::update_eff_lengths)).
     pub fn from_collapsed(eq: &CollapsedEqClasses, num_txps: usize) -> Self {
+        Self::from_collapsed_with(eq, num_txps, true)
+    }
+
+    /// As [`from_collapsed`](Self::from_collapsed), but `keep_weights == false`
+    /// leaves the raw `weights` array empty.
+    ///
+    /// `weights` is read only by the Gibbs sampler; the EM path uses `combined`.
+    /// On a run without `--numGibbsSamples` it is therefore 8 bytes per CSR
+    /// incidence that is allocated, filled and never read — on the order of
+    /// 160 MB for a human-scale run. Callers that know Gibbs will not run pass
+    /// `false`.
+    pub fn from_collapsed_with(
+        eq: &CollapsedEqClasses,
+        num_txps: usize,
+        keep_weights: bool,
+    ) -> Self {
         let n = eq.classes.len();
         // Size the flat arrays up front. Growing them from empty costs a
         // reallocation plus a full copy at every doubling, and leaves a transient
@@ -91,7 +107,7 @@ impl PackedEqClasses {
         let mut labels = Vec::with_capacity(total_labels);
         let mut starts = Vec::with_capacity(n + 1);
         let mut combined = Vec::with_capacity(total_labels);
-        let mut weights = Vec::with_capacity(total_labels);
+        let mut weights = Vec::with_capacity(if keep_weights { total_labels } else { 0 });
         let mut counts = Vec::with_capacity(n);
         // The first class starts at offset 0; every later entry is appended after
         // that class's data has been copied in.
@@ -104,7 +120,9 @@ impl PackedEqClasses {
             }
             labels.extend_from_slice(&group.txps);
             combined.extend_from_slice(&value.combined_weights);
-            weights.extend_from_slice(&value.weights);
+            if keep_weights {
+                weights.extend_from_slice(&value.weights);
+            }
             counts.push(value.count);
             total += value.count;
             starts.push(labels.len() as u32);
@@ -118,6 +136,35 @@ impl PackedEqClasses {
             num_txps,
             total_count: total,
         }
+    }
+
+    /// Rewrite `combined` in place from `eq`'s current `combined_weights`,
+    /// leaving `labels`, `starts`, `counts` and `weights` untouched.
+    ///
+    /// Bias correction recomputes effective lengths and calls
+    /// [`CollapsedEqClasses::update_eff_lengths`], which changes *only* the
+    /// combined weights. Rebuilding the whole packed layout to pick that up
+    /// re-copies the labels and counts too — hundreds of MB on a human-scale run
+    /// — for arrays bit-identical to the ones already held.
+    ///
+    /// `eq` must be the class set the layout was built from. Classes are never
+    /// invalidated after construction (nothing clears `TranscriptGroup::valid`),
+    /// so the filter below matches the original build; the assertion pins that.
+    pub fn refresh_combined(&mut self, eq: &CollapsedEqClasses) {
+        let mut at = 0usize;
+        for (group, value) in &eq.classes {
+            if !group.valid {
+                continue;
+            }
+            let n = value.combined_weights.len();
+            self.combined[at..at + n].copy_from_slice(&value.combined_weights);
+            at += n;
+        }
+        assert_eq!(
+            at,
+            self.combined.len(),
+            "refresh_combined: class set changed since the packed layout was built"
+        );
     }
 
     /// Number of (valid) classes.

--- a/crates/salmon-infer/src/packed.rs
+++ b/crates/salmon-infer/src/packed.rs
@@ -62,15 +62,67 @@ pub struct PackedEqClasses {
     pub total_count: u64,
 }
 
+/// Which posterior-sampling method a run will use, if any.
+///
+/// Bootstrap and Gibbs are mutually exclusive — the CLI rejects both together —
+/// so this is the single place that fact is written down. Deriving it once and
+/// passing it around replaces a `bool` at each call site whose meaning ("does
+/// this run need the raw per-mapping weights?") was only recoverable by knowing
+/// which sampler reads which array.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum PosteriorMethod {
+    /// Point estimate only; no posterior replicates.
+    #[default]
+    None,
+    /// Non-parametric bootstrap over the equivalence classes.
+    Bootstrap { replicates: u32 },
+    /// Collapsed Gibbs sampling.
+    Gibbs { samples: u32 },
+}
+
+impl PosteriorMethod {
+    /// Resolve from the raw option values.
+    ///
+    /// `skip_quant` suppresses both. Bootstrap wins if both counts are somehow
+    /// non-zero, matching the historical dispatch order — though the CLI now
+    /// rejects that combination, so it should be unreachable from a real run.
+    pub fn resolve(skip_quant: bool, num_bootstraps: u32, num_gibbs_samples: u32) -> Self {
+        if skip_quant {
+            Self::None
+        } else if num_bootstraps > 0 {
+            Self::Bootstrap {
+                replicates: num_bootstraps,
+            }
+        } else if num_gibbs_samples > 0 {
+            Self::Gibbs {
+                samples: num_gibbs_samples,
+            }
+        } else {
+            Self::None
+        }
+    }
+
+    /// Whether the run needs [`PackedEqClasses::weights`], the raw per-mapping
+    /// conditional weights.
+    ///
+    /// Only the Gibbs sampler reads them; the EM and the bootstrap use
+    /// `combined`. On a human-scale run that array is ~8 bytes per CSR
+    /// incidence, so skipping it saves on the order of 160 MB that would be
+    /// allocated, filled and never read.
+    pub fn needs_raw_weights(self) -> bool {
+        matches!(self, Self::Gibbs { .. })
+    }
+}
+
 impl PackedEqClasses {
     /// Build the packed layout from a finalized [`CollapsedEqClasses`] whose
     /// `combined_weights` are already populated
     /// ([`update_eff_lengths`](salmon_eqclass::CollapsedEqClasses::update_eff_lengths)).
     pub fn from_collapsed(eq: &CollapsedEqClasses, num_txps: usize) -> Self {
-        Self::from_collapsed_with(eq, num_txps, true)
+        Self::from_collapsed_for(eq, num_txps, PosteriorMethod::Gibbs { samples: 1 })
     }
 
-    /// As [`from_collapsed`](Self::from_collapsed), but `keep_weights == false`
+    /// As [`from_collapsed`](Self::from_collapsed), but skips the raw weights
     /// leaves the raw `weights` array empty.
     ///
     /// `weights` is read only by the Gibbs sampler; the EM path uses `combined`.
@@ -78,10 +130,10 @@ impl PackedEqClasses {
     /// incidence that is allocated, filled and never read — on the order of
     /// 160 MB for a human-scale run. Callers that know Gibbs will not run pass
     /// `false`.
-    pub fn from_collapsed_with(
+    pub fn from_collapsed_for(
         eq: &CollapsedEqClasses,
         num_txps: usize,
-        keep_weights: bool,
+        method: PosteriorMethod,
     ) -> Self {
         let n = eq.classes.len();
         // Size the flat arrays up front. Growing them from empty costs a
@@ -107,6 +159,7 @@ impl PackedEqClasses {
         let mut labels = Vec::with_capacity(total_labels);
         let mut starts = Vec::with_capacity(n + 1);
         let mut combined = Vec::with_capacity(total_labels);
+        let keep_weights = method.needs_raw_weights();
         let mut weights = Vec::with_capacity(if keep_weights { total_labels } else { 0 });
         let mut counts = Vec::with_capacity(n);
         // The first class starts at offset 0; every later entry is appended after

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -51,7 +51,7 @@ use salmon_core::{LibraryFormat, PhaseTimer, ReadType};
 use salmon_eqclass::EquivalenceClassBuilder;
 use salmon_index::SalmonIndex;
 pub use salmon_infer::EmAccel;
-use salmon_infer::{optimize, optimize_with_init, EmOptions};
+use salmon_infer::{optimize_packed_with_init, EmOptions};
 use salmon_map::MapConfig;
 use salmon_model::dumps::{dump_bias_models_to_file, BiasDump};
 use salmon_model::{FragmentLengthDistribution, LibraryTypeDetector, SBModel};
@@ -748,6 +748,18 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             if opts.em.use_vbem { "VBEM" } else { "EM" }
         );
     }
+    // The packed CSR layout is built ONCE and reused by every consumer below: the
+    // burn-in EM, the warm-started EM after bias correction, and bootstrap /
+    // Gibbs. `optimize`/`optimize_with_init` each build their own internally, so
+    // going through them meant re-copying labels, counts and weights (hundreds of
+    // MB on a human-scale run) two to three times over data that is bit-identical
+    // apart from `combined`, which `refresh_combined` rewrites in place.
+    //
+    // `weights` (the raw conditional weights) is only read by Gibbs, so it is
+    // populated only when Gibbs will actually run.
+    let want_gibbs = !opts.skip_quant && opts.num_bootstraps == 0 && opts.num_gibbs_samples > 0;
+    let mut packed =
+        salmon_infer::PackedEqClasses::from_collapsed_with(&collapsed, num_refs, want_gibbs);
     let mut em = if opts.skip_quant && want_rough_abund {
         // `--deterministic` + bias map-only pass: run a SHORT EM on the NAIVE
         // eq-classes (uniform-weight, with library-incompatible placements dropped
@@ -782,9 +794,9 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         // EM, and a zeroed alpha can never recover under the multiplicative
         // update (salmon keeps one continuous, untruncated vector).
         pre.min_alpha = 0.0;
-        optimize(&collapsed, num_refs, &pre, Some(&eff_lengths))
+        optimize_packed_with_init(&packed, &pre, true, None, Some(&eff_lengths))
     } else {
-        optimize(&collapsed, num_refs, &opts.em, Some(&eff_lengths))
+        optimize_packed_with_init(&packed, &opts.em, true, None, Some(&eff_lengths))
     };
 
     // ---- bias correction: re-estimate effective lengths --------------------
@@ -963,16 +975,13 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
             .collect();
         eff_lengths = corrected;
         collapsed.update_eff_lengths(&eff_lengths);
+        // Only the combined weights changed, so patch them into the existing
+        // packed layout rather than rebuilding it.
+        packed.refresh_combined(&collapsed);
         // Warm-start the single full convergence from the burn-in alphas, as
         // salmon continues the same vector after its in-loop correction.
         let warm = std::mem::take(&mut em.alphas);
-        em = optimize_with_init(
-            &collapsed,
-            num_refs,
-            &opts.em,
-            Some(&warm),
-            Some(&eff_lengths),
-        );
+        em = optimize_packed_with_init(&packed, &opts.em, true, Some(&warm), Some(&eff_lengths));
     }
     // The min-alpha truncation is applied inside the EM as a mass-preserving
     // redistribution (see `redistribute_truncated`): the truncated mass flows to
@@ -1018,7 +1027,6 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
 
     // ---- posterior uncertainty (bootstrap / Gibbs) + ambiguity --------------
     // The packed CSR layout (piscem-infer style) makes these parallel-friendly.
-    let packed = salmon_infer::PackedEqClasses::from_collapsed(&collapsed, num_refs);
     let ambig = salmon_infer::ambiguity_counts(&packed);
     let bootstraps: Vec<Vec<f64>> = if opts.skip_quant {
         Vec::new()

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -757,9 +757,16 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     //
     // `weights` (the raw conditional weights) is only read by Gibbs, so it is
     // populated only when Gibbs will actually run.
-    let want_gibbs = !opts.skip_quant && opts.num_bootstraps == 0 && opts.num_gibbs_samples > 0;
+    // One resolution of which posterior method (if any) this run will use; the
+    // packed layout and the dispatch below both read it, so the precedence is
+    // stated once rather than restated at each site.
+    let posterior = salmon_infer::PosteriorMethod::resolve(
+        opts.skip_quant,
+        opts.num_bootstraps,
+        opts.num_gibbs_samples,
+    );
     let mut packed =
-        salmon_infer::PackedEqClasses::from_collapsed_with(&collapsed, num_refs, want_gibbs);
+        salmon_infer::PackedEqClasses::from_collapsed_for(&collapsed, num_refs, posterior);
     let mut em = if opts.skip_quant && want_rough_abund {
         // `--deterministic` + bias map-only pass: run a SHORT EM on the NAIVE
         // eq-classes (uniform-weight, with library-incompatible placements dropped
@@ -1028,28 +1035,30 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     // ---- posterior uncertainty (bootstrap / Gibbs) + ambiguity --------------
     // The packed CSR layout (piscem-infer style) makes these parallel-friendly.
     let ambig = salmon_infer::ambiguity_counts(&packed);
-    let bootstraps: Vec<Vec<f64>> = if opts.skip_quant {
-        Vec::new()
-    } else if opts.num_bootstraps > 0 {
-        salmon_infer::bootstrap(&packed, &opts.em, opts.num_bootstraps, 0x5A13_0000)
-    } else if opts.num_gibbs_samples > 0 {
-        // Gibbs prior follows the main optimizer (salmon): with VBEM and a
-        // per-transcript prior it is `max(1.0, vbPrior)`; with plain EM it is
-        // 1e-3 per transcript. The rust VBEM uses a constant per-transcript prior.
-        let prior = if opts.em.use_vbem {
-            opts.em.vb_prior.max(1.0)
-        } else {
-            1e-3
-        };
-        let gopts = salmon_infer::GibbsOptions {
-            num_samples: opts.num_gibbs_samples,
-            thinning: opts.thinning_factor,
-            prior,
-            per_transcript_prior: true,
-        };
-        salmon_infer::gibbs_sample(&packed, &eff_lengths, &counts, &gopts, 0x6217_0000)
-    } else {
-        Vec::new()
+    // Same `posterior` the packed layout was built for, so the run cannot decide
+    // it needs Gibbs after the weights it reads were skipped.
+    let bootstraps: Vec<Vec<f64>> = match posterior {
+        salmon_infer::PosteriorMethod::None => Vec::new(),
+        salmon_infer::PosteriorMethod::Bootstrap { replicates } => {
+            salmon_infer::bootstrap(&packed, &opts.em, replicates, 0x5A13_0000)
+        }
+        salmon_infer::PosteriorMethod::Gibbs { samples } => {
+            // Gibbs prior follows the main optimizer (salmon): with VBEM and a
+            // per-transcript prior it is `max(1.0, vbPrior)`; with plain EM it is
+            // 1e-3 per transcript. The rust VBEM uses a constant per-transcript prior.
+            let prior = if opts.em.use_vbem {
+                opts.em.vb_prior.max(1.0)
+            } else {
+                1e-3
+            };
+            let gopts = salmon_infer::GibbsOptions {
+                num_samples: samples,
+                thinning: opts.thinning_factor,
+                prior,
+                per_transcript_prior: true,
+            };
+            salmon_infer::gibbs_sample(&packed, &eff_lengths, &counts, &gopts, 0x6217_0000)
+        }
     };
     timer.mark("posterior");
 


### PR DESCRIPTION
Part of #1092. Fixes #1087.

**Measured: peak RSS −1.39% (plain), throughput null.** The larger half of this PR's original rationale was wrong; corrected below.

### What it changes

`optimize` and `optimize_with_init` each construct a `PackedEqClasses` internally, so a bias-corrected run built the flat CSR layout twice and a run with bootstrap or Gibbs three times. The three drivers (reads, alignment, RAD) now build it once and call `optimize_packed_with_init` directly; `refresh_combined` patches the combined weights in place after bias correction, since that is the only array `update_eff_lengths` changes. It asserts the class set has not changed, which holds because nothing ever clears `TranscriptGroup::valid`.

Also gates the raw `weights` array, which only the Gibbs sampler reads: `from_collapsed_with(.., keep_weights)` lets the drivers skip populating it.

### Correction to the original rationale

I claimed avoiding the rebuilds would cut peak memory. **It cannot.** `optimize()` builds its layout, uses it, and drops it on return, so two copies never coexist. The repeated construction costs allocation and copying, not peak RSS. That was wrong and I only found it by measuring.

What the measurement does show is the `keep_weights` gate working, and nothing else:

| configuration | develop | this PR | delta |
| --- | --- | --- | --- |
| plain, `-p 8` | 1079 MB | 1064 MB | **−1.39%** |
| `--numGibbsSamples 4`, `-p 8` | 1072 MB | 1082 MB | +0.89% (noise) |

~15 MB, only when Gibbs is off — which is exactly right, since `weights` is 8 bytes per CSR incidence and Gibbs is the only consumer. With Gibbs requested it is populated in both builds and there is nothing to save.

Wall clock over the same runs: 34.33s vs 34.59s. **No throughput change**, consistent with every other measured item in #1092.

10M read pairs from ERR188044, GRCh38 cDNA release-110 (207,249 transcripts), 16-core arm64, interleaved with the warm-up round discarded.

### Why take it anyway

- Building the structure once instead of three times is simpler to follow than three call sites that each rebuild it implicitly, whatever it costs.
- `refresh_combined` states what actually changes after bias correction, where the previous code re-derived everything and left the reader to work out that only `combined` differs.
- The `keep_weights` gate is a real if modest saving, and it makes the Gibbs-only lifetime of that array explicit rather than implicit.

If the memory number is too small to be worth the diff, that is a fair call and I will not argue it.

### Parity

Byte-identical to develop on `sample_data`: reads mode plain / all three bias models / `--numBootstraps 8` / `--numGibbsSamples 8` (including `bootstraps.gz`, which is what exercises the `keep_weights` gate) / bias+bootstrap; RAD requant plain / bias / Gibbs; alignment mode plain and bias+Gibbs at `-p 1`.

Alignment mode is pinned to `-p 1` because it does not reproduce run to run at `-p > 1` on develop either (#1098). Per the methodology note on #1092, byte comparison above `-p 1` cannot establish parity here.
