### PR TITLE
feat(align): optional in-memory intermediate for deterministic alignment mode

### DIFF
--- a/crates/salmon-align/src/bam_rad.rs
+++ b/crates/salmon-align/src/bam_rad.rs
@@ -76,11 +76,38 @@ pub struct AlignRadSummary {
 
 /// Project a name-grouped transcriptome BAM into a fully-baked salmon RAD at
 /// `rad_path`. Reference ids/names/lengths come from the BAM `@SQ` header.
+/// Where [`write_alignment_rad_to`] should put the RAD it produces.
+pub enum RadDest<'a> {
+    /// Write to this path.
+    Path(&'a Path),
+    /// Build the image in memory and hand it back.
+    Memory,
+}
+
+/// The outcome of a BAM-to-RAD pass: the counts, plus the image itself when it
+/// was built in memory.
+pub struct AlignRadOutput {
+    pub summary: AlignRadSummary,
+    /// `Some` only for [`RadDest::Memory`].
+    pub bytes: Option<Vec<u8>>,
+}
+
+/// Write the alignment RAD to a file. Thin wrapper over
+/// [`write_alignment_rad_to`] for the common case.
 pub fn write_alignment_rad(
     opts: &AlignQuantOptions,
     rad_path: &Path,
     codec: ChunkCodec,
 ) -> Result<AlignRadSummary> {
+    Ok(write_alignment_rad_to(opts, &RadDest::Path(rad_path), codec)?.summary)
+}
+
+/// As [`write_alignment_rad`], but the destination is chosen by the caller.
+pub fn write_alignment_rad_to(
+    opts: &AlignQuantOptions,
+    dest: &RadDest,
+    codec: ChunkCodec,
+) -> Result<AlignRadOutput> {
     let header = read_alignment_header(&opts.bam)?;
     if coordinate_sorted_unusable(&header) {
         bail!(
@@ -138,15 +165,25 @@ pub fn write_alignment_rad(
         opts.deterministic_error_model && ref_bytes.is_some() && !opts.no_error_model;
 
     let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
-    let mut writer = RadOutputWriter::create(
-        rad_path,
-        &name_refs,
-        &lengths,
-        is_paired,
-        RadProfile::SelectiveAlignment,
-        opts.fld_max + 1,
-        codec,
-    )?;
+    let mut writer = match dest {
+        RadDest::Path(rad_path) => RadOutputWriter::create(
+            rad_path,
+            &name_refs,
+            &lengths,
+            is_paired,
+            RadProfile::SelectiveAlignment,
+            opts.fld_max + 1,
+            codec,
+        )?,
+        RadDest::Memory => RadOutputWriter::create_in_memory(
+            &name_refs,
+            &lengths,
+            is_paired,
+            RadProfile::SelectiveAlignment,
+            opts.fld_max + 1,
+            codec,
+        )?,
+    };
 
     let fld = DiscreteFld::new(opts.fld_max);
     let naive = bias_on.then(NaiveEqBuilder::new);
@@ -208,8 +245,14 @@ pub fn write_alignment_rad(
         writer.set_initial_abundances(&em.alphas);
     }
 
-    writer.finalize()?;
-    Ok(summary)
+    let bytes = match dest {
+        RadDest::Path(_) => {
+            writer.finalize()?;
+            None
+        }
+        RadDest::Memory => Some(writer.finalize_into_bytes()?),
+    };
+    Ok(AlignRadOutput { summary, bytes })
 }
 
 fn reduce_summary(parts: Vec<(u64, u64)>) -> AlignRadSummary {

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -40,9 +40,11 @@ mod error_model;
 mod genome_project;
 mod rad;
 
-pub use bam_rad::{write_alignment_rad, AlignRadSummary};
+pub use bam_rad::{
+    write_alignment_rad, write_alignment_rad_to, AlignRadOutput, AlignRadSummary, RadDest,
+};
 pub use genome_project::{project_genome_bam_to_rad, GenomeProjectOptions, ProjectionArtifacts};
-pub use rad::quantify_rad;
+pub use rad::{quantify_rad, quantify_rad_source, RadSource};
 
 use std::collections::HashMap;
 use std::io::{BufRead, Write};

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -355,16 +355,55 @@ fn process_rad_fragment(placements: &[RadPlacement], cfg: &FragCfg) -> bool {
 
 /// Open the file and read its prelude + file-tag values, returning the reader
 /// positioned at the first chunk.
-fn open_prelude(path: &Path) -> Result<(BufReader<File>, RadPrelude, TagMap)> {
-    let mut reader = BufReader::new(
-        File::open(path).with_context(|| format!("opening RAD file {}", path.display()))?,
-    );
+fn open_prelude<'a>(src: &'a RadSource) -> Result<(Box<dyn RadRead + 'a>, RadPrelude, TagMap)> {
+    let mut reader = src.reader()?;
     let prelude = RadPrelude::from_bytes(&mut reader).context("parsing RAD prelude")?;
     let file_tag_map = prelude
         .file_tags
         .parse_tags_from_bytes(&mut reader)
         .context("parsing RAD file tags")?;
     Ok((reader, prelude, file_tag_map))
+}
+
+/// A rewindable RAD byte stream. `libradicl`'s `ParallelRadReader` needs
+/// `BufRead + Seek`, and the producer runs on its own thread, hence `Send`.
+pub trait RadRead: std::io::BufRead + std::io::Seek + Send {}
+impl<T: std::io::BufRead + std::io::Seek + Send> RadRead for T {}
+
+/// Where this run's RAD image lives.
+///
+/// Quantifying a RAD opens it up to five separate times (the prelude probe, the
+/// FLD-derivation pass, the bias pass, the eq-class pass, and the fused pass),
+/// so the source has to be re-openable rather than a single stream. For a file
+/// that is another `File::open`; for an in-memory image it is a fresh `Cursor`
+/// over the same bytes, which costs nothing.
+pub enum RadSource<'a> {
+    /// A RAD file on disk.
+    Path(&'a Path),
+    /// A complete RAD image already in memory — byte-for-byte what would have
+    /// been written to disk. Produced by the `--deterministic` pipeline when it
+    /// is told to keep its intermediate in memory.
+    Bytes(&'a [u8]),
+}
+
+impl RadSource<'_> {
+    /// Open a fresh stream positioned at the start of the image.
+    fn reader<'a>(&'a self) -> Result<Box<dyn RadRead + 'a>> {
+        Ok(match self {
+            RadSource::Path(p) => Box::new(BufReader::new(
+                File::open(p).with_context(|| format!("opening RAD file {}", p.display()))?,
+            )),
+            RadSource::Bytes(b) => Box::new(std::io::Cursor::new(*b)),
+        })
+    }
+
+    /// Human-readable description for log lines and error context.
+    fn describe(&self) -> String {
+        match self {
+            RadSource::Path(p) => p.display().to_string(),
+            RadSource::Bytes(b) => format!("<in-memory RAD, {} bytes>", b.len()),
+        }
+    }
 }
 
 /// Reference lengths from the RAD `ref_lengths` file tag (one per reference).
@@ -521,7 +560,7 @@ fn load_baked_score_kind(file_tag_map: &TagMap) -> u8 {
 /// pool that weights each fragment into the shared equivalence-class builder.
 #[allow(clippy::too_many_arguments)]
 fn run_rad_pass<R>(
-    path: &Path,
+    src: &RadSource,
     nthreads: usize,
     cfg: &FragCfg,
     num_processed: &AtomicU64,
@@ -531,7 +570,7 @@ where
     R: MappedRecord + RadFragment + Send,
     R::ParsingContext: RecordContext + Clone + Send + Sync,
 {
-    let (reader, prelude, file_tag_map) = open_prelude(path)?;
+    let (reader, prelude, file_tag_map) = open_prelude(src)?;
     let nz = NonZeroUsize::new(nthreads.max(1)).unwrap();
     let mut prr =
         ParallelRadReader::<R, _>::from_prelude_and_file_tag_map(reader, prelude, file_tag_map, nz);
@@ -573,7 +612,7 @@ where
 /// unique-fragment FLD, made order-independent by using *all* unique fragments
 /// plus a global-count orientation choice instead of a file-order sample quota.
 fn derive_fld<R>(
-    path: &Path,
+    src: &RadSource,
     nthreads: usize,
     fld_max: usize,
     fld_mean: f64,
@@ -590,7 +629,7 @@ where
     // mapping pass uses, so a derived FLD and a baked one agree.
     let acc = DiscreteFld::new(fld_max);
 
-    let (reader, prelude, file_tag_map) = open_prelude(path)?;
+    let (reader, prelude, file_tag_map) = open_prelude(src)?;
     let nz = NonZeroUsize::new(nthreads.max(1)).unwrap();
     let mut prr =
         ParallelRadReader::<R, _>::from_prelude_and_file_tag_map(reader, prelude, file_tag_map, nz);
@@ -911,7 +950,7 @@ fn collect_bias_fragment(placements: &[RadPlacement], cfg: &BiasCfg, local: &mut
 /// sequence / GC / positional observations.
 #[allow(clippy::type_complexity)]
 fn run_bias_pass<R>(
-    path: &Path,
+    src: &RadSource,
     nthreads: usize,
     cfg: &BiasCfg,
     seq: bool,
@@ -928,7 +967,7 @@ where
     R: MappedRecord + RadFragment + Send,
     R::ParsingContext: RecordContext + Clone + Send + Sync,
 {
-    let (reader, prelude, file_tag_map) = open_prelude(path)?;
+    let (reader, prelude, file_tag_map) = open_prelude(src)?;
     let nz = NonZeroUsize::new(nthreads.max(1)).unwrap();
     let mut prr =
         ParallelRadReader::<R, _>::from_prelude_and_file_tag_map(reader, prelude, file_tag_map, nz);
@@ -967,7 +1006,7 @@ where
 /// and a second RAD read (see the pass matrix in [`quantify_rad`]).
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 fn run_rad_eq_and_bias_pass<R>(
-    path: &Path,
+    src: &RadSource,
     nthreads: usize,
     cfg: &FragCfg,
     bias_cfg: &BiasCfg,
@@ -987,7 +1026,7 @@ where
     R: MappedRecord + RadFragment + Send,
     R::ParsingContext: RecordContext + Clone + Send + Sync,
 {
-    let (reader, prelude, file_tag_map) = open_prelude(path)?;
+    let (reader, prelude, file_tag_map) = open_prelude(src)?;
     let nz = NonZeroUsize::new(nthreads.max(1)).unwrap();
     let mut prr =
         ParallelRadReader::<R, _>::from_prelude_and_file_tag_map(reader, prelude, file_tag_map, nz);
@@ -1028,7 +1067,17 @@ where
 // ---------------------------------------------------------------------------
 
 /// Quantify from a RAD file (`salmon quant --rad`).
+/// Quantify from a RAD file on disk. Convenience wrapper over
+/// [`quantify_rad_source`] for the common case.
 pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQuantResult> {
+    quantify_rad_source(opts, &RadSource::Path(rad_path))
+}
+
+/// Quantify from any [`RadSource`] — a file, or an image already in memory.
+pub fn quantify_rad_source(
+    opts: &AlignQuantOptions,
+    rad_src: &RadSource,
+) -> Result<AlignQuantResult> {
     let start_time = asctime_now();
     let run_timer = std::time::Instant::now();
     let mut timer = PhaseTimer::new();
@@ -1046,7 +1095,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     );
 
     // Header: profile, reference names + lengths (from the RAD file tags).
-    let (_reader, prelude, file_tag_map) = open_prelude(rad_path)?;
+    let (_reader, prelude, file_tag_map) = open_prelude(rad_src)?;
     let profile = salmon_rad::detect_input_profile(&prelude)?;
     let names: Vec<String> = prelude.hdr.ref_names.clone();
     let lengths = ref_lengths_from_tags(&prelude, &file_tag_map)?;
@@ -1062,7 +1111,8 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         RadInputProfile::Salmon(salmon_rad::RadProfile::SelectiveAlignment)
     );
     tracing::info!(
-        "quantifying from RAD ({}), {num_refs} references",
+        "quantifying from RAD {} ({}), {num_refs} references",
+        rad_src.describe(),
         match profile {
             RadInputProfile::PiscemBulk => "piscem bulk",
             RadInputProfile::Salmon(salmon_rad::RadProfile::Sketch) => "salmon sketch",
@@ -1133,7 +1183,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     } else if derive_fld_pass {
         let (f, detected) = match profile {
             RadInputProfile::PiscemBulk => derive_fld::<PiscemBulkReadRecord>(
-                rad_path,
+                rad_src,
                 nthreads,
                 opts.fld_max,
                 opts.fld_mean,
@@ -1141,7 +1191,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                 prepare_eqb.as_ref(),
             )?,
             RadInputProfile::Salmon(_) => derive_fld::<SalmonBulkRecord>(
-                rad_path,
+                rad_src,
                 nthreads,
                 opts.fld_max,
                 opts.fld_mean,
@@ -1318,7 +1368,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             };
             let obs = match profile {
                 RadInputProfile::PiscemBulk => run_rad_eq_and_bias_pass::<PiscemBulkReadRecord>(
-                    rad_path,
+                    rad_src,
                     nthreads,
                     &cfg,
                     &bias_cfg,
@@ -1331,7 +1381,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                     &num_mapped,
                 )?,
                 RadInputProfile::Salmon(_) => run_rad_eq_and_bias_pass::<SalmonBulkRecord>(
-                    rad_path,
+                    rad_src,
                     nthreads,
                     &cfg,
                     &bias_cfg,
@@ -1348,14 +1398,14 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         } else {
             match profile {
                 RadInputProfile::PiscemBulk => run_rad_pass::<PiscemBulkReadRecord>(
-                    rad_path,
+                    rad_src,
                     nthreads,
                     &cfg,
                     &num_processed,
                     &num_mapped,
                 )?,
                 RadInputProfile::Salmon(_) => run_rad_pass::<SalmonBulkRecord>(
-                    rad_path,
+                    rad_src,
                     nthreads,
                     &cfg,
                     &num_processed,
@@ -1450,7 +1500,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             };
             let (seq_obs, gc_obs, pos_obs) = match profile {
                 RadInputProfile::PiscemBulk => run_bias_pass::<PiscemBulkReadRecord>(
-                    rad_path,
+                    rad_src,
                     nthreads,
                     &bias_cfg,
                     opts.seq_bias,
@@ -1460,7 +1510,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                     opts.gc_bins,
                 )?,
                 RadInputProfile::Salmon(_) => run_bias_pass::<SalmonBulkRecord>(
-                    rad_path,
+                    rad_src,
                     nthreads,
                     &bias_cfg,
                     opts.seq_bias,

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -537,6 +537,18 @@ struct QuantArgs {
     /// deleted once quantification finishes). Ignored without --deterministic.
     #[arg(long = "keepRad")]
     keep_rad: bool,
+    /// `-a --deterministic`: keep the intermediate RAD in memory instead of
+    /// writing it to disk.
+    ///
+    /// Deterministic alignment mode writes an intermediate RAD, reads it back,
+    /// then deletes it. This skips the file entirely — one fewer full write and
+    /// every re-read served from memory — at the cost of holding the whole image
+    /// resident. Output is unchanged: the bytes are the same either way.
+    ///
+    /// Ignored when the RAD is itself a deliverable (`--writeRad`, `--keepRad`,
+    /// `--skipQuant`), which force the on-disk path.
+    #[arg(long = "radInMemory")]
+    rad_in_memory: bool,
     /// Enable sequence-specific bias correction.
     #[arg(long = "seqBias")]
     seq_bias: bool,
@@ -1144,6 +1156,7 @@ fn run_deterministic_align(
     keep_rad: bool,
     gene_map: Option<&GeneMapOpts>,
     codec: ChunkCodec,
+    in_memory: bool,
 ) -> Result<()> {
     let out_dir = opts.output_dir.clone();
     // An explicit `--writeRad PATH` is honoured and kept; otherwise a temp under
@@ -1154,24 +1167,47 @@ fn run_deterministic_align(
     std::fs::create_dir_all(&out_dir)
         .with_context(|| format!("creating output directory {}", out_dir.display()))?;
 
+    // The intermediate can stay in memory when nobody wants the file: an
+    // explicit `--writeRad`, `--keepRad` and `--skipQuant` all make the RAD a
+    // deliverable, so those force the on-disk path regardless of the flag.
+    let want_file = explicit || keep_rad || opts.skip_quant;
+    let use_memory = in_memory && !want_file;
+
     // Phase 1 — one BAM pass: write placements + bake FLD / library format
     // (+ rough abundances when bias is on) so phase 2 is a single baked pass.
-    let summary = salmon_align::write_alignment_rad(&opts, &rad_path, codec)
+    let dest = if use_memory {
+        salmon_align::RadDest::Memory
+    } else {
+        salmon_align::RadDest::Path(&rad_path)
+    };
+    let out = salmon_align::write_alignment_rad_to(&opts, &dest, codec)
         .context("deterministic alignment RAD-write pass failed")?;
+    let summary = out.summary;
     let pct = if summary.num_processed > 0 {
         100.0 * summary.num_mapped as f64 / summary.num_processed as f64
     } else {
         0.0
     };
     tracing::info!(
-        "deterministic: wrote {} / {} aligned fragments ({:.2}%) to the intermediate RAD; quantifying",
+        "deterministic: wrote {} / {} aligned fragments ({:.2}%) to {}; quantifying",
         summary.num_mapped,
         summary.num_processed,
-        pct
+        pct,
+        if use_memory {
+            "an in-memory intermediate RAD".to_string()
+        } else {
+            format!("the intermediate RAD at {}", rad_path.display())
+        }
     );
 
     // Phase 2 — quantify from the fully-baked RAD (single pass, order-independent).
-    let res = quantify_rad(&opts, &rad_path).context("deterministic requant pass failed")?;
+    // The reader cannot tell the two sources apart; the bytes are identical.
+    let rad_src = match &out.bytes {
+        Some(b) => salmon_align::RadSource::Bytes(b),
+        None => salmon_align::RadSource::Path(&rad_path),
+    };
+    let res = salmon_align::quantify_rad_source(&opts, &rad_src)
+        .context("deterministic requant pass failed")?;
     let pct2 = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
     } else {
@@ -1195,7 +1231,9 @@ fn run_deterministic_align(
             &res.counts,
         )?;
     }
-    if explicit || keep_rad || opts.skip_quant {
+    if use_memory {
+        // Nothing was written, so nothing to keep or remove.
+    } else if want_file {
         tracing::info!("kept intermediate RAD at {}", rad_path.display());
     } else if let Err(e) = std::fs::remove_file(&rad_path) {
         tracing::warn!(
@@ -1467,6 +1505,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
                 args.keep_rad,
                 gene_map.as_ref(),
                 codec,
+                args.rad_in_memory,
             );
         }
 

--- a/crates/salmon-rad/src/writer.rs
+++ b/crates/salmon-rad/src/writer.rs
@@ -26,7 +26,7 @@
 //! aggregation downstream, not from file order.
 
 use std::fs::File;
-use std::io::BufWriter;
+use std::io::{BufWriter, Cursor, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use libradicl::chunk::ChunkBuf;
@@ -38,10 +38,46 @@ use libradicl::ChunkCodec;
 use crate::record::{SalmonBulkContext, SalmonBulkRecord};
 use crate::{schema, RadProfile, BAKED_ABUND, BAKED_FLD, BAKED_LIBFMT, BAKED_SCORE_KIND};
 
-/// Shared, thread-safe RAD output sink for one file.
+/// Where a [`RadOutputWriter`]'s bytes go.
+///
+/// `libradicl`'s writer is already generic over `Write + Seek` (it needs `Seek`
+/// for the header backpatching at finalize), so supporting an in-memory image
+/// costs only this dispatch. It is an enum rather than a type parameter
+/// deliberately: a generic would leak through every worker that holds a
+/// `&RadOutputWriter`, for a choice made once at construction.
+enum Sink {
+    File(BufWriter<File>),
+    Memory(Cursor<Vec<u8>>),
+}
+
+impl Write for Sink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Sink::File(w) => w.write(buf),
+            Sink::Memory(w) => w.write(buf),
+        }
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Sink::File(w) => w.flush(),
+            Sink::Memory(w) => w.flush(),
+        }
+    }
+}
+
+impl Seek for Sink {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        match self {
+            Sink::File(w) => w.seek(pos),
+            Sink::Memory(w) => w.seek(pos),
+        }
+    }
+}
+
+/// Shared, thread-safe RAD output sink.
 pub struct RadOutputWriter {
-    /// The underlying file, wrapped so that appends from many threads are safe.
-    ccw: ConcurrentChunkWriter<BufWriter<File>>,
+    /// The underlying sink, wrapped so that appends from many threads are safe.
+    ccw: ConcurrentChunkWriter<Sink>,
     /// Which profile records are written in (decides the per-hit layout).
     ctx: SalmonBulkContext,
     /// reserved-slot lengths, so baked values are padded/truncated to fit exactly.
@@ -80,7 +116,7 @@ impl RadOutputWriter {
             schema::build_prelude(profile, is_paired, ref_names, ref_lengths, fld_len, codec);
         // `BufWriter` batches small writes into large ones; without it every
         // chunk append would become a separate system call.
-        let file = BufWriter::new(File::create(path)?);
+        let file = Sink::File(BufWriter::new(File::create(path)?));
         // Writing the prelude here means the file is valid (if empty) from the
         // moment it is created.
         let fw = RadFileWriter::new(file, &prelude, &file_tag_map)?;
@@ -90,6 +126,46 @@ impl RadOutputWriter {
             fld_len,
             num_refs: ref_names.len(),
             // Nothing is baked until the run finishes.
+            pending_fld: None,
+            pending_abund: None,
+            pending_libfmt: None,
+            pending_score_kind: None,
+            codec,
+        })
+    }
+
+    /// Create a RAD image held entirely in memory.
+    ///
+    /// Same prelude, same records, same backpatching as [`create`](Self::create)
+    /// — only the destination differs, so the bytes are indistinguishable from a
+    /// file's and any reader accepts them.
+    ///
+    /// This exists for the `--deterministic` pipeline, which writes an
+    /// intermediate RAD, reads it back (up to five separate passes, depending on
+    /// what has to be derived), then deletes it. Keeping it in memory removes a
+    /// full write and every one of those re-reads. The trade is explicit and the
+    /// caller makes it: the whole image is resident instead of on disk.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_in_memory(
+        ref_names: &[&str],
+        ref_lengths: &[u32],
+        is_paired: bool,
+        profile: RadProfile,
+        fld_len: usize,
+        codec: ChunkCodec,
+    ) -> anyhow::Result<Self> {
+        let (prelude, file_tag_map): (RadPrelude, _) =
+            schema::build_prelude(profile, is_paired, ref_names, ref_lengths, fld_len, codec);
+        let fw = RadFileWriter::new(
+            Sink::Memory(Cursor::new(Vec::new())),
+            &prelude,
+            &file_tag_map,
+        )?;
+        Ok(Self {
+            ccw: ConcurrentChunkWriter::new(fw),
+            ctx: SalmonBulkContext { profile },
+            fld_len,
+            num_refs: ref_names.len(),
             pending_fld: None,
             pending_abund: None,
             pending_libfmt: None,
@@ -152,6 +228,27 @@ impl RadOutputWriter {
     /// appended afterwards. Call after all workers have flushed and dropped their
     /// references.
     pub fn finalize(self) -> anyhow::Result<()> {
+        self.finalize_sink()?;
+        Ok(())
+    }
+
+    /// Finalize and take the completed image, for a writer built by
+    /// [`create_in_memory`](Self::create_in_memory).
+    ///
+    /// Returns an error if this writer is backed by a file — the caller asked for
+    /// bytes from something that put them on disk, which is a programming error
+    /// rather than a runtime condition.
+    pub fn finalize_into_bytes(self) -> anyhow::Result<Vec<u8>> {
+        match self.finalize_sink()? {
+            Sink::Memory(c) => Ok(c.into_inner()),
+            Sink::File(_) => {
+                anyhow::bail!("finalize_into_bytes called on a file-backed RAD writer")
+            }
+        }
+    }
+
+    /// Backpatch the baked slots, finalize, and hand back the sink.
+    fn finalize_sink(self) -> anyhow::Result<Sink> {
         // Move the fields out before consuming `self.ccw` below.
         let fld_len = self.fld_len;
         let num_refs = self.num_refs;
@@ -194,9 +291,8 @@ impl RadOutputWriter {
         if flags != 0 {
             w.backpatch_file_tag_value(crate::BAKED_FLAGS_TAG, &TagValue::U8(flags))?;
         }
-        // Writes the final chunk count into the header and flushes the file.
-        w.finalize()?;
-        Ok(())
+        // Writes the final chunk count into the header and flushes the sink.
+        w.finalize()
     }
 }
 


### PR DESCRIPTION
Follow-up to #1098. **Draft in the sense that I would like a read on whether the direction is wanted before polishing** — the mechanism is complete and verified, but it adds a flag, and you may prefer a different shape (or none).

### What it does

`-a --deterministic` currently writes an intermediate RAD, reads it back, then deletes it. The read side opens that file up to **five separate times** — the prelude probe, plus the FLD-derivation, bias, eq-class and fused passes, depending on what has to be derived. So the round trip is one full write and several full reads of a file that exists only to be consumed and unlinked.

`--radInMemory` keeps the image in memory instead. The bytes are byte-for-byte what would have gone to disk, so the reader cannot tell the difference and the output is unchanged.

### Why it is small

Both ends of `libradicl` were already generic: `RadFileWriter<W: Write + Seek>` (it needs `Seek` for the header backpatching at finalize) and `ParallelRadReader<R, T: BufRead + Seek>`. Only salmon pinned them to `File`. So this is mostly removing that pin.

Two deliberate design choices:

- **The writer gains an internal `Sink` enum, not a type parameter.** A generic `RadOutputWriter<W>` would leak through every worker that holds a `&RadOutputWriter` (`WriteWorker`, `ScoreWriteWorker`, `write_record`, and `genome_project.rs`), which is a lot of signature churn for a choice made once at construction. I tried the generic first; the enum is much less invasive.
- **The read side gains a `RadSource` (path or bytes), not a reader.** It has to *re-open* the image per pass rather than stream it once, so a single `impl BufRead` would not do.

### Scope

Off by default. Ignored when the RAD is itself a deliverable — `--writeRad`, `--keepRad`, `--skipQuant` all force the on-disk path — so the flag can never silently withhold something the user asked for.

Reads-mode `--deterministic` is untouched. There the second pass exists to avoid **re-mapping**, and the intermediate is what makes that affordable; the trade is completely different and I did not want to conflate them.

### Verification

On `sample_data`:

- `quant.sf` byte-identical between on-disk and in-memory paths
- byte-identical to unmodified `develop`'s `-a --deterministic`
- no file left behind in the in-memory case
- each of the three deliverable guards verified to force the disk path
- reads-mode `--deterministic` output unchanged
- four consecutive in-memory runs identical

Full workspace suite green, clippy clean, fmt clean.

### What I have not done

**No benchmark.** `sample_data` produces a 128 KB intermediate for 10k fragments, far too small to time meaningfully. The argument is structural — one write and up to five reads of an N-byte file traded for N bytes resident — and it scales with the intermediate, which is exactly why this is opt-in rather than a default. If you want numbers on a real BAM before considering it, that is fair and I will produce them.

**This does not address #1098.** Default alignment mode is still nondeterministic; this only makes the existing deterministic path cheaper. I mention it because the two are easy to conflate.

Happy to close this if the flag is not wanted — the underlying `Sink`/`RadSource` split might still be useful on its own, or not.
