### PR TITLE
feat(io): detect input compression from content, shared across input paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,11 +2684,14 @@ dependencies = [
 name = "salmon-core"
 version = "2.4.1"
 dependencies = [
+ "flate2",
  "niffler",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.19",
  "tracing",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -517,25 +517,17 @@ fn base_2bit(b: u8) -> u8 {
     }
 }
 
-/// Load a (optionally gzip'd) transcriptome FASTA and return the (ASCII) base
-/// sequences aligned to the BAM's reference order (`names`); a name absent from
-/// the FASTA yields an empty sequence (its model contributions are skipped). The
-/// same bytes feed both the error model (2-bit on the fly) and the bias models.
+/// Load a (optionally compressed) transcriptome FASTA and return the (ASCII)
+/// base sequences aligned to the BAM's reference order (`names`); a name absent
+/// from the FASTA yields an empty sequence (its model contributions are
+/// skipped). The same bytes feed both the error model (2-bit on the fly) and the
+/// bias models.
+///
+/// Compression is detected from content, so gzip/BGZF, bzip2, xz and zstd all
+/// work regardless of how the file is named.
 fn load_ref_bytes(path: &Path, names: &[String]) -> Result<Vec<Vec<u8>>> {
-    let file = std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
-    let mut magic = [0u8; 2];
-    let is_gz = {
-        use std::io::Read;
-        let mut f = std::fs::File::open(path)?;
-        f.read_exact(&mut magic).is_ok() && magic == [0x1f, 0x8b]
-    };
-    let reader: Box<dyn BufRead> = if is_gz {
-        Box::new(std::io::BufReader::new(flate2::read::MultiGzDecoder::new(
-            file,
-        )))
-    } else {
-        Box::new(std::io::BufReader::new(file))
-    };
+    let reader: Box<dyn BufRead> = salmon_core::compress::open_maybe_compressed(path)
+        .with_context(|| format!("opening {}", path.display()))?;
 
     let mut by_name: HashMap<String, Vec<u8>> = HashMap::new();
     let mut cur_name: Option<String> = None;
@@ -640,18 +632,15 @@ fn is_sam_path(p: &Path) -> bool {
     s.ends_with(".sam") || s.ends_with(".sam.gz")
 }
 
-/// Open a SAM file (transparently gunzipping `.sam.gz`) as a noodles reader over
-/// a boxed `BufRead`, so plain and gzipped inputs share one concrete type.
+/// Open a SAM file (transparently decompressing it) as a noodles reader over a
+/// boxed `BufRead`, so every input shares one concrete type.
+///
+/// Compression is detected from content rather than from the name, so a
+/// gzip/bzip2/xz/zstd SAM is read whatever it is called — `is_sam_path` still
+/// decides SAM-vs-BAM by extension, which is a different question.
 fn open_sam_reader(path: &Path) -> Result<sam::io::Reader<Box<dyn BufRead + Send>>> {
-    let file = std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
-    let lower = path.to_string_lossy().to_ascii_lowercase();
-    let inner: Box<dyn BufRead + Send> = if lower.ends_with(".gz") {
-        Box::new(std::io::BufReader::new(flate2::read::MultiGzDecoder::new(
-            file,
-        )))
-    } else {
-        Box::new(std::io::BufReader::new(file))
-    };
+    let inner = salmon_core::compress::open_maybe_compressed(path)
+        .with_context(|| format!("opening {}", path.display()))?;
     Ok(sam::io::Reader::new(inner))
 }
 

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -626,18 +626,24 @@ fn kind_to_op(k: Kind) -> AlnOp {
     }
 }
 
-/// Does this path name a SAM file (plain or gzipped) rather than a BAM?
+/// Does this path name a SAM file rather than a BAM, whatever it is compressed
+/// with?
+///
+/// SAM-vs-BAM is a name question, and compression is a content question, so any
+/// compression suffix is stripped before asking: `aln.sam.zst` is a SAM file
+/// that happens to be zstd, and routing it to the BAM reader produced a report
+/// about an invalid BGZF header for a file that was never BGZF.
 fn is_sam_path(p: &Path) -> bool {
     let s = p.to_string_lossy().to_ascii_lowercase();
-    s.ends_with(".sam") || s.ends_with(".sam.gz")
+    salmon_core::compress::strip_compression_extension(&s).ends_with(".sam")
 }
 
 /// Open a SAM file (transparently decompressing it) as a noodles reader over a
 /// boxed `BufRead`, so every input shares one concrete type.
 ///
-/// Compression is detected from content rather than from the name, so a
-/// gzip/bzip2/xz/zstd SAM is read whatever it is called — `is_sam_path` still
-/// decides SAM-vs-BAM by extension, which is a different question.
+/// Compression is detected from content, so the stream is decoded correctly
+/// however it was compressed. Which files reach here at all is a separate,
+/// name-based question, answered by [`is_sam_path`].
 fn open_sam_reader(path: &Path) -> Result<sam::io::Reader<Box<dyn BufRead + Send>>> {
     let inner = salmon_core::compress::open_maybe_compressed(path)
         .with_context(|| format!("opening {}", path.display()))?;

--- a/crates/salmon-core/Cargo.toml
+++ b/crates/salmon-core/Cargo.toml
@@ -20,3 +20,8 @@ niffler = { workspace = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+flate2 = { workspace = true }
+zstd = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/salmon-core/src/compress.rs
+++ b/crates/salmon-core/src/compress.rs
@@ -42,7 +42,7 @@ use std::path::Path;
 /// reported as an error — an empty or stub input is the parser's business to
 /// diagnose, not this function's.
 pub fn open_maybe_compressed(path: &Path) -> io::Result<Box<dyn BufRead + Send>> {
-    Ok(BufReader::new(open_maybe_compressed_raw(path)?).into_boxed_bufread())
+    Ok(Box::new(BufReader::new(open_maybe_compressed_raw(path)?)))
 }
 
 /// As [`open_maybe_compressed`], but unbuffered, for callers that will impose
@@ -61,15 +61,26 @@ pub fn open_maybe_compressed_raw(path: &Path) -> io::Result<Box<dyn Read + Send>
     }
 }
 
-/// Helper so [`open_maybe_compressed`] can name its return type without a turbofish.
-trait IntoBoxedBufRead {
-    fn into_boxed_bufread(self) -> Box<dyn BufRead + Send>;
-}
-
-impl<R: BufRead + Send + 'static> IntoBoxedBufRead for R {
-    fn into_boxed_bufread(self) -> Box<dyn BufRead + Send> {
-        Box::new(self)
+/// Strip one trailing compression extension from a file name, if present.
+///
+/// This module decides *compression* from content, never from the name — but a
+/// caller may still have a name-based question to ask about what is underneath,
+/// such as whether an alignment file is SAM or BAM. `reads.sam.zst` is a SAM
+/// file, and asking "does this end in `.sam`" of the whole name answers no.
+///
+/// So this is not name-based compression detection creeping back in: it removes
+/// compression noise from a name so a *different* question can be asked of what
+/// remains. The suffixes are the ones [`open_maybe_compressed`] can actually
+/// decode.
+pub fn strip_compression_extension(name: &str) -> &str {
+    const EXTENSIONS: [&str; 7] = [".gz", ".bgz", ".zst", ".zstd", ".bz2", ".xz", ".lzma"];
+    let lower = name.to_ascii_lowercase();
+    for ext in EXTENSIONS {
+        if lower.ends_with(ext) {
+            return &name[..name.len() - ext.len()];
+        }
     }
+    name
 }
 
 #[cfg(test)]
@@ -149,6 +160,27 @@ mod tests {
             .read_to_string(&mut got)
             .unwrap();
         assert_eq!(got, ">a\nACGT\n>b\nTTTT\n");
+    }
+
+    /// Stripping a compression suffix lets a name-based format question see the
+    /// name underneath, which is how `foo.sam.zst` is recognised as SAM.
+    #[test]
+    fn strips_one_compression_extension() {
+        for (input, want) in [
+            ("a.sam.gz", "a.sam"),
+            ("a.sam.zst", "a.sam"),
+            ("a.sam.ZST", "a.sam"),
+            ("a.sam.bz2", "a.sam"),
+            ("a.sam.xz", "a.sam"),
+            ("a.sam", "a.sam"),
+            ("a.bam", "a.bam"),
+            // Only one is removed: the remaining name is what the caller asks about.
+            ("a.sam.gz.gz", "a.sam.gz"),
+            // A bare compression name has nothing underneath, and must not panic.
+            (".gz", ""),
+        ] {
+            assert_eq!(strip_compression_extension(input), want, "for {input}");
+        }
     }
 
     /// A file too short to sniff is plain text by construction, and must open

--- a/crates/salmon-core/src/compress.rs
+++ b/crates/salmon-core/src/compress.rs
@@ -1,0 +1,168 @@
+//! Transparent decompression of user-supplied input files.
+//!
+//! # Why this is shared
+//!
+//! salmon takes files from users in several places — the transcriptome FASTA,
+//! the reads, an alignment record stream, a gene map — and users compress them
+//! with whatever their pipeline uses. Deciding "is this compressed, and how"
+//! separately at each entry point is how the four input paths ended up disagreeing:
+//! one sniffed content with `needletail`, one sniffed magic bytes for gzip only,
+//! one matched on a `.gz` file extension, and one used `niffler`. A file that
+//! `salmon index` happily read could then be rejected by `salmon quant`.
+//!
+//! This module is the single answer. Everything that opens a user-supplied file
+//! goes through it, so support is uniform by construction rather than by four
+//! implementations agreeing.
+//!
+//! # Detection is by content, never by name
+//!
+//! A file extension is a hint, not a fact. `reads.fq.gz` may be plain text and
+//! `reads.fq` may be gzip; neither is unusual once files have been moved,
+//! renamed, or produced by a tool with its own conventions. [`niffler`] reads the
+//! leading magic bytes and picks the decoder from what is actually there, which
+//! also means a correctly-compressed file with an unexpected name just works
+//! instead of failing with a parse error about the *decompressed* format that
+//! never happened.
+//!
+//! Supported: gzip (including BGZF and multi-member files, via `MultiGzDecoder`,
+//! so concatenated members are read in full rather than truncated at the first),
+//! bzip2, xz and zstd. Anything else is passed through unchanged as plain text.
+
+use std::io::{self, BufRead, BufReader, Read};
+use std::path::Path;
+
+/// Open `path`, transparently decompressing it if it is compressed.
+///
+/// Returns a buffered, `Send` reader so the result can be handed to a worker
+/// thread (paraseq moves readers onto workers) and read line-wise without the
+/// caller re-wrapping it.
+///
+/// A file shorter than niffler's five-byte sniff window cannot be any of the
+/// compressed formats, so it is re-opened and returned as plain text rather than
+/// reported as an error — an empty or stub input is the parser's business to
+/// diagnose, not this function's.
+pub fn open_maybe_compressed(path: &Path) -> io::Result<Box<dyn BufRead + Send>> {
+    Ok(BufReader::new(open_maybe_compressed_raw(path)?).into_boxed_bufread())
+}
+
+/// As [`open_maybe_compressed`], but unbuffered, for callers that will impose
+/// their own buffering (or hand the stream to a reader that does).
+pub fn open_maybe_compressed_raw(path: &Path) -> io::Result<Box<dyn Read + Send>> {
+    let open = || std::fs::File::open(path);
+    // Buffer *before* sniffing: niffler reads the first few bytes to identify the
+    // format, and an unbuffered file would make that several tiny syscalls.
+    let probe: Box<dyn Read + Send> = Box::new(BufReader::new(open()?));
+    match niffler::send::get_reader(probe) {
+        Ok((reader, _format)) => Ok(reader),
+        // Too short to be compressed: it is plain text by construction.
+        Err(niffler::Error::FileTooShort) => Ok(Box::new(open()?)),
+        Err(niffler::Error::IOError(e)) => Err(e),
+        Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
+    }
+}
+
+/// Helper so [`open_maybe_compressed`] can name its return type without a turbofish.
+trait IntoBoxedBufRead {
+    fn into_boxed_bufread(self) -> Box<dyn BufRead + Send>;
+}
+
+impl<R: BufRead + Send + 'static> IntoBoxedBufRead for R {
+    fn into_boxed_bufread(self) -> Box<dyn BufRead + Send> {
+        Box::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Round-trip each supported format through the sniffer and check the
+    /// decompressed bytes come back, so a format regression is caught here rather
+    /// than as a confusing parse error in whichever caller hit it first.
+    #[test]
+    fn sniffs_every_supported_format_by_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let payload = b">seq1\nACGTACGTACGTACGTACGT\n";
+
+        let write = |name: &str, bytes: &[u8]| {
+            let p = dir.path().join(name);
+            std::fs::File::create(&p).unwrap().write_all(bytes).unwrap();
+            p
+        };
+
+        // Plain.
+        let plain = write("a.fa", payload);
+        let mut got = String::new();
+        open_maybe_compressed(&plain)
+            .unwrap()
+            .read_to_string(&mut got)
+            .unwrap();
+        assert_eq!(got.as_bytes(), payload);
+
+        // gzip, deliberately named so the extension says nothing useful — the
+        // case that used to fail with "Invalid start character".
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(payload).unwrap();
+        let gz = write("b.plaintext", &enc.finish().unwrap());
+        let mut got = String::new();
+        open_maybe_compressed(&gz)
+            .unwrap()
+            .read_to_string(&mut got)
+            .unwrap();
+        assert_eq!(
+            got.as_bytes(),
+            payload,
+            "gzip must be detected from content, not from the file name"
+        );
+
+        // zstd.
+        let zst = write("c.fa.zst", &zstd::encode_all(&payload[..], 3).unwrap());
+        let mut got = String::new();
+        open_maybe_compressed(&zst)
+            .unwrap()
+            .read_to_string(&mut got)
+            .unwrap();
+        assert_eq!(got.as_bytes(), payload);
+    }
+
+    /// Multi-member gzip (what BGZF is) must be read to the end, not truncated at
+    /// the first member — the reason gzip goes through `MultiGzDecoder`.
+    #[test]
+    fn reads_all_members_of_a_concatenated_gzip() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut bytes = Vec::new();
+        for part in [b">a\nACGT\n".as_slice(), b">b\nTTTT\n".as_slice()] {
+            let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            enc.write_all(part).unwrap();
+            bytes.extend(enc.finish().unwrap());
+        }
+        let p = dir.path().join("multi.fa.gz");
+        std::fs::File::create(&p)
+            .unwrap()
+            .write_all(&bytes)
+            .unwrap();
+
+        let mut got = String::new();
+        open_maybe_compressed(&p)
+            .unwrap()
+            .read_to_string(&mut got)
+            .unwrap();
+        assert_eq!(got, ">a\nACGT\n>b\nTTTT\n");
+    }
+
+    /// A file too short to sniff is plain text by construction, and must open
+    /// rather than error.
+    #[test]
+    fn very_short_file_opens_as_plain_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("tiny.fa");
+        std::fs::File::create(&p).unwrap().write_all(b">a").unwrap();
+        let mut got = String::new();
+        open_maybe_compressed(&p)
+            .unwrap()
+            .read_to_string(&mut got)
+            .unwrap();
+        assert_eq!(got, ">a");
+    }
+}

--- a/crates/salmon-core/src/genemap.rs
+++ b/crates/salmon-core/src/genemap.rs
@@ -128,25 +128,13 @@ fn has_gtf_extension(path: &Path) -> bool {
 
 /// Open `path`, transparently decompressing it when it is compressed.
 ///
-/// [`niffler::get_reader`] sniffs the leading magic bytes and returns the
-/// matching decoder — gzip (via `MultiGzDecoder`, so concatenated members and
-/// BGZF are read in full rather than truncated at the first member), bzip2, xz
-/// and zstd — or the stream unchanged when it is plain text. Detection is by
-/// content, so a compressed annotation that kept a bare `.gtf` name still works.
+/// Delegates to [`crate::compress::open_maybe_compressed`] so the gene map is
+/// decoded by exactly the same rules as every other user-supplied input, and
+/// adds this module's path-annotated error context.
 fn open_maybe_compressed(path: &Path) -> io::Result<Box<dyn BufRead>> {
-    let open = || std::fs::File::open(path).map_err(|e| annotate_read_error(path, e));
-    match niffler::get_reader(Box::new(io::BufReader::new(open()?))) {
-        Ok((reader, _format)) => Ok(Box::new(io::BufReader::new(reader))),
-        // niffler reads five bytes to sniff and rejects anything shorter. No
-        // compressed file is that small, so a stub gene map is plain text by
-        // construction; re-open it and let the line loop handle it (an empty or
-        // header-only file still trips the `map.is_empty()` guard below).
-        Err(niffler::Error::FileTooShort) => Ok(Box::new(io::BufReader::new(open()?))),
-        Err(niffler::Error::IOError(e)) => Err(annotate_read_error(path, e)),
-        Err(e) => Err(annotate_read_error(
-            path,
-            io::Error::new(io::ErrorKind::InvalidData, e.to_string()),
-        )),
+    match crate::compress::open_maybe_compressed(path) {
+        Ok(r) => Ok(r),
+        Err(e) => Err(annotate_read_error(path, e)),
     }
 }
 

--- a/crates/salmon-core/src/lib.rs
+++ b/crates/salmon-core/src/lib.rs
@@ -31,6 +31,7 @@
 //! them: it is the shared bottom of the stack, which is why it must stay light.
 
 pub mod atomic;
+pub mod compress;
 pub mod diagnostics;
 pub mod error;
 pub mod genemap;


### PR DESCRIPTION
Fixes the non-FASTQ half of #1102.

### The problem

salmon decided "is this compressed, and how" independently at four entry points, with four different answers:

| path | mechanism | accepted |
| --- | --- | --- |
| `salmon index -t` | `needletail`, sniffs content | gzip, bzip2, xz, zstd |
| `--geneMap` | `niffler`, sniffs magic bytes | gzip, bzip2, xz, zstd |
| `quant -a -t` | hand-rolled 2-byte gzip magic check | gzip only |
| `quant -1/-2` | file-extension match on `.gz` | `.gz`-named gzip only |

So `salmon index -t transcripts.fa.zst` worked while `quant -a -t transcripts.fa.zst` did not, and a perfectly ordinary gzip file that was not named `.gz` was rejected with

```
Invalid start character (), expected either '>' or '@'
```

which describes the decompressed format that never happened, rather than the compression that was not detected.

### The change

Adds `salmon_core::compress`, a single helper over `niffler` — already a workspace dependency and already used by `--geneMap` — and routes the transcriptome FASTA (`load_ref_bytes`) and the SAM reader through it. Detection is by magic bytes, so a correctly compressed file is read whatever it is called, and gzip goes through `MultiGzDecoder` so multi-member and BGZF files are read in full rather than truncated at the first member.

`genemap` keeps its path-annotated error messages but now delegates the decoding, so there is one implementation rather than two that happen to agree.

`is_sam_path` still decides SAM-vs-BAM by extension. That is a different question from how the bytes are compressed, and it stays as it was.

### The FASTQ path is deliberately excluded

I had it implemented and dropped it: per your answer on #1102, `open_reader` will be replaced by piscem 0.9's decoder selection with auto-balanced mapping/decompression threads. No point landing something that is about to be replaced.

One thing worth checking when 0.9 lands, phrased as a question rather than a request: is its decoder selection format-general, or gzip-centric? If the latter, `-1/-2` would still reject zstd/bz2/xz while every other salmon input accepts them, and the helper added here is the piece that would compose with it. Entirely your call — I am not proposing anything for that path now.

### Verification

`quant -a -t`, all four forms of the same transcriptome, at `-p 1`:

| form | result |
| --- | --- |
| `t.fa` | ✅ |
| `t.fa.gz` | ✅ byte-identical `quant.sf` |
| gzip named `t.fa.gzip` | ✅ byte-identical |
| `t.fa.zst` | ✅ byte-identical |

and byte-identical to develop's own plain `-p 1` run, so the decoding change alters nothing else.

`--geneMap` still accepts plain / gz / zstd after being rewired onto the shared helper. The reads path is confirmed unchanged (zstd still rejected there, as intended).

Comparisons are at `-p 1` deliberately: alignment mode is not run-to-run reproducible at `-p > 1` (#1098), so a multi-threaded comparison here would measure that rather than this change.

Three unit tests on the helper cover content-sniffing regardless of file name, multi-member gzip being read to the end, and a file too short to sniff opening as plain text. Full suite green, clippy clean, fmt clean.
