### PR TITLE
fix(rad): never leave a truncated RAD under the requested name

### DIFF
--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -1044,7 +1044,11 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             if let (Some(rad), Some(buf)) = (sh.rad, rad_buf.as_mut()) {
                 if !maps.is_empty() {
                     let rec = build_rad_record(&maps);
-                    let _ = buf.write(&rec, rad.context());
+                    buf.write(&rec, rad.context()).map_err(|e| {
+                        paraseq::Error::from(std::io::Error::other(format!(
+                            "serializing RAD record: {e:#}"
+                        )))
+                    })?;
                 }
             }
             if let Some(acc) = sh.discrete_fld {
@@ -1072,7 +1076,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         self.shared.fld.refresh_online();
         flush_sam(self)?;
         flush_bam(self)?;
-        flush_rad(self);
+        flush_rad(self)?;
         Ok(())
     }
 
@@ -1081,7 +1085,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         merge_unmapped(self);
         flush_sam(self)?;
         flush_bam(self)?;
-        flush_rad(self);
+        flush_rad(self)?;
         Ok(())
     }
 }
@@ -1170,7 +1174,11 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             if let (Some(rad), Some(buf)) = (sh.rad, rad_buf.as_mut()) {
                 if !maps.is_empty() {
                     let radrec = build_rad_record(&maps);
-                    let _ = buf.write(&radrec, rad.context());
+                    buf.write(&radrec, rad.context()).map_err(|e| {
+                        paraseq::Error::from(std::io::Error::other(format!(
+                            "serializing RAD record: {e:#}"
+                        )))
+                    })?;
                 }
             }
             if let Some(acc) = sh.discrete_fld {
@@ -1198,7 +1206,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         self.shared.fld.refresh_online();
         flush_sam(self)?;
         flush_bam(self)?;
-        flush_rad(self);
+        flush_rad(self)?;
         Ok(())
     }
 
@@ -1207,7 +1215,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         merge_unmapped(self);
         flush_sam(self)?;
         flush_bam(self)?;
-        flush_rad(self);
+        flush_rad(self)?;
         Ok(())
     }
 }
@@ -1268,15 +1276,20 @@ fn build_rad_record(maps: &[ScoredMapping]) -> salmon_rad::SalmonBulkRecord {
 }
 
 /// Flush this thread's accumulated RAD records as one chunk to the shared writer.
-fn flush_rad(proc: &mut QuantProcessor) {
+///
+/// Errors here are fatal and must propagate: this is the only point at which a
+/// RAD write actually reaches the filesystem, so discarding the result means a
+/// full disk (`ENOSPC`) or an I/O error silently yields a truncated RAD that the
+/// run then reports as successful. See salmon#1105.
+fn flush_rad(proc: &mut QuantProcessor) -> paraseq::Result<()> {
     if let (Some(rad), Some(buf)) = (proc.shared.rad, proc.rad_buf.as_mut()) {
         if buf.nrec() > 0 {
-            match buf.take_bytes() {
-                Ok(bytes) => {
-                    let _ = rad.append_chunk_bytes(&bytes);
-                }
-                Err(e) => tracing::error!("failed to serialize RAD chunk: {e}"),
-            }
+            let bytes = buf
+                .take_bytes()
+                .map_err(|e| paraseq::Error::from(std::io::Error::other(e.to_string())))?;
+            rad.append_chunk_bytes(&bytes)
+                .map_err(|e| paraseq::Error::from(std::io::Error::other(format!("{e:#}"))))?;
         }
     }
+    Ok(())
 }

--- a/crates/salmon-rad/src/lib.rs
+++ b/crates/salmon-rad/src/lib.rs
@@ -198,6 +198,15 @@ pub const BAKED_LIBFMT: u8 = 0x04;
 /// [`BAKED_FLAGS_TAG`] bit: a non-default [`SCORE_KIND_TAG`] is present (the
 /// per-hit score is a quantized log-weight, not a raw aligner `AS`).
 pub const BAKED_SCORE_KIND: u8 = 0x08;
+/// [`BAKED_FLAGS_TAG`] bit: the writer reached finalize, so the file is complete.
+///
+/// This is **confirmatory only**. Its presence proves the file was fully
+/// written; its absence proves nothing, because a conforming producer may stream
+/// a RAD file without ever backpatching (the same reason `num_chunks == 0` is a
+/// valid "unknown chunk count" signal). Readers may use it as a fast path, but
+/// must never require it, or they would reject legitimate files from other
+/// tools.
+pub const WRITE_COMPLETE: u8 = 0x10;
 
 /// File-tag name: how a reader should interpret the per-hit `alignment_score`
 /// (present only in the selective-alignment profile). A `u8`:

--- a/crates/salmon-rad/src/writer.rs
+++ b/crates/salmon-rad/src/writer.rs
@@ -25,9 +25,10 @@
 //! unordered bag and salmon's determinism comes from order-independent
 //! aggregation downstream, not from file order.
 
+use anyhow::Context;
 use std::fs::File;
 use std::io::BufWriter;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use libradicl::chunk::ChunkBuf;
 use libradicl::header::RadPrelude;
@@ -40,6 +41,10 @@ use crate::{schema, RadProfile, BAKED_ABUND, BAKED_FLD, BAKED_LIBFMT, BAKED_SCOR
 
 /// Shared, thread-safe RAD output sink for one file.
 pub struct RadOutputWriter {
+    /// where the finished file should end up
+    final_path: PathBuf,
+    /// where bytes are actually written until `finalize` renames it
+    partial_path: PathBuf,
     /// The underlying file, wrapped so that appends from many threads are safe.
     ccw: ConcurrentChunkWriter<BufWriter<File>>,
     /// Which profile records are written in (decides the per-hit layout).
@@ -62,6 +67,19 @@ pub struct RadOutputWriter {
     codec: ChunkCodec,
 }
 
+/// The sibling path a RAD file is written to before it is finalized.
+///
+/// Keeping it next to the destination (rather than in a temp dir) means the
+/// final rename is within one filesystem, so it is atomic; a cross-device rename
+/// would degrade to a copy and reintroduce the partial-file window this exists
+/// to close. The pid keeps concurrent runs targeting the same output from
+/// colliding.
+fn partial_path_for(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".partial-{}", std::process::id()));
+    path.with_file_name(name)
+}
+
 impl RadOutputWriter {
     /// Create a RAD file at `path`, writing the prelude + file tags for the
     /// given profile. `ref_names`/`ref_lengths` cover the full reference table.
@@ -78,13 +96,25 @@ impl RadOutputWriter {
     ) -> anyhow::Result<Self> {
         let (prelude, file_tag_map): (RadPrelude, _) =
             schema::build_prelude(profile, is_paired, ref_names, ref_lengths, fld_len, codec);
+        // Write to a sibling temporary path and rename onto `path` only once the
+        // run has finalized successfully. A partial RAD therefore never appears
+        // under the name the user asked for, so a later `--rad` run cannot pick
+        // one up believing it is complete. Rename rather than delete-on-error,
+        // because rename is atomic and also covers `SIGKILL`, where no cleanup
+        // code of ours would run at all.
+        let partial_path = partial_path_for(path);
         // `BufWriter` batches small writes into large ones; without it every
         // chunk append would become a separate system call.
-        let file = BufWriter::new(File::create(path)?);
+        let file = BufWriter::new(
+            File::create(&partial_path)
+                .with_context(|| format!("creating RAD output file {}", partial_path.display()))?,
+        );
         // Writing the prelude here means the file is valid (if empty) from the
         // moment it is created.
         let fw = RadFileWriter::new(file, &prelude, &file_tag_map)?;
         Ok(Self {
+            final_path: path.to_path_buf(),
+            partial_path,
             ccw: ConcurrentChunkWriter::new(fw),
             ctx: SalmonBulkContext { profile },
             fld_len,
@@ -142,7 +172,13 @@ impl RadOutputWriter {
     /// Append a fully-framed chunk (from [`FragmentChunkBuf::take_bytes`]) to the
     /// file. Thread-safe: takes `&self`, so every worker can call it directly.
     pub fn append_chunk_bytes(&self, bytes: &[u8]) -> anyhow::Result<()> {
-        self.ccw.append_chunk_bytes(bytes)
+        self.ccw.append_chunk_bytes(bytes).with_context(|| {
+            format!(
+                "writing RAD chunk to {}\n  \
+                 the incomplete file has been left there; it is NOT usable as `--rad` input",
+                self.partial_path.display()
+            )
+        })
     }
 
     /// Backpatch any baked FLD / abundances + the `baked_flags` marker, then flush
@@ -191,11 +227,40 @@ impl RadOutputWriter {
                 flags |= BAKED_SCORE_KIND;
             }
         }
-        if flags != 0 {
-            w.backpatch_file_tag_value(crate::BAKED_FLAGS_TAG, &TagValue::U8(flags))?;
-        }
+        // Reaching here means every chunk was written and the header is about to
+        // be patched, so record completeness alongside whatever else was baked.
+        // See `WRITE_COMPLETE`: readers treat this as confirmatory, never required.
+        flags |= crate::WRITE_COMPLETE;
+        w.backpatch_file_tag_value(crate::BAKED_FLAGS_TAG, &TagValue::U8(flags))?;
         // Writes the final chunk count into the header and flushes the file.
-        w.finalize()?;
+        let buf = w
+            .finalize()
+            .with_context(|| format!("finalizing {}", self.partial_path.display()))?;
+        // `into_inner` flushes, and unlike dropping the `BufWriter` it reports a
+        // failure to do so rather than swallowing it.
+        let file = buf.into_inner().map_err(|e| {
+            anyhow::anyhow!(
+                "flushing {}: {}",
+                self.partial_path.display(),
+                e.into_error()
+            )
+        })?;
+        // Flush to the device before the rename makes this the user-visible
+        // output. On NFS in particular a deferred `ENOSPC` surfaces only here, so
+        // dropping the handle instead would discard exactly the error this fix
+        // exists to report (salmon#1105).
+        file.sync_all()
+            .with_context(|| format!("flushing {} to disk", self.partial_path.display()))?;
+        // Only now does the output take the name the user asked for. Any failure
+        // before this point leaves the bytes under the `.partial-*` name, where a
+        // later `--rad` run will not mistake them for a complete file.
+        std::fs::rename(&self.partial_path, &self.final_path).with_context(|| {
+            format!(
+                "renaming {} to {}",
+                self.partial_path.display(),
+                self.final_path.display()
+            )
+        })?;
         Ok(())
     }
 }

--- a/crates/salmon-rad/tests/roundtrip.rs
+++ b/crates/salmon-rad/tests/roundtrip.rs
@@ -97,6 +97,19 @@ fn read_all(
     (prelude, ref_lengths, ctx, recs)
 }
 
+/// Read one file tag by name from a written RAD file.
+fn read_file_tag(path: &std::path::Path, name: &str) -> TagValue {
+    let mut data = Vec::new();
+    std::fs::File::open(path)
+        .unwrap()
+        .read_to_end(&mut data)
+        .unwrap();
+    let mut rc = Cursor::new(data);
+    let prelude = RadPrelude::from_bytes(&mut rc).unwrap();
+    let ftm = prelude.file_tags.parse_tags_from_bytes(&mut rc).unwrap();
+    ftm.get(name).unwrap().clone()
+}
+
 fn check_roundtrip(profile: RadProfile, expected_detect: RadInputProfile) {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     let recs = sample_records(profile);
@@ -219,4 +232,86 @@ fn concurrent_writer_counts_chunks() {
     let (prelude, _, _, got) = read_all(tmp.path());
     assert_eq!(prelude.hdr.num_chunks, 4, "one chunk per thread");
     assert_eq!(got.len(), 4, "all four records present");
+}
+
+/// A RAD file must only take the name the user asked for once it is complete.
+///
+/// Regression test for salmon#1105: a run that died mid-write (a full disk) left
+/// a truncated file at the requested path, and a later `--rad` run consumed it
+/// as if it were whole.
+#[test]
+fn abandoned_write_never_claims_the_final_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.rad");
+    let names = ["t0", "t1", "t2"];
+    let lens = [100u32, 200, 300];
+
+    let w = RadOutputWriter::create(
+        &path,
+        &names,
+        &lens,
+        true,
+        RadProfile::SelectiveAlignment,
+        1024,
+        ChunkCodec::None,
+    )
+    .unwrap();
+    let ctx: SalmonBulkContext = *w.context();
+    let mut cb = FragmentChunkBuf::with_capacity_codec(1024, ChunkCodec::None);
+    for r in &sample_records(RadProfile::SelectiveAlignment) {
+        cb.write(r, &ctx).unwrap();
+    }
+    w.append_chunk_bytes(&cb.take_bytes().unwrap()).unwrap();
+    // Simulates the run dying before finalize: chunks are on disk, but the
+    // header was never backpatched.
+    drop(w);
+
+    assert!(
+        !path.exists(),
+        "an unfinalized write must not appear at the requested path"
+    );
+    let partials: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("out.rad.partial-"))
+        .collect();
+    assert_eq!(
+        partials.len(),
+        1,
+        "the incomplete bytes should remain under a `.partial-*` name, found {partials:?}"
+    );
+}
+
+/// `finalize` renames the partial into place and marks the file complete.
+#[test]
+fn finalize_renames_and_marks_complete() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.rad");
+    write_file_codec(
+        &path,
+        RadProfile::SelectiveAlignment,
+        &sample_records(RadProfile::SelectiveAlignment),
+        ChunkCodec::None,
+    );
+
+    assert!(
+        path.exists(),
+        "finalize should rename the partial into place"
+    );
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|n| n.contains(".partial-"))
+        .collect();
+    assert!(leftovers.is_empty(), "partial left behind: {leftovers:?}");
+
+    let flags = match read_file_tag(&path, salmon_rad::BAKED_FLAGS_TAG) {
+        TagValue::U8(v) => v,
+        other => panic!("baked_flags should be a u8, got {other:?}"),
+    };
+    assert_ne!(
+        flags & salmon_rad::WRITE_COMPLETE,
+        0,
+        "a finalized file should carry the confirmatory completeness bit"
+    );
 }


### PR DESCRIPTION
Writer-side half of #1105. The reader-side hang is being fixed upstream in libradicl (COMBINE-lab/libradicl#45); this closes the hole that produced the bad file in the first place.

## What went wrong

A run whose RAD write failed on a full disk **exited 0** and left a truncated file at the path the user asked for. A later `--rad` run then read that file as though it were complete and hung. Three separate defects lined up:

**1. The write result was discarded.** `flush_rad` is the only point at which RAD bytes reach the filesystem, and it ended in:

```rust
let _ = rad.append_chunk_bytes(&bytes);
```

Both per-record buffer writes were `let _ = ` too. `ENOSPC` was therefore structurally invisible. These now propagate and the run fails loudly.

**2. Bytes went straight to the destination.** Output is now written to a sibling `<name>.partial-<pid>` and renamed into place only after a successful finalize. Rename rather than delete-on-error because it is atomic and also covers `SIGKILL`, where no cleanup code of ours would run at all. Keeping the temp file next to the destination (not in a temp dir) keeps the rename within one filesystem; a cross-device rename would degrade to a copy and reopen the very window this closes.

Write errors name the partial explicitly:

```
Error: quantification failed

Caused by:
    mapping failed: FASTX error: Error reading from buffer: writing RAD chunk to /path/out.rad.partial-2629896
      the incomplete file has been left there; it is NOT usable as `--rad` input: couldn't write chunk bytes to RAD file: File too large (os error 27)
```

`finalize` also now flushes via `into_inner` + `sync_all` instead of dropping the handle. Dropping a `BufWriter` flushes but swallows the error, and on NFS a deferred `ENOSPC` surfaces only at that point — which is exactly where the original report came from.

**3. Nothing recorded completeness.** `finalize` sets a `WRITE_COMPLETE` bit in `baked_flags`.

To be explicit about the contract, since this came up in discussion: **this bit is confirmatory only.** Its presence proves the file was fully written; its absence proves nothing, because a conforming producer may stream a RAD file without ever backpatching — the same reason `num_chunks == 0` is a valid "unknown chunk count" signal rather than a corruption signal. Readers may use it as a fast path but must never require it, or they would reject legitimate files from other tools. No reader-side rejection is added here.

## Verification

Simulating a write failure **without filling a device**: `ulimit -f` caps the file size a process may create, so writes past the cap fail with `EFBIG` — the same class of failure as `ENOSPC`.

```bash
ulimit -f 4        # 2 KiB
trap '' XFSZ       # take the error return rather than the signal
salmon quant -i idx -l A -1 r1.fq -2 r2.fq -o out --writeRad out.rad -p 2
```

| | before | after |
|---|---|---|
| exit code | 0 | 1 |
| error reported | none | names the partial file |
| file at requested path | truncated `out.rad` | absent |
| leftover | — | `out.rad.partial-<pid>` |

Happy path re-checked end to end: `--writeRad` produces the file at the requested name with no partial left behind, and a `--rad` run consumes it and produces the expected `quant.sf`.

Two regression tests in `salmon-rad`. Negative control run on the first: reverting the temp path to `File::create(path)` makes `abandoned_write_never_claims_the_final_path` fail, so it catches the actual bug rather than passing vacuously.

`cargo fmt`, `clippy --workspace --all-targets -D warnings`, and the full workspace suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKxqH6k1sbmDC1bpNso3zr