### PR TITLE
feat(rad): record what the mapping pass observed, so a requant reproduces it

### DIFF
--- a/crates/salmon-align/src/bam_rad.rs
+++ b/crates/salmon-align/src/bam_rad.rs
@@ -146,6 +146,12 @@ pub fn write_alignment_rad(
         RadProfile::SelectiveAlignment,
         opts.fld_max + 1,
         codec,
+        // Fragments came from an external aligner, and there is no salmon index
+        // behind them; a reader reads the absent index as "unknown".
+        &salmon_rad::WriterProvenance {
+            mapping_type: salmon_rad::MappingType::Alignment,
+            index: None,
+        },
     )?;
 
     let fld = DiscreteFld::new(opts.fld_max);

--- a/crates/salmon-align/src/bam_rad.rs
+++ b/crates/salmon-align/src/bam_rad.rs
@@ -151,6 +151,9 @@ pub fn write_alignment_rad(
         &salmon_rad::WriterProvenance {
             mapping_type: salmon_rad::MappingType::Alignment,
             index: None,
+            // Carry the aligner's own account of how these alignments were made,
+            // so a requant reports the command line and not merely "a BAM".
+            source_programs: crate::source_program_lines(&header),
         },
     )?;
 
@@ -214,6 +217,13 @@ pub fn write_alignment_rad(
         writer.set_initial_abundances(&em.alphas);
     }
 
+    // The BAM's own fragment total, which the records cannot show once unmapped
+    // ones are dropped. The `_vm` counters and the decoy count have no meaning
+    // for an aligner's output and stay zero.
+    writer.set_map_counters(salmon_rad::MapCounters {
+        num_processed: summary.num_processed,
+        ..Default::default()
+    });
     writer.finalize()?;
     Ok(summary)
 }

--- a/crates/salmon-align/src/genome_project.rs
+++ b/crates/salmon-align/src/genome_project.rs
@@ -160,6 +160,9 @@ pub fn project_genome_bam_to_rad(
         &salmon_rad::WriterProvenance {
             mapping_type: salmon_rad::MappingType::Alignment,
             index: None,
+            // Carry the aligner's own account of how these alignments were made,
+            // so a requant reports the command line and not merely "a BAM".
+            source_programs: crate::source_program_lines(&header),
         },
     )?;
 

--- a/crates/salmon-align/src/genome_project.rs
+++ b/crates/salmon-align/src/genome_project.rs
@@ -155,6 +155,12 @@ pub fn project_genome_bam_to_rad(
         RadProfile::SelectiveAlignment,
         opts.fld_max + 1,
         opts.rad_codec,
+        // Fragments came from an external aligner, and there is no salmon index
+        // behind them; a reader reads the absent index as "unknown".
+        &salmon_rad::WriterProvenance {
+            mapping_type: salmon_rad::MappingType::Alignment,
+            index: None,
+        },
     )?;
 
     // Short-read projection only. Long-read genome quantification is out of scope

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -271,6 +271,15 @@ impl AlignQuantOptions {
 }
 
 /// Quantification results.
+/// What a quantification run read its fragments from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FragmentSource {
+    /// an alignment file given with `-a`
+    Bam,
+    /// a RAD file given with `--rad`, or written as a `--deterministic` intermediate
+    Rad,
+}
+
 #[derive(Debug, Clone)]
 pub struct AlignQuantResult {
     pub names: Vec<String>,
@@ -290,6 +299,13 @@ pub struct AlignQuantResult {
     /// what the RAD says about the mapping pass that produced it; empty for a
     /// BAM input, which has no RAD provenance to read
     pub provenance: crate::rad::RadProvenance,
+    /// verbatim `@PG` lines describing how the fragments were produced: read
+    /// from a BAM's header directly, or carried through a BAM-derived RAD
+    pub source_programs: Vec<String>,
+    /// what this run actually read, which decides which metadata is even
+    /// applicable — an index hash is missing from a RAD requant but simply does
+    /// not apply to a BAM, and blaming a RAD that was never read would be wrong
+    pub source: FragmentSource,
     /// fragment mass dropped in the final min-alpha redistribution (every member
     /// of an equivalence class truncated); normally 0.
     pub inference_truncated_mass: f64,
@@ -1398,6 +1414,88 @@ fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> bo
 /// the reliable signal that records are usably grouped is `GO:query`. So we only
 /// reject when coordinate-sorted AND not query-grouped. (Query-name *sorted* files
 /// report `SO:queryname`, not coordinate, and pass.)
+/// One `@PG` header record: what a program said about how it touched the file.
+///
+/// `command_line` is the field that actually answers "how was this BAM made";
+/// the rest identify the program well enough to make sense of it.
+#[derive(Clone, Debug, Default, Serialize, PartialEq, Eq)]
+pub struct SourceProgram {
+    /// `ID` — unique within the file, and the link target of `PP`
+    pub id: String,
+    /// `PN` — program name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub program_name: Option<String>,
+    /// `VN` — program version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// `CL` — the command line the program was invoked with
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_line: Option<String>,
+    /// `PP` — the previous program in the chain, so the order is recoverable
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_id: Option<String>,
+    /// `DS` — free-text description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Render a BAM header's `@PG` chain as verbatim SAM lines.
+///
+/// Kept as text on the way into a RAD so nothing the aligner recorded is dropped
+/// in transit; [`parse_source_programs`] reads them back.
+pub fn source_program_lines(header: &noodles_sam::Header) -> Vec<String> {
+    header
+        .programs()
+        .as_ref()
+        .iter()
+        .map(|(id, program)| {
+            let mut line = format!("@PG\tID:{}", String::from_utf8_lossy(id.as_ref()));
+            // Every tag the aligner wrote is carried through, standard or not:
+            // this is provenance, not a schema to validate against.
+            for (tag, value) in program.other_fields() {
+                let t: &[u8; 2] = tag.as_ref();
+                line.push_str(&format!(
+                    "\t{}:{}",
+                    String::from_utf8_lossy(t),
+                    String::from_utf8_lossy(value.as_ref())
+                ));
+            }
+            line
+        })
+        .collect()
+}
+
+/// Parse `@PG` lines produced by [`source_program_lines`] back into records.
+///
+/// Unknown tags are ignored rather than rejected: a `@PG` record may carry
+/// anything, and provenance that fails to parse is worse than provenance that
+/// reports only the fields it understands.
+pub fn parse_source_programs(lines: &[String]) -> Vec<SourceProgram> {
+    lines
+        .iter()
+        .filter(|l| l.starts_with("@PG\t"))
+        .map(|line| {
+            let mut prog = SourceProgram::default();
+            for field in line.split('\t').skip(1) {
+                let Some((tag, value)) = field.split_once(':') else {
+                    continue;
+                };
+                let value = value.to_string();
+                match tag {
+                    "ID" => prog.id = value,
+                    "PN" => prog.program_name = Some(value),
+                    "VN" => prog.version = Some(value),
+                    "CL" => prog.command_line = Some(value),
+                    "PP" => prog.previous_id = Some(value),
+                    "DS" => prog.description = Some(value),
+                    _ => {}
+                }
+            }
+            prog
+        })
+        .collect()
+}
+
 fn coordinate_sorted_unusable(header: &noodles_sam::Header) -> bool {
     let Some(hd) = header.header() else {
         return false;
@@ -1940,6 +2038,9 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
         // orphans; both are reported as unknown rather than as zero.
         num_orphan: None,
         provenance: crate::rad::RadProvenance::default(),
+        // Straight from the BAM being quantified, no RAD in between.
+        source_programs: source_program_lines(&header),
+        source: FragmentSource::Bam,
         names,
         lengths,
         eff_lengths,
@@ -2051,7 +2152,11 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         /// 100% because a RAD holds only the fragments that mapped.
         meta_info_complete: bool,
         #[serde(skip_serializing_if = "Vec::is_empty")]
-        incomplete_meta_info_fields: Vec<&'static str>,
+        incomplete_meta_info_fields: Vec<salmon_core::MissingMetaField>,
+        /// what the source BAM's `@PG` chain said about how it was produced;
+        /// omitted when the fragments did not come from an alignment file
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        alignment_provenance: Vec<SourceProgram>,
         num_em_iterations: u32,
         em_converged: bool,
         detected_library_type: Option<String>,
@@ -2077,7 +2182,27 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
     // `meta_info_complete` records for whoever reads the results later.
     let counters = res.provenance.counters;
     let index_prov = res.provenance.index.clone().unwrap_or_default();
-    let incomplete_meta_info_fields = res.provenance.missing_meta_info_fields();
+    // Only a RAD requant can be short of the mapping pass's own record of itself.
+    // Alignment mode never had index hashes — that is by design, not a gap — and
+    // it counts its own fragments, so nothing there is missing for want of an
+    // upstream.
+    let mut incomplete_meta_info_fields = match res.source {
+        FragmentSource::Rad => res.provenance.missing_meta_info_fields(),
+        FragmentSource::Bam => Vec::new(),
+    };
+    // What the aligner recorded about itself, carried through a BAM-derived RAD.
+    // A BAM with no `@PG` chain is itself worth recording: the gap is upstream,
+    // and saying so is more useful than an empty field the reader must interpret.
+    let alignment_provenance = crate::parse_source_programs(&res.source_programs);
+    let from_alignments = res.source == FragmentSource::Bam
+        || res.provenance.mapping_type == Some(salmon_rad::MappingType::Alignment);
+    if from_alignments && alignment_provenance.is_empty() {
+        incomplete_meta_info_fields.push(salmon_core::MissingMetaField::bam(
+            "alignment_provenance",
+            "the source BAM's header carries no @PG records, so how its \
+             alignments were produced is not recorded anywhere in the file",
+        ));
+    }
     let meta = MetaInfo {
         salmon_version: SALMON_VERSION.to_string(),
         samp_type: "none".to_string(),
@@ -2107,7 +2232,11 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
             .mapping_type
             .map_or("alignment", |m| m.as_str())
             .to_string(),
-        keep_duplicates: res.provenance.index.as_ref().map(|p| p.keep_duplicates),
+        keep_duplicates: res
+            .provenance
+            .index
+            .as_ref()
+            .and_then(|p| p.keep_duplicates),
         index_seq_hash: index_prov.seq_hash,
         index_name_hash: index_prov.name_hash,
         index_seq_hash512: index_prov.seq_hash512,
@@ -2133,6 +2262,7 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         num_orphan: res.num_orphan,
         meta_info_complete: incomplete_meta_info_fields.is_empty(),
         incomplete_meta_info_fields,
+        alignment_provenance,
         range_factorization_bins: opts.range_factorization_bins,
         num_em_iterations: res.em_iters,
         em_converged: res.em_converged,

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -1439,19 +1439,27 @@ pub struct SourceProgram {
     pub description: Option<String>,
 }
 
-/// Render a BAM header's `@PG` chain as verbatim SAM lines.
+/// Render a BAM header's `@PG` chain as SAM lines.
 ///
 /// Kept as text on the way into a RAD so nothing the aligner recorded is dropped
 /// in transit; [`parse_source_programs`] reads them back. Empty when the header
 /// has no `@PG` records at all, which is common enough — plenty of tools write
 /// none — that callers must treat it as ordinary rather than exceptional.
+///
+/// Values are escaped rather than passed through raw. RAD imposes nothing here:
+/// it stores a string as an explicit length followed by bytes, so it would carry
+/// any content. The constraint is entirely from *this* representation — records
+/// joined by newlines, fields by tabs — so those characters are escaped to keep
+/// the framing unambiguous, and [`parse_source_programs`] restores them. SAM
+/// forbids them in header values anyway, so it only matters for a malformed
+/// input, where preserving the value beats silently rewriting it.
 pub fn source_program_lines(header: &noodles_sam::Header) -> Vec<String> {
-    header
+    let mut lines: Vec<String> = header
         .programs()
         .as_ref()
         .iter()
         .map(|(id, program)| {
-            let mut line = format!("@PG\tID:{}", sanitize_header_value(id.as_ref()));
+            let mut line = format!("@PG\tID:{}", escape_header_value(id.as_ref()));
             // Every tag the aligner wrote is carried through, standard or not:
             // this is provenance, not a schema to validate against.
             for (tag, value) in program.other_fields() {
@@ -1459,22 +1467,76 @@ pub fn source_program_lines(header: &noodles_sam::Header) -> Vec<String> {
                 line.push_str(&format!(
                     "\t{}:{}",
                     String::from_utf8_lossy(t),
-                    sanitize_header_value(value.as_ref())
+                    escape_header_value(value.as_ref())
                 ));
             }
             line
         })
-        .collect()
+        .collect();
+
+    // A RAD string tag is length-prefixed with a `u16`, and that length is cast
+    // rather than checked, so an over-long value wraps and corrupts the file
+    // instead of failing. Drop whole trailing records until the chain fits: a
+    // shortened chain is a poor outcome, an unreadable RAD a far worse one.
+    while !lines.is_empty() && joined_len(&lines) > salmon_rad::MAX_FILE_TAG_STRING_LEN {
+        let dropped = lines.pop().unwrap_or_default();
+        tracing::warn!(
+            "the @PG chain is longer than the {} bytes a RAD string tag holds; \
+             dropping its trailing record ({}...) so the file stays readable",
+            salmon_rad::MAX_FILE_TAG_STRING_LEN,
+            dropped.chars().take(60).collect::<String>()
+        );
+    }
+    lines
 }
 
-/// Flatten the separators a SAM header value must not contain.
+/// Length of the newline-joined form the RAD tag actually stores.
+fn joined_len(lines: &[String]) -> usize {
+    lines.iter().map(String::len).sum::<usize>() + lines.len().saturating_sub(1)
+}
+
+/// Escape the characters that frame the joined `@PG` representation.
 ///
-/// The spec forbids tabs and newlines here, but a malformed file can carry them,
-/// and they are exactly the two characters this round trip is framed by: a tab
-/// would invent a field and a newline would split one record into two. Replacing
-/// them keeps a bad header from silently corrupting the neighbouring provenance.
-fn sanitize_header_value(value: &[u8]) -> String {
-    String::from_utf8_lossy(value).replace(['\t', '\n', '\r'], " ")
+/// Backslash is escaped too, so the mapping is reversible: without it a value
+/// containing a literal backslash-n (two characters) would be indistinguishable
+/// from an escaped newline.
+fn escape_header_value(value: &[u8]) -> String {
+    let mut out = String::new();
+    for c in String::from_utf8_lossy(value).chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Reverse [`escape_header_value`]. An unrecognized escape is left as written,
+/// so text that was never escaped survives unchanged.
+fn unescape_header_value(value: &str) -> String {
+    let mut out = String::new();
+    let mut chars = value.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('\\') => out.push('\\'),
+            Some('t') => out.push('\t'),
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 /// Parse `@PG` lines produced by [`source_program_lines`] back into records.
@@ -1492,7 +1554,7 @@ pub fn parse_source_programs(lines: &[String]) -> Vec<SourceProgram> {
                 let Some((tag, value)) = field.split_once(':') else {
                     continue;
                 };
-                let value = value.to_string();
+                let value = unescape_header_value(value);
                 match tag {
                     "ID" => prog.id = value,
                     "PN" => prog.program_name = Some(value),

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -837,6 +837,8 @@ struct PassAccum {
     )>,
     num_processed: u64,
     num_mapped: u64,
+    /// mapped fragments where every surviving placement placed only one mate
+    num_orphan: u64,
 }
 
 /// The online pass over an alignment record stream, structured as a persistent
@@ -929,7 +931,7 @@ where
         let mut workers = Vec::with_capacity(cfg.nthreads);
         for _ in 0..cfg.nthreads {
             let rx = rx.clone();
-            workers.push(scope.spawn(move || -> (Local, u64, u64) {
+            workers.push(scope.spawn(move || -> (Local, u64, u64, u64) {
                 let mut local = Local::new(
                     cfg.use_error_model,
                     cfg.error_bins,
@@ -941,6 +943,7 @@ where
                 );
                 let mut count = 0u64;
                 let mut mapped = 0u64;
+                let mut orphan = 0u64;
                 let mut frags: Vec<FragRecord> = Vec::new();
                 while let Ok((log_fm, raw_batch)) = rx.recv() {
                     let ctx = FragCtx {
@@ -963,6 +966,9 @@ where
                     };
                     let mut since_flush = 0usize;
                     let mut batch_mapped = 0u64;
+                    // Plain locals, summed once per worker at the end: the
+                    // per-fragment cost is an increment, with no atomic traffic.
+                    let mut batch_orphan = 0u64;
                     for raw_group in &raw_batch {
                         frags.clear();
                         for r in raw_group {
@@ -970,8 +976,13 @@ where
                                 frags.push(f);
                             }
                         }
-                        if process_fragment(&frags, &ctx, &mut local) {
-                            batch_mapped += 1;
+                        match process_fragment(&frags, &ctx, &mut local) {
+                            FragmentOutcome::Unmapped => {}
+                            FragmentOutcome::Mapped => batch_mapped += 1,
+                            FragmentOutcome::MappedOrphan => {
+                                batch_mapped += 1;
+                                batch_orphan += 1;
+                            }
                         }
                         // Publish the error-model delta into the shared model
                         // every FLUSH_INTERVAL fragments so other workers' `basis`
@@ -996,6 +1007,7 @@ where
                     }
                     count += raw_batch.len() as u64;
                     mapped += batch_mapped;
+                    orphan += batch_orphan;
                     // Live progress: every fragment in the BAM is "processed";
                     // only fragments with a surviving strand-compatible placement
                     // are "mapped" (so percent_mapped is correct on stranded data).
@@ -1008,7 +1020,7 @@ where
                             .fetch_add(batch_mapped, std::sync::atomic::Ordering::Relaxed);
                     }
                 }
-                (local, count, mapped)
+                (local, count, mapped, orphan)
             }));
         }
         drop(rx); // workers hold their own clones; lets the queue disconnect
@@ -1029,13 +1041,15 @@ where
         );
         let mut total = 0u64;
         let mut total_mapped = 0u64;
+        let mut total_orphan = 0u64;
         for w in workers {
-            let (local, count, mapped) = w
+            let (local, count, mapped, orphan) = w
                 .join()
                 .map_err(|_| anyhow::anyhow!("alignment worker thread panicked"))?;
             merged = merged.merge(local);
             total += count;
             total_mapped += mapped;
+            total_orphan += orphan;
         }
         acc.seq_obs = merged.seq_obs;
         acc.gc_obs = merged.gc_obs;
@@ -1045,6 +1059,7 @@ where
         // They differ only for stranded libraries; matches reads-mode (#1025).
         acc.num_processed = total;
         acc.num_mapped = total_mapped;
+        acc.num_orphan = total_orphan;
         Ok(())
     })
 }
@@ -1174,7 +1189,24 @@ impl Local {
 /// caller counts a fragment as *mapped* only when this returns `true`, so a
 /// stranded library does not over-report `num_mapped` for fragments whose every
 /// alignment is strand-incompatible (the alignment-mode analog of #1025).
-fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> bool {
+/// What became of one fragment.
+///
+/// Distinguishes the two mapped cases so `-a` can report the concordant/orphan
+/// split the reads path does, without a second pass over the placements.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum FragmentOutcome {
+    /// no reported alignment survived compatibility filtering
+    Unmapped,
+    /// assigned, with at least one placement pairing both mates
+    Mapped,
+    /// assigned in a paired library, but every surviving placement placed only
+    /// one mate. Matches the RAD fragment-level rule, which takes the *most
+    /// complete* status across hits: a fragment that is a proper pair on one
+    /// transcript and an orphan on another counts as a pair.
+    MappedOrphan,
+}
+
+fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> FragmentOutcome {
     use salmon_model::seqbias::{CONTEXT_LEFT, CONTEXT_LENGTH, CONTEXT_RIGHT};
     // salmon's LOG_EPSILON = log(0.375e-10): the orphan / implausible-length penalty.
     const LOG_EPSILON: f64 = -23.998_158_637_57;
@@ -1197,6 +1229,9 @@ fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> bo
     let mut sp_online: Vec<f64> = Vec::with_capacity(placements.len());
     let mut sp_geom: Vec<(usize, usize, bool)> = Vec::with_capacity(placements.len());
     let mut sp_pl: Vec<usize> = Vec::with_capacity(placements.len());
+    // Whether any surviving placement paired both mates; folded into the loop
+    // below, which already computes `proper` for its own use.
+    let mut any_proper = false;
     for (pi, pl) in placements.iter().enumerate() {
         let tid = pl.tid;
         let idxs = &pl.idxs;
@@ -1254,6 +1289,7 @@ fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> bo
                 aux += ctx.incompat_prior.ln();
             }
         }
+        any_proper |= proper;
         sp_tid.push(tid);
         sp_eq.push(aux);
         sp_online.push(aux + start_pos);
@@ -1263,8 +1299,14 @@ fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> bo
     // a fragment whose every reported alignment was incompatible is a
     // zero-probability fragment: it is not assigned and joins no eq-class.
     if sp_tid.is_empty() {
-        return false;
+        return FragmentOutcome::Unmapped;
     }
+    // Single-end libraries have no mate to be missing, so they are never orphans.
+    let outcome = if ctx.paired_lib && !any_proper {
+        FragmentOutcome::MappedOrphan
+    } else {
+        FragmentOutcome::Mapped
+    };
 
     // Aggregate surviving placements by distinct transcript id (sorted).
     let mut agg: std::collections::BTreeMap<u32, Vec<usize>> = std::collections::BTreeMap::new();
@@ -1402,7 +1444,7 @@ fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> bo
         TranscriptGroup::from_sorted(tids)
     };
     ctx.eq_builder.add_group(group, weights, 1);
-    true
+    outcome
 }
 
 /// Is the input coordinate-sorted and *not* grouped by read name?
@@ -1874,7 +1916,7 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
     // is trained there too but not needed afterward. Scope `cfg`/`acc` so their
     // borrows (fld, eq_builder, online, ...) are released before the post-pass
     // effective-length / EM work below.
-    let (seq_obs, gc_obs, pos_obs, num_processed, num_mapped) = {
+    let (seq_obs, gc_obs, pos_obs, num_processed, num_mapped, num_orphan) = {
         let cfg = PassCfg {
             online: online.as_ref(),
             fld: &fld,
@@ -1908,6 +1950,7 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             pos_obs: None,
             num_processed: 0,
             num_mapped: 0,
+            num_orphan: 0,
         };
         stream_online_pass(&opts.bam, &cfg, &mut acc)?;
         (
@@ -1916,6 +1959,7 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             acc.pos_obs,
             acc.num_processed,
             acc.num_mapped,
+            acc.num_orphan,
         )
     };
 
@@ -2108,9 +2152,9 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
     timer.mark("posterior");
 
     let result = AlignQuantResult {
-        // A BAM input carries no RAD provenance, and this path does not tally
-        // orphans; both are reported as unknown rather than as zero.
-        num_orphan: None,
+        // Tallied while streaming the BAM, so `-a` reports the same
+        // concordant/orphan split the reads path does.
+        num_orphan: Some(num_orphan),
         provenance: crate::rad::RadProvenance::default(),
         // Straight from the BAM being quantified, no RAD in between.
         source_programs: source_program_lines(&header),

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -1442,14 +1442,16 @@ pub struct SourceProgram {
 /// Render a BAM header's `@PG` chain as verbatim SAM lines.
 ///
 /// Kept as text on the way into a RAD so nothing the aligner recorded is dropped
-/// in transit; [`parse_source_programs`] reads them back.
+/// in transit; [`parse_source_programs`] reads them back. Empty when the header
+/// has no `@PG` records at all, which is common enough — plenty of tools write
+/// none — that callers must treat it as ordinary rather than exceptional.
 pub fn source_program_lines(header: &noodles_sam::Header) -> Vec<String> {
     header
         .programs()
         .as_ref()
         .iter()
         .map(|(id, program)| {
-            let mut line = format!("@PG\tID:{}", String::from_utf8_lossy(id.as_ref()));
+            let mut line = format!("@PG\tID:{}", sanitize_header_value(id.as_ref()));
             // Every tag the aligner wrote is carried through, standard or not:
             // this is provenance, not a schema to validate against.
             for (tag, value) in program.other_fields() {
@@ -1457,12 +1459,22 @@ pub fn source_program_lines(header: &noodles_sam::Header) -> Vec<String> {
                 line.push_str(&format!(
                     "\t{}:{}",
                     String::from_utf8_lossy(t),
-                    String::from_utf8_lossy(value.as_ref())
+                    sanitize_header_value(value.as_ref())
                 ));
             }
             line
         })
         .collect()
+}
+
+/// Flatten the separators a SAM header value must not contain.
+///
+/// The spec forbids tabs and newlines here, but a malformed file can carry them,
+/// and they are exactly the two characters this round trip is framed by: a tab
+/// would invent a field and a newline would split one record into two. Replacing
+/// them keeps a bad header from silently corrupting the neighbouring provenance.
+fn sanitize_header_value(value: &[u8]) -> String {
+    String::from_utf8_lossy(value).replace(['\t', '\n', '\r'], " ")
 }
 
 /// Parse `@PG` lines produced by [`source_program_lines`] back into records.
@@ -2196,12 +2208,30 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
     let alignment_provenance = crate::parse_source_programs(&res.source_programs);
     let from_alignments = res.source == FragmentSource::Bam
         || res.provenance.mapping_type == Some(salmon_rad::MappingType::Alignment);
-    if from_alignments && alignment_provenance.is_empty() {
-        incomplete_meta_info_fields.push(salmon_core::MissingMetaField::bam(
-            "alignment_provenance",
-            "the source BAM's header carries no @PG records, so how its \
-             alignments were produced is not recorded anywhere in the file",
-        ));
+    if from_alignments {
+        // `@PG` is optional in SAM and plenty of tools omit it, so its absence is
+        // an ordinary outcome — but it is still the record of how the alignments
+        // came about, and a reader deserves to be told it was unavailable rather
+        // than left to wonder whether salmon simply did not look.
+        if alignment_provenance.is_empty() {
+            incomplete_meta_info_fields.push(salmon_core::MissingMetaField::bam(
+                "alignment_provenance",
+                "the source BAM's header carries no @PG records, so how its \
+                 alignments were produced is not recorded anywhere in the file",
+            ));
+        } else if alignment_provenance
+            .iter()
+            .all(|p| p.command_line.is_none())
+        {
+            // The chain identifies the programs but not how they were invoked,
+            // which is the part that actually reproduces the alignments.
+            incomplete_meta_info_fields.push(salmon_core::MissingMetaField::bam(
+                "alignment_provenance[].command_line",
+                "the source BAM's @PG records name the programs but none carries \
+                 a CL field, so the commands that produced the alignments are not \
+                 recorded in the file",
+            ));
+        }
     }
     let meta = MetaInfo {
         salmon_version: SALMON_VERSION.to_string(),

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -1229,9 +1229,16 @@ fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> Fr
     let mut sp_online: Vec<f64> = Vec::with_capacity(placements.len());
     let mut sp_geom: Vec<(usize, usize, bool)> = Vec::with_capacity(placements.len());
     let mut sp_pl: Vec<usize> = Vec::with_capacity(placements.len());
-    // Whether any surviving placement paired both mates; folded into the loop
-    // below, which already computes `proper` for its own use.
-    let mut any_proper = false;
+    // Orphan bookkeeping, folded into the loop below so it costs two register
+    // ORs per surviving placement and no second pass.
+    //
+    // Deliberately *not* keyed on `proper`, which is `idxs.len() >= 2 && flen > 0`
+    // and so would call a both-mates placement with no reported fragment length an
+    // orphan. This mirrors `frag_format`, the canonical status derivation, which
+    // looks only at how many mates were placed and at the `0x1` multi-segment flag
+    // — the same signal #1057 turned on.
+    let mut any_both_mates = false;
+    let mut any_orphan = false;
     for (pi, pl) in placements.iter().enumerate() {
         let tid = pl.tid;
         let idxs = &pl.idxs;
@@ -1289,7 +1296,13 @@ fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> Fr
                 aux += ctx.incompat_prior.ln();
             }
         }
-        any_proper |= proper;
+        if idxs.len() >= 2 {
+            any_both_mates = true;
+        } else {
+            // A lone record is an orphan only if it belongs to a multi-segment
+            // template; a genuine single-end read has no mate to be missing.
+            any_orphan |= recs[idxs[0]].is_paired;
+        }
         sp_tid.push(tid);
         sp_eq.push(aux);
         sp_online.push(aux + start_pos);
@@ -1301,8 +1314,11 @@ fn process_fragment(recs: &[FragRecord], ctx: &FragCtx, local: &mut Local) -> Fr
     if sp_tid.is_empty() {
         return FragmentOutcome::Unmapped;
     }
-    // Single-end libraries have no mate to be missing, so they are never orphans.
-    let outcome = if ctx.paired_lib && !any_proper {
+    // The fragment counts as an orphan only when nothing paired both mates, so a
+    // fragment that is a proper pair on one transcript and an orphan on another
+    // counts as a pair — the same "most complete status wins" rule the RAD
+    // fragment-level type uses.
+    let outcome = if any_orphan && !any_both_mates {
         FragmentOutcome::MappedOrphan
     } else {
         FragmentOutcome::Mapped

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -280,6 +280,16 @@ pub struct AlignQuantResult {
     pub counts: Vec<f64>,
     pub num_processed: u64,
     pub num_mapped: u64,
+    /// mapped fragments placed as orphans (only one mate mapped).
+    ///
+    /// `Some` whenever the records were tallied, which is any RAD input —
+    /// orphan status is in the records themselves, so this works for a piscem
+    /// RAD too, independently of whether the file carries salmon's provenance.
+    /// `None` for a BAM input, which this path does not tally.
+    pub num_orphan: Option<u64>,
+    /// what the RAD says about the mapping pass that produced it; empty for a
+    /// BAM input, which has no RAD provenance to read
+    pub provenance: crate::rad::RadProvenance,
     /// fragment mass dropped in the final min-alpha redistribution (every member
     /// of an equivalence class truncated); normally 0.
     pub inference_truncated_mass: f64,
@@ -1926,6 +1936,10 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
     timer.mark("posterior");
 
     let result = AlignQuantResult {
+        // A BAM input carries no RAD provenance, and this path does not tally
+        // orphans; both are reported as unknown rather than as zero.
+        num_orphan: None,
+        provenance: crate::rad::RadProvenance::default(),
         names,
         lengths,
         eff_lengths,
@@ -1997,7 +2011,12 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         pos_bias_correct: bool,
         num_bias_bins: usize,
         mapping_type: String,
-        // index hashes are empty in alignment mode (no salmon index)
+        /// how the index was built; known only from a salmon RAD's provenance,
+        /// omitted (rather than guessed) for a BAM input
+        #[serde(skip_serializing_if = "Option::is_none")]
+        keep_duplicates: Option<bool>,
+        // empty in alignment mode (no salmon index); recovered from the RAD's
+        // provenance when quantifying one salmon wrote
         index_seq_hash: String,
         index_name_hash: String,
         index_seq_hash512: String,
@@ -2019,7 +2038,20 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         num_decoy_fragments: u64,
         inference_truncated_mass: f64,
         num_bootstraps: u32,
+        /// mapped fragments placed as orphans; counted from RAD records, so
+        /// omitted for a BAM input where this path does not tally them
+        #[serde(skip_serializing_if = "Option::is_none")]
+        num_orphan: Option<u64>,
         range_factorization_bins: u32,
+        /// whether every field above is a true observation of the run.
+        ///
+        /// `false` means the RAD quantified from did not record what its mapping
+        /// pass observed, so the fields named in `incomplete_meta_info_fields`
+        /// are placeholders — most visibly `percent_mapped`, which then reads
+        /// 100% because a RAD holds only the fragments that mapped.
+        meta_info_complete: bool,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        incomplete_meta_info_fields: Vec<&'static str>,
         num_em_iterations: u32,
         em_converged: bool,
         detected_library_type: Option<String>,
@@ -2040,13 +2072,25 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
     } else {
         vec!["gzipped".to_string()]
     };
+    // A salmon-written RAD records what its mapping pass saw; anything else
+    // leaves these unknown, which the reader has already warned about and which
+    // `meta_info_complete` records for whoever reads the results later.
+    let counters = res.provenance.counters;
+    let index_prov = res.provenance.index.clone().unwrap_or_default();
+    let incomplete_meta_info_fields = res.provenance.missing_meta_info_fields();
     let meta = MetaInfo {
         salmon_version: SALMON_VERSION.to_string(),
         samp_type: "none".to_string(),
         opt_type: if opts.em.use_vbem { "vb" } else { "em" }.to_string(),
         quant_errors: vec![],
         num_libraries: 1,
-        library_types: vec![opts.lib_type.clone()],
+        // The format actually applied, not the `-l A` that requested detection:
+        // reads mode reports the resolved one, and a RAD carries it baked, so a
+        // requant can report it too.
+        library_types: vec![res
+            .detected_library_type
+            .clone()
+            .unwrap_or_else(|| opts.lib_type.clone())],
         frag_dist_length: res.frag_len_dist.len(),
         frag_length_mean: res.frag_len_mean,
         frag_length_sd: res.frag_len_sd,
@@ -2055,13 +2099,21 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         gc_bias_correct: opts.gc_bias,
         pos_bias_correct: opts.pos_bias,
         num_bias_bins: 0,
-        mapping_type: "alignment".to_string(),
-        index_seq_hash: String::new(),
-        index_name_hash: String::new(),
-        index_seq_hash512: String::new(),
-        index_name_hash512: String::new(),
-        index_decoy_seq_hash: String::new(),
-        index_decoy_name_hash: String::new(),
+        // What the RAD says its producer was; a BAM input has no RAD to ask, and
+        // an older or foreign RAD does not record it, so both fall back to the
+        // value this path has always reported.
+        mapping_type: res
+            .provenance
+            .mapping_type
+            .map_or("alignment", |m| m.as_str())
+            .to_string(),
+        keep_duplicates: res.provenance.index.as_ref().map(|p| p.keep_duplicates),
+        index_seq_hash: index_prov.seq_hash,
+        index_name_hash: index_prov.name_hash,
+        index_seq_hash512: index_prov.seq_hash512,
+        index_name_hash512: index_prov.name_hash512,
+        index_decoy_seq_hash: index_prov.decoy_seq_hash,
+        index_decoy_name_hash: index_prov.decoy_name_hash,
         num_valid_targets: res.names.len(),
         num_decoy_targets: 0,
         num_eq_classes: res.num_eq_classes,
@@ -2070,13 +2122,17 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         length_classes: res.length_classes.clone(),
         num_processed: res.num_processed,
         num_mapped: res.num_mapped,
-        num_dovetail_fragments: 0,
-        num_fragments_filtered_vm: 0,
-        num_alignments_below_threshold_for_mapped_fragments_vm: 0,
+        num_dovetail_fragments: counters.map_or(0, |c| c.num_dovetail),
+        num_fragments_filtered_vm: counters.map_or(0, |c| c.num_filtered_vm),
+        num_alignments_below_threshold_for_mapped_fragments_vm: counters
+            .map_or(0, |c| c.num_below_threshold_vm),
         percent_mapped: pct,
         num_decoy_fragments: 0,
         inference_truncated_mass: res.inference_truncated_mass,
         num_bootstraps: res.bootstraps.len() as u32,
+        num_orphan: res.num_orphan,
+        meta_info_complete: incomplete_meta_info_fields.is_empty(),
+        incomplete_meta_info_fields,
         range_factorization_bins: opts.range_factorization_bins,
         num_em_iterations: res.em_iters,
         em_converged: res.em_converged,
@@ -2092,6 +2148,42 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         dir.join("aux_info").join("meta_info.json"),
         serde_json::to_string_pretty(&meta)?,
     )?;
+
+    // lib_format_counts.json — reads mode writes one, so a RAD requant should
+    // too, or a pipeline that reads it breaks on the requant of its own output.
+    // The concordant/orphan split comes from the records' fragment types, which
+    // is why it is available here at all.
+    if let Some(num_orphan) = res.num_orphan {
+        #[derive(Serialize)]
+        struct LibCounts {
+            read_files: Vec<String>,
+            expected_format: String,
+            compatible_fragment_ratio: f64,
+            num_compatible_fragments: u64,
+            num_assigned_fragments: u64,
+            num_frags_with_concordant_consistent_mappings: u64,
+            num_frags_with_inconsistent_or_orphan_mappings: u64,
+            strand_mapping_bias: f64,
+        }
+        let counts = LibCounts {
+            // The RAD is the input; the reads that produced it are not known here.
+            read_files: vec![],
+            expected_format: res
+                .detected_library_type
+                .clone()
+                .unwrap_or_else(|| opts.lib_type.clone()),
+            compatible_fragment_ratio: 1.0,
+            num_compatible_fragments: res.num_mapped,
+            num_assigned_fragments: res.num_mapped,
+            num_frags_with_concordant_consistent_mappings: res.num_mapped - num_orphan,
+            num_frags_with_inconsistent_or_orphan_mappings: num_orphan,
+            strand_mapping_bias: 0.0,
+        };
+        std::fs::write(
+            dir.join("lib_format_counts.json"),
+            serde_json::to_string_pretty(&counts)?,
+        )?;
+    }
 
     // aux_info/bootstrap/{names.tsv.gz, bootstraps.gz}: posterior samples in the
     // same layout reads mode uses (gzipped tab-separated names; gzipped raw

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -441,34 +441,66 @@ pub struct RadProvenance {
     pub index: Option<salmon_rad::IndexProvenance>,
     /// how the fragments were produced; `None` for a RAD that does not say
     pub mapping_type: Option<salmon_rad::MappingType>,
+    /// verbatim `@PG` lines from the BAM behind these fragments, when there was
+    /// one; empty for a RAD produced by mapping reads
+    pub source_programs: Vec<String>,
 }
 
 impl RadProvenance {
     /// The `meta_info.json` fields this file cannot support, in output order.
     ///
     /// Empty ⇒ the requant reproduces the mapping run's `meta_info.json`.
-    pub fn missing_meta_info_fields(&self) -> Vec<&'static str> {
+    pub fn missing_meta_info_fields(&self) -> Vec<salmon_core::MissingMetaField> {
+        use salmon_core::MissingMetaField as M;
         let mut missing = Vec::new();
         if self.counters.is_none() {
-            missing.extend([
-                "num_processed",
-                "percent_mapped",
-                "num_dovetail_fragments",
-                "num_fragments_filtered_vm",
-                "num_alignments_below_threshold_for_mapped_fragments_vm",
-                "num_decoy_fragments",
-            ]);
+            const REASON: &str = "the RAD does not record what its mapping pass \
+                                  observed; only fragments that mapped are in the file, \
+                                  so this cannot be recovered from it. RADs written by \
+                                  salmon 2.5.0 and later carry it.";
+            missing.extend(
+                [
+                    "num_processed",
+                    "percent_mapped",
+                    "num_dovetail_fragments",
+                    "num_fragments_filtered_vm",
+                    "num_alignments_below_threshold_for_mapped_fragments_vm",
+                    "num_decoy_fragments",
+                ]
+                .map(|f| M::rad(f, REASON)),
+            );
         }
-        if self.index.is_none() {
-            missing.extend([
+        // Alignment-derived fragments never had a salmon index behind them, so
+        // index identity is not applicable rather than missing — reporting it as
+        // a gap would tell a user to fix something that cannot exist.
+        let index_applicable = self.mapping_type != Some(salmon_rad::MappingType::Alignment);
+        match &self.index {
+            None if !index_applicable => {}
+            None => {
+                const REASON: &str = "the RAD does not identify the index its mappings \
+                                      were made against, and the `--rad` path loads no \
+                                      index of its own";
+                missing.extend(
+                    [
+                        "keep_duplicates",
+                        "index_seq_hash",
+                        "index_name_hash",
+                        "index_seq_hash512",
+                        "index_name_hash512",
+                        "index_decoy_seq_hash",
+                        "index_decoy_name_hash",
+                    ]
+                    .map(|f| M::rad(f, REASON)),
+                );
+            }
+            // The index was identified but predates recording how it was built,
+            // so this one field is unknown while the hashes are exact.
+            Some(p) if p.keep_duplicates.is_none() => missing.push(M::index(
                 "keep_duplicates",
-                "index_seq_hash",
-                "index_name_hash",
-                "index_seq_hash512",
-                "index_name_hash512",
-                "index_decoy_seq_hash",
-                "index_decoy_name_hash",
-            ]);
+                "the index that produced this RAD predates recording it; \
+                 rebuild the index to record it",
+            )),
+            Some(_) => {}
         }
         missing
     }
@@ -520,14 +552,14 @@ fn warn_incomplete_provenance(provenance: &RadProvenance) {
     if missing.is_empty() {
         return;
     }
+    let fields: Vec<&str> = missing.iter().map(|m| m.field).collect();
     tracing::warn!(
-        "this RAD does not record what the mapping pass observed, so these \
-         meta_info.json fields cannot be reproduced and are reported as \
-         placeholders: {}. In particular the mapping rate will read 100%, since \
-         a RAD holds only the fragments that mapped. RAD files written by salmon \
-         2.5.0 and later carry this information; `meta_info_complete` in \
-         meta_info.json records that this run's did not.",
-        missing.join(", ")
+        "this RAD cannot supply every meta_info.json field, so these are reported \
+         as placeholders: {}. Where the mapping-pass counters are missing the \
+         mapping rate reads 100%, since a RAD holds only the fragments that \
+         mapped. `meta_info_complete` in meta_info.json records this, with the \
+         reason for each field.",
+        fields.join(", ")
     );
 }
 
@@ -566,11 +598,19 @@ fn load_provenance(file_tag_map: &TagMap) -> RadProvenance {
         name_hash512: string_tag(salmon_rad::INDEX_NAME_HASH512_TAG),
         decoy_seq_hash: string_tag(salmon_rad::INDEX_DECOY_SEQ_HASH_TAG),
         decoy_name_hash: string_tag(salmon_rad::INDEX_DECOY_NAME_HASH_TAG),
-        keep_duplicates: matches!(
-            file_tag_map.get(salmon_rad::KEEP_DUPLICATES_TAG),
-            Some(TagValue::U8(1))
-        ),
+        // Absent ⇒ the writing index never recorded it; that is unknown, not
+        // `false`, and is reported as a missing field rather than guessed.
+        keep_duplicates: match file_tag_map.get(salmon_rad::KEEP_DUPLICATES_TAG) {
+            Some(TagValue::U8(v)) => Some(*v == 1),
+            _ => None,
+        },
     });
+    // Split back into the lines they were joined from; an aligner's command line
+    // may contain anything except a newline, so this round-trips.
+    let source_programs = match file_tag_map.get(salmon_rad::SOURCE_PROGRAMS_TAG) {
+        Some(TagValue::String(v)) if !v.is_empty() => v.split('\n').map(str::to_string).collect(),
+        _ => Vec::new(),
+    };
     let mapping_type = match file_tag_map.get(salmon_rad::MAPPING_TYPE_TAG) {
         Some(TagValue::String(v)) => salmon_rad::MappingType::from_str_tag(v),
         _ => None,
@@ -579,6 +619,7 @@ fn load_provenance(file_tag_map: &TagMap) -> RadProvenance {
         counters,
         index,
         mapping_type,
+        source_programs,
     }
 }
 
@@ -1750,6 +1791,8 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         num_processed,
         num_mapped,
         num_orphan: Some(num_orphan),
+        source_programs: provenance.source_programs.clone(),
+        source: crate::FragmentSource::Rad,
         provenance,
         inference_truncated_mass,
         num_eq_classes,

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -428,6 +428,160 @@ fn warn_baked_fld_overrides(
     );
 }
 
+/// What a RAD file says about the mapping pass that produced it.
+///
+/// Every field is `None` when the file does not carry it. That distinction is
+/// the point: a missing count is not a zero, and reporting it as one is how a
+/// requant ends up claiming a 100% mapping rate.
+#[derive(Clone, Debug, Default)]
+pub struct RadProvenance {
+    /// counters describing what the mapping pass saw
+    pub counters: Option<salmon_rad::MapCounters>,
+    /// identity of the index the mappings were made against
+    pub index: Option<salmon_rad::IndexProvenance>,
+    /// how the fragments were produced; `None` for a RAD that does not say
+    pub mapping_type: Option<salmon_rad::MappingType>,
+}
+
+impl RadProvenance {
+    /// The `meta_info.json` fields this file cannot support, in output order.
+    ///
+    /// Empty ⇒ the requant reproduces the mapping run's `meta_info.json`.
+    pub fn missing_meta_info_fields(&self) -> Vec<&'static str> {
+        let mut missing = Vec::new();
+        if self.counters.is_none() {
+            missing.extend([
+                "num_processed",
+                "percent_mapped",
+                "num_dovetail_fragments",
+                "num_fragments_filtered_vm",
+                "num_alignments_below_threshold_for_mapped_fragments_vm",
+                "num_decoy_fragments",
+            ]);
+        }
+        if self.index.is_none() {
+            missing.extend([
+                "keep_duplicates",
+                "index_seq_hash",
+                "index_name_hash",
+                "index_seq_hash512",
+                "index_name_hash512",
+                "index_decoy_seq_hash",
+                "index_decoy_name_hash",
+            ]);
+        }
+        missing
+    }
+}
+
+/// Fragment tallies accumulated while *reading* a RAD.
+///
+/// Deliberately not named after the `meta_info.json` fields they feed: `records`
+/// is how many records the file holds, which equals the mapping pass's
+/// `num_processed` only if every fragment mapped. Conflating the two is what made
+/// a requant report a 100% mapping rate; the real count comes from
+/// [`RadProvenance`].
+#[derive(Default)]
+struct RadTallies {
+    /// records present in the file
+    records: AtomicU64,
+    /// records with at least one library-compatible placement
+    mapped: AtomicU64,
+    /// mapped records placed as orphans (only one mate mapped)
+    orphans: AtomicU64,
+}
+
+impl RadTallies {
+    fn tally(&self, assigned: bool, placements: &[RadPlacement]) {
+        self.records.fetch_add(1, Ordering::Relaxed);
+        if !assigned {
+            return;
+        }
+        self.mapped.fetch_add(1, Ordering::Relaxed);
+        // A fragment's surviving mappings share one status, so the first is
+        // representative — the same definition the mapping pass counts by.
+        if matches!(
+            placements.first().map(|p| p.status),
+            Some(MateStatus::PairedEndLeft | MateStatus::PairedEndRight)
+        ) {
+            self.orphans.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Warn, once, that the RAD cannot support every `meta_info.json` field.
+///
+/// A warning rather than an error: the file is perfectly quantifiable, and
+/// refusing to use a piscem RAD over reporting metadata would be a poor trade.
+/// The same information is recorded in `meta_info.json` itself, so a result read
+/// long after the run still says which of its fields are unreliable.
+fn warn_incomplete_provenance(provenance: &RadProvenance) {
+    let missing = provenance.missing_meta_info_fields();
+    if missing.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        "this RAD does not record what the mapping pass observed, so these \
+         meta_info.json fields cannot be reproduced and are reported as \
+         placeholders: {}. In particular the mapping rate will read 100%, since \
+         a RAD holds only the fragments that mapped. RAD files written by salmon \
+         2.5.0 and later carry this information; `meta_info_complete` in \
+         meta_info.json records that this run's did not.",
+        missing.join(", ")
+    );
+}
+
+/// Read the mapping-pass provenance a salmon writer baked into the header.
+///
+/// Absent for a RAD salmon did not write, and for one written before provenance
+/// existed; the caller warns and proceeds rather than failing, since the file is
+/// still perfectly quantifiable — only its `meta_info.json` is diminished.
+fn load_provenance(file_tag_map: &TagMap) -> RadProvenance {
+    use libradicl::rad_types::TagValue;
+    let flags = match file_tag_map.get(salmon_rad::BAKED_FLAGS_TAG) {
+        Some(TagValue::U8(f)) => *f,
+        _ => 0,
+    };
+    let u64_tag = |name: &str| match file_tag_map.get(name) {
+        Some(TagValue::U64(v)) => *v,
+        _ => 0,
+    };
+    // The counter slots are reserved as zeros, so only the flag distinguishes
+    // "observed none" from "never filled in".
+    let counters = (flags & salmon_rad::BAKED_MAP_COUNTERS != 0).then(|| salmon_rad::MapCounters {
+        num_processed: u64_tag(salmon_rad::NUM_PROCESSED_TAG),
+        num_dovetail: u64_tag(salmon_rad::NUM_DOVETAIL_TAG),
+        num_filtered_vm: u64_tag(salmon_rad::NUM_FILTERED_VM_TAG),
+        num_below_threshold_vm: u64_tag(salmon_rad::NUM_BELOW_THRESH_VM_TAG),
+        num_decoy_fragments: u64_tag(salmon_rad::NUM_DECOY_FRAGMENTS_TAG),
+    });
+    let string_tag = |name: &str| match file_tag_map.get(name) {
+        Some(TagValue::String(v)) => v.clone(),
+        _ => String::new(),
+    };
+    let index = (flags & salmon_rad::BAKED_INDEX_PROV != 0).then(|| salmon_rad::IndexProvenance {
+        seq_hash: string_tag(salmon_rad::INDEX_SEQ_HASH_TAG),
+        name_hash: string_tag(salmon_rad::INDEX_NAME_HASH_TAG),
+        seq_hash512: string_tag(salmon_rad::INDEX_SEQ_HASH512_TAG),
+        name_hash512: string_tag(salmon_rad::INDEX_NAME_HASH512_TAG),
+        decoy_seq_hash: string_tag(salmon_rad::INDEX_DECOY_SEQ_HASH_TAG),
+        decoy_name_hash: string_tag(salmon_rad::INDEX_DECOY_NAME_HASH_TAG),
+        keep_duplicates: matches!(
+            file_tag_map.get(salmon_rad::KEEP_DUPLICATES_TAG),
+            Some(TagValue::U8(1))
+        ),
+    });
+    let mapping_type = match file_tag_map.get(salmon_rad::MAPPING_TYPE_TAG) {
+        Some(TagValue::String(v)) => salmon_rad::MappingType::from_str_tag(v),
+        _ => None,
+    };
+    RadProvenance {
+        counters,
+        index,
+        mapping_type,
+    }
+}
+
 /// Load a fragment-length distribution baked into the RAD header by salmon's
 /// writer, if present (the `baked_flags` byte has the FLD bit set and a non-empty
 /// `frag_length_dist` log-PMF tag exists).
@@ -520,13 +674,7 @@ fn load_baked_score_kind(file_tag_map: &TagMap) -> u8 {
 /// Run the parallel RAD pass: `ParallelRadReader` feeds MetaChunks to a worker
 /// pool that weights each fragment into the shared equivalence-class builder.
 #[allow(clippy::too_many_arguments)]
-fn run_rad_pass<R>(
-    path: &Path,
-    nthreads: usize,
-    cfg: &FragCfg,
-    num_processed: &AtomicU64,
-    num_mapped: &AtomicU64,
-) -> Result<()>
+fn run_rad_pass<R>(path: &Path, nthreads: usize, cfg: &FragCfg, tallies: &RadTallies) -> Result<()>
 where
     R: MappedRecord + RadFragment + Send,
     R::ParsingContext: RecordContext + Clone + Send + Sync,
@@ -543,11 +691,9 @@ where
                 for mc in chunks {
                     for chunk in mc.iter() {
                         for rec in &chunk.reads {
-                            let assigned = process_rad_fragment(&rec.placements(), cfg);
-                            num_processed.fetch_add(1, Ordering::Relaxed);
-                            if assigned {
-                                num_mapped.fetch_add(1, Ordering::Relaxed);
-                            }
+                            let pls = rec.placements();
+                            let assigned = process_rad_fragment(&pls, cfg);
+                            tallies.tally(assigned, &pls);
                         }
                     }
                 }
@@ -976,8 +1122,7 @@ fn run_rad_eq_and_bias_pass<R>(
     pos: bool,
     cond_gc_bins: usize,
     gc_bins: usize,
-    num_processed: &AtomicU64,
-    num_mapped: &AtomicU64,
+    tallies: &RadTallies,
 ) -> Result<(
     Option<(SBModel, SBModel)>,
     Option<GcFragModel>,
@@ -1004,10 +1149,7 @@ where
                         for rec in &chunk.reads {
                             let pls = rec.placements();
                             let assigned = process_rad_fragment(&pls, cfg);
-                            num_processed.fetch_add(1, Ordering::Relaxed);
-                            if assigned {
-                                num_mapped.fetch_add(1, Ordering::Relaxed);
-                            }
+                            tallies.tally(assigned, &pls);
                             collect_bias_fragment(&pls, bias_cfg, &mut local);
                         }
                     }
@@ -1048,6 +1190,11 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     // Header: profile, reference names + lengths (from the RAD file tags).
     let (_reader, prelude, file_tag_map) = open_prelude(rad_path)?;
     let profile = salmon_rad::detect_input_profile(&prelude)?;
+    // What the mapping pass recorded about itself. Absent for a RAD salmon did
+    // not write; the run proceeds either way, but its `meta_info.json` then says
+    // which fields it could not honour.
+    let provenance = load_provenance(&file_tag_map);
+    warn_incomplete_provenance(&provenance);
     let names: Vec<String> = prelude.hdr.ref_names.clone();
     let lengths = ref_lengths_from_tags(&prelude, &file_tag_map)?;
     let num_refs = names.len();
@@ -1268,8 +1415,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     });
 
     let eq_builder = EquivalenceClassBuilder::new();
-    let num_processed = AtomicU64::new(0);
-    let num_mapped = AtomicU64::new(0);
+    let tallies = RadTallies::default();
 
     // When the abundances that weight bias collection are known up FRONT (baked by
     // the write run / `--deterministic`), eq-building and bias collection can share
@@ -1327,8 +1473,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                     opts.pos_bias,
                     opts.cond_gc_bins,
                     opts.gc_bins,
-                    &num_processed,
-                    &num_mapped,
+                    &tallies,
                 )?,
                 RadInputProfile::Salmon(_) => run_rad_eq_and_bias_pass::<SalmonBulkRecord>(
                     rad_path,
@@ -1340,33 +1485,29 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                     opts.pos_bias,
                     opts.cond_gc_bins,
                     opts.gc_bins,
-                    &num_processed,
-                    &num_mapped,
+                    &tallies,
                 )?,
             };
             Some(obs)
         } else {
             match profile {
-                RadInputProfile::PiscemBulk => run_rad_pass::<PiscemBulkReadRecord>(
-                    rad_path,
-                    nthreads,
-                    &cfg,
-                    &num_processed,
-                    &num_mapped,
-                )?,
-                RadInputProfile::Salmon(_) => run_rad_pass::<SalmonBulkRecord>(
-                    rad_path,
-                    nthreads,
-                    &cfg,
-                    &num_processed,
-                    &num_mapped,
-                )?,
+                RadInputProfile::PiscemBulk => {
+                    run_rad_pass::<PiscemBulkReadRecord>(rad_path, nthreads, &cfg, &tallies)?
+                }
+                RadInputProfile::Salmon(_) => {
+                    run_rad_pass::<SalmonBulkRecord>(rad_path, nthreads, &cfg, &tallies)?
+                }
             }
             None
         }
     };
-    let num_processed = num_processed.into_inner();
-    let num_mapped = num_mapped.into_inner();
+    let num_records = tallies.records.into_inner();
+    let num_mapped = tallies.mapped.into_inner();
+    let num_orphan = tallies.orphans.into_inner();
+    // How many fragments the *mapper* saw, which only the header can say; falling
+    // back to the record count is what yields a 100% rate, so it is reported as
+    // such (see `warn_incomplete_provenance`).
+    let num_processed = provenance.counters.map_or(num_records, |c| c.num_processed);
     tracing::info!("mapped {num_mapped} / {num_processed} fragments from RAD");
 
     // ---- inference ---------------------------------------------------------
@@ -1608,6 +1749,8 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         counts,
         num_processed,
         num_mapped,
+        num_orphan: Some(num_orphan),
+        provenance,
         inference_truncated_mass,
         num_eq_classes,
         frag_len_mean: fld.mean(),

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -1033,7 +1033,7 @@ fn separators_in_header_values_survive_escaping() {
     // A value carrying the framing characters, and a literal backslash-n that
     // must not be confused with an escaped newline.
     let escaped = "@PG\tID:a\tCL:one\\ttwo\\nthree\\\\nfour\tVN:1".to_string();
-    let progs = salmon_align::parse_source_programs(&[escaped.clone()]);
+    let progs = salmon_align::parse_source_programs(std::slice::from_ref(&escaped));
     assert_eq!(progs.len(), 1, "escapes must not split the record");
     assert_eq!(
         progs[0].command_line.as_deref(),

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -1019,23 +1019,67 @@ fn pg_record_without_command_line_is_still_reported() {
 }
 
 /// A tab or newline inside a header value would invent a field or split a
-/// record. The SAM spec forbids both, but a malformed file can carry them, and
-/// they must not corrupt the neighbouring provenance.
+/// record. RAD itself would carry either happily — it length-prefixes strings —
+/// so the constraint comes from this newline-joined, tab-separated
+/// representation, and escaping keeps it reversible rather than rewriting the
+/// value.
 #[test]
-fn separators_in_header_values_do_not_corrupt_the_chain() {
-    // Built directly, since a conforming parser would not produce this.
-    let lines = vec![
-        "@PG\tID:a\tCL:cmd one\tVN:1".to_string(),
-        "@PG\tID:b\tCL:cmd two".to_string(),
-    ];
-    let progs = salmon_align::parse_source_programs(&lines);
-    assert_eq!(progs.len(), 2);
-    assert_eq!(progs[0].command_line.as_deref(), Some("cmd one"));
-    assert_eq!(progs[1].id, "b");
+fn separators_in_header_values_survive_escaping() {
+    // Built through the real parser, so the escaping is whatever the writer does.
+    let sam = "@HD\tVN:1.6\n@SQ\tSN:t0\tLN:100\n@PG\tID:a\tCL:x\n";
+    let header: noodles_sam::Header = sam.parse().unwrap();
+    assert_eq!(salmon_align::source_program_lines(&header).len(), 1);
 
-    // The join/split round trip the RAD uses must preserve record boundaries.
+    // A value carrying the framing characters, and a literal backslash-n that
+    // must not be confused with an escaped newline.
+    let escaped = "@PG\tID:a\tCL:one\\ttwo\\nthree\\\\nfour\tVN:1".to_string();
+    let progs = salmon_align::parse_source_programs(&[escaped.clone()]);
+    assert_eq!(progs.len(), 1, "escapes must not split the record");
+    assert_eq!(
+        progs[0].command_line.as_deref(),
+        Some("one\ttwo\nthree\\nfour"),
+        "escapes must decode back to the original bytes"
+    );
+    assert_eq!(
+        progs[0].version.as_deref(),
+        Some("1"),
+        "later fields survive"
+    );
+
+    // The joined form the RAD stores must still split into whole records.
+    let lines = vec![escaped, "@PG\tID:b\tCL:plain".to_string()];
     let joined = lines.join("\n");
     let split: Vec<String> = joined.split('\n').map(str::to_string).collect();
-    assert_eq!(split, lines);
+    assert_eq!(split, lines, "an escaped newline must not create a record");
     assert_eq!(salmon_align::parse_source_programs(&split).len(), 2);
+}
+
+/// A RAD string tag is length-prefixed with a `u16` and the length is *cast*, so
+/// an over-long chain would wrap and corrupt the file rather than fail. The
+/// writer must fit the chain instead of handing one over.
+#[test]
+fn overlong_pg_chain_is_trimmed_to_what_a_rad_tag_holds() {
+    let long_cl = "x".repeat(20_000);
+    let mut sam = String::from("@HD\tVN:1.6\n@SQ\tSN:t0\tLN:100\n");
+    for i in 0..8 {
+        sam.push_str(&format!("@PG\tID:p{i}\tCL:{long_cl}\n"));
+    }
+    let header: noodles_sam::Header = sam.parse().unwrap();
+    let lines = salmon_align::source_program_lines(&header);
+
+    let joined_len = lines.iter().map(String::len).sum::<usize>() + lines.len().saturating_sub(1);
+    assert!(
+        joined_len <= salmon_rad::MAX_FILE_TAG_STRING_LEN,
+        "the joined chain ({joined_len} bytes) must fit a u16 length"
+    );
+    assert!(
+        !lines.is_empty() && lines.len() < 8,
+        "records should be dropped, not all of them and not none: got {}",
+        lines.len()
+    );
+    // What survives is whole records, still parseable.
+    assert_eq!(
+        salmon_align::parse_source_programs(&lines).len(),
+        lines.len()
+    );
 }

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -34,6 +34,14 @@ fn write_rad(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Provenance for RADs these tests write, standing in for a mapping pass.
+fn prov() -> salmon_rad::WriterProvenance {
+    salmon_rad::WriterProvenance {
+        mapping_type: salmon_rad::MappingType::Mapping,
+        index: None,
+    }
+}
+
 fn write_rad_codec(
     path: &Path,
     ref_names: &[&str],
@@ -43,8 +51,17 @@ fn write_rad_codec(
     baked_log_pmf: Option<&[f64]>,
     codec: salmon_rad::ChunkCodec,
 ) {
-    let mut w =
-        RadOutputWriter::create(path, ref_names, ref_lengths, true, profile, 1024, codec).unwrap();
+    let mut w = RadOutputWriter::create(
+        path,
+        ref_names,
+        ref_lengths,
+        true,
+        profile,
+        1024,
+        codec,
+        &prov(),
+    )
+    .unwrap();
     if let Some(pmf) = baked_log_pmf {
         w.set_frag_length_dist(pmf);
     }
@@ -649,6 +666,7 @@ fn auto_orientation_derives_fld_from_majority_bucket() {
         RadProfile::Sketch,
         1024,
         salmon_rad::ChunkCodec::None,
+        &prov(),
     )
     .unwrap();
     let ctx: SalmonBulkContext = *w.context();
@@ -725,6 +743,7 @@ fn baked_library_format_is_authoritative_under_auto() {
         RadProfile::Sketch,
         1024,
         salmon_rad::ChunkCodec::None,
+        &prov(),
     )
     .unwrap();
     let ctx: SalmonBulkContext = *w.context();

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -982,3 +982,60 @@ fn source_program_lines_parse_back() {
     assert_eq!(progs.len(), 1);
     assert_eq!(progs[0].id, "x");
 }
+
+/// `@PG` is optional in SAM, and plenty of tools write none. An absent chain
+/// must be an ordinary empty result, not a panic or a bogus record.
+#[test]
+fn absent_pg_chain_yields_no_programs() {
+    assert!(salmon_align::parse_source_programs(&[]).is_empty());
+    assert!(salmon_align::parse_source_programs(&["@HD\tVN:1.6".to_string()]).is_empty());
+
+    // A header with no @PG at all, through the real noodles parser.
+    let sam = "@HD\tVN:1.6\tSO:unsorted\n@SQ\tSN:t0\tLN:100\n";
+    let header: noodles_sam::Header = sam.parse().unwrap();
+    assert!(
+        salmon_align::source_program_lines(&header).is_empty(),
+        "a header with no @PG records has no lines to carry"
+    );
+}
+
+/// A `@PG` record may carry an ID and nothing else. That is still worth
+/// reporting — it names the program — but the command line is genuinely absent.
+#[test]
+fn pg_record_without_command_line_is_still_reported() {
+    let sam = "@HD\tVN:1.6\n@SQ\tSN:t0\tLN:100\n@PG\tID:mystery-aligner\n";
+    let header: noodles_sam::Header = sam.parse().unwrap();
+    let lines = salmon_align::source_program_lines(&header);
+    assert_eq!(lines.len(), 1);
+
+    let progs = salmon_align::parse_source_programs(&lines);
+    assert_eq!(progs.len(), 1);
+    assert_eq!(progs[0].id, "mystery-aligner");
+    assert_eq!(
+        progs[0].command_line, None,
+        "an absent CL must stay absent rather than becoming an empty string"
+    );
+    assert_eq!(progs[0].program_name, None);
+}
+
+/// A tab or newline inside a header value would invent a field or split a
+/// record. The SAM spec forbids both, but a malformed file can carry them, and
+/// they must not corrupt the neighbouring provenance.
+#[test]
+fn separators_in_header_values_do_not_corrupt_the_chain() {
+    // Built directly, since a conforming parser would not produce this.
+    let lines = vec![
+        "@PG\tID:a\tCL:cmd one\tVN:1".to_string(),
+        "@PG\tID:b\tCL:cmd two".to_string(),
+    ];
+    let progs = salmon_align::parse_source_programs(&lines);
+    assert_eq!(progs.len(), 2);
+    assert_eq!(progs[0].command_line.as_deref(), Some("cmd one"));
+    assert_eq!(progs[1].id, "b");
+
+    // The join/split round trip the RAD uses must preserve record boundaries.
+    let joined = lines.join("\n");
+    let split: Vec<String> = joined.split('\n').map(str::to_string).collect();
+    assert_eq!(split, lines);
+    assert_eq!(salmon_align::parse_source_programs(&split).len(), 2);
+}

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -39,6 +39,7 @@ fn prov() -> salmon_rad::WriterProvenance {
     salmon_rad::WriterProvenance {
         mapping_type: salmon_rad::MappingType::Mapping,
         index: None,
+        source_programs: vec![],
     }
 }
 
@@ -943,4 +944,41 @@ fn all_bias_rad_is_thread_invariant() {
             && !parallel.bias_dump.exp5_pos.is_empty(),
         "sequence and positional bias dumps should be populated"
     );
+}
+
+/// The `@PG` chain a BAM carries must parse back into the fields
+/// `meta_info.json` reports, including a command line containing spaces and
+/// colons — the characters most likely to break a naive split.
+#[test]
+fn source_program_lines_parse_back() {
+    let lines = vec![
+        "@PG\tID:bowtie2\tPN:bowtie2\tVN:2.4.5\tCL:bowtie2 -x idx -1 a.fq -2 b.fq --rg-id x:y"
+            .to_string(),
+        "@PG\tID:samtools\tPN:samtools\tPP:bowtie2\tVN:1.17\tDS:sorted".to_string(),
+    ];
+    let progs = salmon_align::parse_source_programs(&lines);
+    assert_eq!(progs.len(), 2);
+
+    assert_eq!(progs[0].id, "bowtie2");
+    assert_eq!(progs[0].program_name.as_deref(), Some("bowtie2"));
+    assert_eq!(progs[0].version.as_deref(), Some("2.4.5"));
+    assert_eq!(
+        progs[0].command_line.as_deref(),
+        Some("bowtie2 -x idx -1 a.fq -2 b.fq --rg-id x:y"),
+        "a command line's own colons must not truncate it"
+    );
+    assert_eq!(progs[0].previous_id, None);
+
+    assert_eq!(progs[1].previous_id.as_deref(), Some("bowtie2"));
+    assert_eq!(progs[1].description.as_deref(), Some("sorted"));
+
+    // Non-@PG lines and unknown tags are ignored rather than rejected: provenance
+    // that fails to parse is worse than provenance reporting what it understands.
+    let mixed = vec![
+        "@HD\tVN:1.6".to_string(),
+        "@PG\tID:x\tZZ:unknown-tag".to_string(),
+    ];
+    let progs = salmon_align::parse_source_programs(&mixed);
+    assert_eq!(progs.len(), 1);
+    assert_eq!(progs[0].id, "x");
 }

--- a/crates/salmon-core/src/diagnostics.rs
+++ b/crates/salmon-core/src/diagnostics.rs
@@ -137,3 +137,61 @@ pub fn peak_rss_kb() -> u64 {
         })
         .unwrap_or(0)
 }
+
+/// A `meta_info.json` field a complete description would carry, that this run
+/// could not fill, and the upstream that could not supply it.
+///
+/// Recorded rather than silently omitted: a consumer reading a result long after
+/// the run cannot otherwise tell "this run observed nothing" from "nobody could
+/// tell this run". The `source` says which upstream to fix, so the record is
+/// actionable and not merely an apology.
+#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
+pub struct MissingMetaField {
+    /// the `meta_info.json` field that is absent or a placeholder
+    pub field: &'static str,
+    /// which upstream could not supply it
+    pub source: MetaFieldSource,
+    /// why it is unavailable, and where possible what would make it available
+    pub reason: &'static str,
+}
+
+/// The upstream a [`MissingMetaField`] would have come from.
+#[derive(Clone, Copy, Debug, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MetaFieldSource {
+    /// the salmon index the run was given
+    Index,
+    /// the RAD file the run quantified
+    Rad,
+    /// the BAM file the run quantified
+    Bam,
+}
+
+impl MissingMetaField {
+    /// Record a field the index could not supply.
+    pub fn index(field: &'static str, reason: &'static str) -> Self {
+        Self {
+            field,
+            source: MetaFieldSource::Index,
+            reason,
+        }
+    }
+
+    /// Record a field the input RAD could not supply.
+    pub fn rad(field: &'static str, reason: &'static str) -> Self {
+        Self {
+            field,
+            source: MetaFieldSource::Rad,
+            reason,
+        }
+    }
+
+    /// Record a field the input BAM could not supply.
+    pub fn bam(field: &'static str, reason: &'static str) -> Self {
+        Self {
+            field,
+            source: MetaFieldSource::Bam,
+            reason,
+        }
+    }
+}

--- a/crates/salmon-core/src/lib.rs
+++ b/crates/salmon-core/src/lib.rs
@@ -48,7 +48,9 @@ pub mod transcript;
 // `salmon_core::transcript::Transcript`. It also lets a type move between
 // modules later without breaking every caller.
 pub use atomic::AtomicF64;
-pub use diagnostics::{input_diagnostics, peak_rss_kb, Diagnostic};
+pub use diagnostics::{
+    input_diagnostics, peak_rss_kb, Diagnostic, MetaFieldSource, MissingMetaField,
+};
 pub use libtype::{compatible_paired, compatible_single, is_compatible, observed_paired_format};
 pub use progress::ProgressCounters;
 pub use refprovider::RefProvider;

--- a/crates/salmon-index/src/lib.rs
+++ b/crates/salmon-index/src/lib.rs
@@ -253,6 +253,14 @@ pub struct IndexInfo {
     /// from `salmon_version`, the software release string below.
     #[serde(default)]
     pub index_version: u32,
+    /// whether the index was built with `--keepDuplicates`.
+    ///
+    /// `Option` rather than a defaulted `bool`: an index built before this was
+    /// recorded must read as *unknown*, not as `false`, or a quant run would
+    /// report a guess as an observation. `None` propagates into
+    /// `meta_info.json`'s `incomplete_meta_info_fields`.
+    #[serde(default)]
+    pub keep_duplicates: Option<bool>,
     /// salmon version that produced the index
     pub salmon_version: String,
     /// SHA-256/512 of the reference sequences and names, computed to byte-match
@@ -932,6 +940,7 @@ pub fn build(opts: &IndexBuildOptions) -> Result<IndexInfo> {
         first_decoy_index,
         num_decoys,
         index_version: INDEX_FORMAT_VERSION,
+        keep_duplicates: Some(opts.keep_duplicates),
         // `env!` reads an environment variable at compile time; Cargo sets this
         // one from Cargo.toml, so the recorded version is always this build's.
         salmon_version: env!("CARGO_PKG_VERSION").to_string(),

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -449,6 +449,28 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
                     profile,
                     fld_len,
                     opts.rad_codec,
+                    // Identity of the index these mappings were made against, so a
+                    // requant reports the provenance of the run that produced the
+                    // records rather than of whatever index it was handed.
+                    &salmon_rad::WriterProvenance {
+                        mapping_type: if opts.sketch {
+                            salmon_rad::MappingType::Pseudo
+                        } else {
+                            salmon_rad::MappingType::Mapping
+                        },
+                        index: Some(salmon_rad::IndexProvenance {
+                            seq_hash: salmon.info().seq_hash.clone(),
+                            name_hash: salmon.info().name_hash.clone(),
+                            seq_hash512: salmon.info().seq_hash512.clone(),
+                            name_hash512: salmon.info().name_hash512.clone(),
+                            decoy_seq_hash: salmon.info().decoy_seq_hash.clone(),
+                            decoy_name_hash: salmon.info().decoy_name_hash.clone(),
+                            // Not persisted in the index (see `info.json`), so the
+                            // mapping pass reports the same constant the reads
+                            // path does.
+                            keep_duplicates: false,
+                        }),
+                    },
                 )
                 .context("opening RAD output")?,
             )
@@ -1027,6 +1049,16 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         if let Some(f) = resolved_fmt {
             rw.set_library_format(f.format_id());
         }
+        // What the pass *saw*, which the records cannot show: a RAD holds only
+        // the fragments that mapped, so without these a requant would report a
+        // 100% mapping rate by construction.
+        rw.set_map_counters(salmon_rad::MapCounters {
+            num_processed: num_processed.load(Ordering::Relaxed),
+            num_dovetail: num_dovetail.load(Ordering::Relaxed),
+            num_filtered_vm: num_frags_filtered_vm.load(Ordering::Relaxed),
+            num_below_threshold_vm: num_below_threshold_vm.load(Ordering::Relaxed),
+            num_decoy_fragments: num_decoy.load(Ordering::Relaxed),
+        });
         rw.finalize().context("finalizing RAD output")?;
     }
 

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -261,7 +261,7 @@ impl QuantOptions {
     }
 }
 
-pub use salmon_core::Diagnostic;
+pub use salmon_core::{Diagnostic, MissingMetaField};
 
 /// Quantification results (also written to disk by [`write_outputs`]).
 ///
@@ -295,7 +295,10 @@ pub struct QuantResult {
     /// [`Self::first_decoy_index`]); 0 when the index has no decoys
     pub num_decoys: usize,
     /// whether the index collapsed duplicate sequences (for meta_info)
-    pub keep_duplicates: bool,
+    /// whether the index was built with `--keepDuplicates`; `None` when the
+    /// index predates recording it, which is reported as a missing field rather
+    /// than guessed as `false`
+    pub keep_duplicates: Option<bool>,
     /// fragments dropped because their best alignment was to a decoy
     pub num_decoy_fragments: u64,
     /// fragments whose mates dovetail (overlap past each other)
@@ -465,11 +468,13 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
                             name_hash512: salmon.info().name_hash512.clone(),
                             decoy_seq_hash: salmon.info().decoy_seq_hash.clone(),
                             decoy_name_hash: salmon.info().decoy_name_hash.clone(),
-                            // Not persisted in the index (see `info.json`), so the
-                            // mapping pass reports the same constant the reads
-                            // path does.
-                            keep_duplicates: false,
+                            // `None` for an index built before this was
+                            // recorded; the RAD then omits the tag, so a
+                            // requant reports it unknown rather than `false`.
+                            keep_duplicates: salmon.info().keep_duplicates,
                         }),
+                        // No BAM behind reads; nothing an aligner said to carry.
+                        source_programs: Vec::new(),
                     },
                 )
                 .context("opening RAD output")?,
@@ -1160,7 +1165,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         num_eq_classes,
         first_decoy_index: salmon.info().first_decoy_index,
         num_decoys: salmon.info().num_decoys,
-        keep_duplicates: false,
+        keep_duplicates: salmon.info().keep_duplicates,
         num_decoy_fragments: num_decoy.load(Ordering::Relaxed),
         num_dovetail_fragments: num_dovetail.load(Ordering::Relaxed),
         num_fragments_filtered_vm: num_frags_filtered_vm.load(Ordering::Relaxed),

--- a/crates/salmon-quant/src/output.rs
+++ b/crates/salmon-quant/src/output.rs
@@ -357,6 +357,13 @@ struct MetaInfo {
     num_bootstraps: u32,
     /// mapped fragments placed as orphans (only one mate mapped)
     num_orphan: u64,
+    /// whether every field here is a true observation of the run.
+    ///
+    /// Always `true` on this path: it mapped the reads itself, so nothing is
+    /// inferred. A requant from a RAD that does not record what its mapping pass
+    /// observed reports `false` and names the affected fields (see the `--rad`
+    /// path in `salmon-align`).
+    meta_info_complete: bool,
     /// range-factorization bins used for equivalence classes (0 = disabled)
     range_factorization_bins: u32,
     /// EM/VBEM convergence
@@ -446,6 +453,7 @@ fn write_meta_info(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Resul
         inference_truncated_mass: res.inference_truncated_mass,
         num_bootstraps: res.bootstraps.len() as u32,
         num_orphan: res.num_orphan,
+        meta_info_complete: true,
         range_factorization_bins: opts.range_factorization_bins,
         num_em_iterations: res.em_iters,
         em_converged: res.em_converged,

--- a/crates/salmon-quant/src/output.rs
+++ b/crates/salmon-quant/src/output.rs
@@ -331,7 +331,10 @@ struct MetaInfo {
     pos_bias_correct: bool,
     num_bias_bins: usize,
     mapping_type: String,
-    keep_duplicates: bool,
+    /// how the index was built; omitted when the index predates recording it,
+    /// rather than reported as a `false` the run cannot actually vouch for
+    #[serde(skip_serializing_if = "Option::is_none")]
+    keep_duplicates: Option<bool>,
     index_seq_hash: String,
     index_name_hash: String,
     index_seq_hash512: String,
@@ -359,11 +362,13 @@ struct MetaInfo {
     num_orphan: u64,
     /// whether every field here is a true observation of the run.
     ///
-    /// Always `true` on this path: it mapped the reads itself, so nothing is
-    /// inferred. A requant from a RAD that does not record what its mapping pass
-    /// observed reports `false` and names the affected fields (see the `--rad`
-    /// path in `salmon-align`).
+    /// Mapping the reads directly supplies almost everything, but not quite
+    /// everything: an index built before it recorded how it was built cannot say,
+    /// and guessing would be worse than saying so. Each gap is listed below with
+    /// the upstream responsible, so it is actionable.
     meta_info_complete: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    incomplete_meta_info_fields: Vec<crate::MissingMetaField>,
     /// range-factorization bins used for equivalence classes (0 = disabled)
     range_factorization_bins: u32,
     /// EM/VBEM convergence
@@ -382,6 +387,16 @@ struct MetaInfo {
 }
 
 fn write_meta_info(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Result<()> {
+    // Mapping the reads answers nearly everything directly; what it cannot
+    // answer comes from the index, which may predate recording it.
+    let mut missing_meta_info_fields = Vec::new();
+    if res.keep_duplicates.is_none() {
+        missing_meta_info_fields.push(crate::MissingMetaField::index(
+            "keep_duplicates",
+            "this index predates recording how it was built; rebuild the index \
+             to record it",
+        ));
+    }
     let percent_mapped = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
     } else {
@@ -453,7 +468,8 @@ fn write_meta_info(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Resul
         inference_truncated_mass: res.inference_truncated_mass,
         num_bootstraps: res.bootstraps.len() as u32,
         num_orphan: res.num_orphan,
-        meta_info_complete: true,
+        meta_info_complete: missing_meta_info_fields.is_empty(),
+        incomplete_meta_info_fields: missing_meta_info_fields,
         range_factorization_bins: opts.range_factorization_bins,
         num_em_iterations: res.em_iters,
         em_converged: res.em_converged,

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -1044,7 +1044,11 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             if let (Some(rad), Some(buf)) = (sh.rad, rad_buf.as_mut()) {
                 if !maps.is_empty() {
                     let rec = build_rad_record(&maps);
-                    let _ = buf.write(&rec, rad.context());
+                    buf.write(&rec, rad.context()).map_err(|e| {
+                        paraseq::Error::from(std::io::Error::other(format!(
+                            "serializing RAD record: {e:#}"
+                        )))
+                    })?;
                 }
             }
             if let Some(acc) = sh.discrete_fld {
@@ -1072,7 +1076,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         self.shared.fld.refresh_online();
         flush_sam(self)?;
         flush_bam(self)?;
-        flush_rad(self);
+        flush_rad(self)?;
         Ok(())
     }
 
@@ -1081,7 +1085,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         merge_unmapped(self);
         flush_sam(self)?;
         flush_bam(self)?;
-        flush_rad(self);
+        flush_rad(self)?;
         Ok(())
     }
 }
@@ -1170,7 +1174,11 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             if let (Some(rad), Some(buf)) = (sh.rad, rad_buf.as_mut()) {
                 if !maps.is_empty() {
                     let radrec = build_rad_record(&maps);
-                    let _ = buf.write(&radrec, rad.context());
+                    buf.write(&radrec, rad.context()).map_err(|e| {
+                        paraseq::Error::from(std::io::Error::other(format!(
+                            "serializing RAD record: {e:#}"
+                        )))
+                    })?;
                 }
             }
             if let Some(acc) = sh.discrete_fld {
@@ -1198,7 +1206,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         self.shared.fld.refresh_online();
         flush_sam(self)?;
         flush_bam(self)?;
-        flush_rad(self);
+        flush_rad(self)?;
         Ok(())
     }
 
@@ -1207,7 +1215,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
         merge_unmapped(self);
         flush_sam(self)?;
         flush_bam(self)?;
-        flush_rad(self);
+        flush_rad(self)?;
         Ok(())
     }
 }
@@ -1268,15 +1276,20 @@ fn build_rad_record(maps: &[ScoredMapping]) -> salmon_rad::SalmonBulkRecord {
 }
 
 /// Flush this thread's accumulated RAD records as one chunk to the shared writer.
-fn flush_rad(proc: &mut QuantProcessor) {
+///
+/// Errors here are fatal and must propagate: this is the only point at which a
+/// RAD write actually reaches the filesystem, so discarding the result means a
+/// full disk (`ENOSPC`) or an I/O error silently yields a truncated RAD that the
+/// run then reports as successful. See salmon#1105.
+fn flush_rad(proc: &mut QuantProcessor) -> paraseq::Result<()> {
     if let (Some(rad), Some(buf)) = (proc.shared.rad, proc.rad_buf.as_mut()) {
         if buf.nrec() > 0 {
-            match buf.take_bytes() {
-                Ok(bytes) => {
-                    let _ = rad.append_chunk_bytes(&bytes);
-                }
-                Err(e) => tracing::error!("failed to serialize RAD chunk: {e}"),
-            }
+            let bytes = buf
+                .take_bytes()
+                .map_err(|e| paraseq::Error::from(std::io::Error::other(e.to_string())))?;
+            rad.append_chunk_bytes(&bytes)
+                .map_err(|e| paraseq::Error::from(std::io::Error::other(format!("{e:#}"))))?;
         }
     }
+    Ok(())
 }

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -457,6 +457,17 @@ fn record_discrete(sh: &Shared, maps: &[ScoredMapping], acc: &salmon_model::Disc
         return;
     }
     sh.num_mapped.fetch_add(1, Ordering::Relaxed);
+    // Same orphan definition `record` uses: a fragment's surviving mappings share
+    // one status, so the first is representative. Counting it here is what lets
+    // `--deterministic` report the concordant/orphan split in
+    // `lib_format_counts.json` instead of calling every mapped fragment
+    // concordant.
+    if matches!(
+        maps[0].status,
+        MateStatus::PairedEndLeft | MateStatus::PairedEndRight
+    ) {
+        sh.num_orphan.fetch_add(1, Ordering::Relaxed);
+    }
     // A uniquely-mapped proper pair unambiguously implies its fragment length and
     // orientation; its observed format also feeds order-independent `-l A`
     // detection. Uses the raw mapping (like the RAD records written this pass, and

--- a/crates/salmon-rad/src/lib.rs
+++ b/crates/salmon-rad/src/lib.rs
@@ -198,6 +198,15 @@ pub const BAKED_LIBFMT: u8 = 0x04;
 /// [`BAKED_FLAGS_TAG`] bit: a non-default [`SCORE_KIND_TAG`] is present (the
 /// per-hit score is a quantized log-weight, not a raw aligner `AS`).
 pub const BAKED_SCORE_KIND: u8 = 0x08;
+/// [`BAKED_FLAGS_TAG`] bit: the writer reached finalize, so the file is complete.
+///
+/// This is **confirmatory only**. Its presence proves the file was fully
+/// written; its absence proves nothing, because a conforming producer may stream
+/// a RAD file without ever backpatching (the same reason `num_chunks == 0` is a
+/// valid "unknown chunk count" signal). Readers may use it as a fast path, but
+/// must never require it, or they would reject legitimate files from other
+/// tools.
+pub const WRITE_COMPLETE: u8 = 0x10;
 
 /// File-tag name: how a reader should interpret the per-hit `alignment_score`
 /// (present only in the selective-alignment profile). A `u8`:

--- a/crates/salmon-rad/src/lib.rs
+++ b/crates/salmon-rad/src/lib.rs
@@ -237,7 +237,17 @@ pub const INDEX_DECOY_SEQ_HASH_TAG: &str = "index_decoy_seq_hash";
 /// See [`INDEX_SEQ_HASH_TAG`].
 pub const INDEX_DECOY_NAME_HASH_TAG: &str = "index_decoy_name_hash";
 /// File-tag name: whether the index was built with `--keepDuplicates`.
+///
+/// Written only when the index actually recorded it; absent means unknown,
+/// which a reader must not collapse to `false`.
 pub const KEEP_DUPLICATES_TAG: &str = "keep_duplicates";
+/// File-tag name: the `@PG` header records of the BAM these fragments came from,
+/// verbatim, one per line.
+///
+/// Stored as the raw SAM lines rather than a parsed structure so nothing the
+/// aligner recorded is dropped in transit; a reader parses them back out for
+/// `meta_info.json`. Present only for a RAD derived from an alignment file.
+pub const SOURCE_PROGRAMS_TAG: &str = "source_programs";
 
 /// File-tag name: how the fragments in this RAD were produced.
 ///
@@ -290,6 +300,11 @@ pub struct WriterProvenance {
     pub mapping_type: MappingType,
     /// identity of the index the mappings were made against, when there is one
     pub index: Option<IndexProvenance>,
+    /// verbatim `@PG` lines from the source BAM, when the fragments came from
+    /// one; empty otherwise. Propagates what the aligner said about itself, so a
+    /// requant reports how the alignments were produced and not merely that they
+    /// were alignments.
+    pub source_programs: Vec<String>,
 }
 
 /// Identity of the index a mapping pass ran against, recorded in the RAD.
@@ -312,8 +327,9 @@ pub struct IndexProvenance {
     pub decoy_seq_hash: String,
     /// hash of the decoy names (empty when the index has no decoys)
     pub decoy_name_hash: String,
-    /// whether the index was built with `--keepDuplicates`
-    pub keep_duplicates: bool,
+    /// whether the index was built with `--keepDuplicates`; `None` when the
+    /// index predates recording it, which must not be reported as `false`
+    pub keep_duplicates: Option<bool>,
 }
 
 /// Counters describing what a mapping pass *saw*, as opposed to what it wrote.

--- a/crates/salmon-rad/src/lib.rs
+++ b/crates/salmon-rad/src/lib.rs
@@ -241,6 +241,13 @@ pub const INDEX_DECOY_NAME_HASH_TAG: &str = "index_decoy_name_hash";
 /// Written only when the index actually recorded it; absent means unknown,
 /// which a reader must not collapse to `false`.
 pub const KEEP_DUPLICATES_TAG: &str = "keep_duplicates";
+/// The longest string a RAD file tag can hold.
+///
+/// A string tag is written as a `u16` length followed by its bytes, and that
+/// length is cast rather than checked, so anything longer wraps and corrupts the
+/// file rather than failing to write. Producers must fit their values to this.
+pub const MAX_FILE_TAG_STRING_LEN: usize = u16::MAX as usize;
+
 /// File-tag name: the `@PG` header records of the BAM these fragments came from,
 /// verbatim, one per line.
 ///

--- a/crates/salmon-rad/src/lib.rs
+++ b/crates/salmon-rad/src/lib.rs
@@ -189,6 +189,152 @@ pub const INITIAL_ABUNDANCES_TAG: &str = "initial_abundances";
 /// concordance filtering under `-l A` without re-inferring the type (the write
 /// run already detected it). Absent ⇒ the reader auto-detects from the RAD.
 pub const LIBRARY_FORMAT_TAG: &str = "library_format";
+// ---------------------------------------------------------------------------
+// Mapping-pass provenance.
+//
+// The counters and index identity below are observations of the *mapping* pass,
+// not of the fragments it emitted, so a reader cannot recover them from the
+// records: a RAD holds only the fragments that mapped. Without them a requant
+// can say how many fragments it quantified but not how many were seen, so it
+// reports a 100% mapping rate by construction.
+//
+// Two groups, because they become known at different times. The index identity
+// is known before the first record is written, so it is written directly. The
+// counters are only final once the pass ends, so their slots are reserved and
+// backpatched at finalize, exactly like the FLD (see [`BAKED_MAP_COUNTERS`]).
+// ---------------------------------------------------------------------------
+
+/// File-tag name: total fragments the mapping pass *observed*, mapped or not.
+///
+/// The one quantity a RAD reader can never derive, and the one every mapping-rate
+/// figure depends on.
+pub const NUM_PROCESSED_TAG: &str = "num_processed";
+/// File-tag name: fragments whose mappings were dovetailed.
+pub const NUM_DOVETAIL_TAG: &str = "num_dovetail_fragments";
+/// File-tag name: fragments dropped by the mapping-score filter.
+pub const NUM_FILTERED_VM_TAG: &str = "num_fragments_filtered_vm";
+/// File-tag name: alignments scoring below threshold among mapped fragments.
+pub const NUM_BELOW_THRESH_VM_TAG: &str = "num_alignments_below_threshold_vm";
+/// File-tag name: fragments whose best mapping was to a decoy.
+///
+/// Decoy mappings are filtered before records are written, so this count is
+/// unrecoverable from the file itself.
+pub const NUM_DECOY_FRAGMENTS_TAG: &str = "num_decoy_fragments";
+/// File-tag names identifying the index the mappings were made against.
+///
+/// Recorded from the mapping pass rather than read from whatever index the
+/// requant happens to be given: these describe the index that actually produced
+/// the records, which is what the provenance in `meta_info.json` claims.
+pub const INDEX_SEQ_HASH_TAG: &str = "index_seq_hash";
+/// See [`INDEX_SEQ_HASH_TAG`].
+pub const INDEX_NAME_HASH_TAG: &str = "index_name_hash";
+/// See [`INDEX_SEQ_HASH_TAG`].
+pub const INDEX_SEQ_HASH512_TAG: &str = "index_seq_hash512";
+/// See [`INDEX_SEQ_HASH_TAG`].
+pub const INDEX_NAME_HASH512_TAG: &str = "index_name_hash512";
+/// See [`INDEX_SEQ_HASH_TAG`].
+pub const INDEX_DECOY_SEQ_HASH_TAG: &str = "index_decoy_seq_hash";
+/// See [`INDEX_SEQ_HASH_TAG`].
+pub const INDEX_DECOY_NAME_HASH_TAG: &str = "index_decoy_name_hash";
+/// File-tag name: whether the index was built with `--keepDuplicates`.
+pub const KEEP_DUPLICATES_TAG: &str = "keep_duplicates";
+
+/// File-tag name: how the fragments in this RAD were produced.
+///
+/// Recorded explicitly rather than inferred from the record profile, because the
+/// two do not agree: a BAM-derived RAD is written in the selective-alignment
+/// profile but its fragments came from an aligner, not from salmon's mapper.
+pub const MAPPING_TYPE_TAG: &str = "mapping_type";
+
+/// How the fragments in a RAD were produced; `meta_info.json`'s `mapping_type`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MappingType {
+    /// salmon's selective-alignment mapper
+    Mapping,
+    /// salmon's sketch (pseudoalignment) mapper
+    Pseudo,
+    /// an external aligner, via a BAM
+    Alignment,
+}
+
+impl MappingType {
+    /// The string salmon reports in `meta_info.json`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mapping => "mapping",
+            Self::Pseudo => "pseudo",
+            Self::Alignment => "alignment",
+        }
+    }
+
+    /// Parse the tag written by [`Self::as_str`]; `None` for anything else.
+    pub fn from_str_tag(s: &str) -> Option<Self> {
+        match s {
+            "mapping" => Some(Self::Mapping),
+            "pseudo" => Some(Self::Pseudo),
+            "alignment" => Some(Self::Alignment),
+            _ => None,
+        }
+    }
+}
+
+/// What a writer records about the pass that produced a RAD.
+///
+/// Grouped rather than passed as loose arguments because the parts are not
+/// independent: a BAM-derived RAD has a `mapping_type` but no index behind it,
+/// and `None` there must reach the reader as "unknown" rather than as empty
+/// strings that look like real hashes.
+#[derive(Clone, Debug)]
+pub struct WriterProvenance {
+    /// how the fragments were produced
+    pub mapping_type: MappingType,
+    /// identity of the index the mappings were made against, when there is one
+    pub index: Option<IndexProvenance>,
+}
+
+/// Identity of the index a mapping pass ran against, recorded in the RAD.
+///
+/// Lets a requant report the same index provenance the original run did. It has
+/// to be recorded rather than read back from the index at requant time, both
+/// because the `--rad` path loads no index at all and because the user may hand
+/// it a different one than the mappings were made against.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct IndexProvenance {
+    /// hash of the reference sequences
+    pub seq_hash: String,
+    /// hash of the reference names
+    pub name_hash: String,
+    /// 512-bit form of [`Self::seq_hash`]
+    pub seq_hash512: String,
+    /// 512-bit form of [`Self::name_hash`]
+    pub name_hash512: String,
+    /// hash of the decoy sequences (empty when the index has no decoys)
+    pub decoy_seq_hash: String,
+    /// hash of the decoy names (empty when the index has no decoys)
+    pub decoy_name_hash: String,
+    /// whether the index was built with `--keepDuplicates`
+    pub keep_duplicates: bool,
+}
+
+/// Counters describing what a mapping pass *saw*, as opposed to what it wrote.
+///
+/// Every field here is unrecoverable from the records: a RAD contains only the
+/// fragments that mapped, so without these a reader cannot report a mapping rate
+/// (see [`NUM_PROCESSED_TAG`]).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MapCounters {
+    /// total fragments observed, mapped or not
+    pub num_processed: u64,
+    /// fragments whose mappings were dovetailed
+    pub num_dovetail: u64,
+    /// fragments dropped by the mapping-score filter
+    pub num_filtered_vm: u64,
+    /// alignments below threshold among mapped fragments
+    pub num_below_threshold_vm: u64,
+    /// fragments whose best mapping was to a decoy
+    pub num_decoy_fragments: u64,
+}
+
 /// [`BAKED_FLAGS_TAG`] bit: a fragment-length distribution is present.
 pub const BAKED_FLD: u8 = 0x01;
 /// [`BAKED_FLAGS_TAG`] bit: initial abundance estimates are present.
@@ -207,6 +353,13 @@ pub const BAKED_SCORE_KIND: u8 = 0x08;
 /// must never require it, or they would reject legitimate files from other
 /// tools.
 pub const WRITE_COMPLETE: u8 = 0x10;
+/// [`BAKED_FLAGS_TAG`] bit: the mapping-pass counters hold real values.
+///
+/// Distinguishes "the pass observed zero of these" from "nobody filled the
+/// slot", which a zero alone cannot: the slots are reserved as zeros.
+pub const BAKED_MAP_COUNTERS: u8 = 0x20;
+/// [`BAKED_FLAGS_TAG`] bit: the index-identity tags are present.
+pub const BAKED_INDEX_PROV: u8 = 0x40;
 
 /// File-tag name: how a reader should interpret the per-hit `alignment_score`
 /// (present only in the selective-alignment profile). A `u8`:

--- a/crates/salmon-rad/src/schema.rs
+++ b/crates/salmon-rad/src/schema.rs
@@ -61,6 +61,7 @@ pub fn build_prelude(
     ref_lengths: &[u32],
     fld_len: usize,
     codec: ChunkCodec,
+    provenance: &crate::WriterProvenance,
 ) -> (RadPrelude, TagMap) {
     let num_refs = ref_names.len();
     // File tags carry concrete values (written once, after the header). The
@@ -84,7 +85,54 @@ pub fn build_prelude(
             TagValue::ArrayF64(vec![0.0; num_refs]),
         ),
         (crate::LIBRARY_FORMAT_TAG, TagValue::U8(0)),
+        // Mapping-pass counters. Reserved as zeros and backpatched at finalize;
+        // the `BAKED_MAP_COUNTERS` flag says whether they were actually filled,
+        // since a real count of zero is indistinguishable from a placeholder.
+        (crate::NUM_PROCESSED_TAG, TagValue::U64(0)),
+        (crate::NUM_DOVETAIL_TAG, TagValue::U64(0)),
+        (crate::NUM_FILTERED_VM_TAG, TagValue::U64(0)),
+        (crate::NUM_BELOW_THRESH_VM_TAG, TagValue::U64(0)),
+        (crate::NUM_DECOY_FRAGMENTS_TAG, TagValue::U64(0)),
     ];
+    // Index identity, known before the first record, so written outright rather
+    // than reserved. Omitted entirely when the producer has no index (a BAM-derived
+    // RAD), because an absent tag says "unknown" and an empty string does not.
+    file_tag_values.push((
+        crate::MAPPING_TYPE_TAG,
+        TagValue::String(provenance.mapping_type.as_str().to_string()),
+    ));
+    if let Some(prov) = &provenance.index {
+        file_tag_values.extend([
+            (
+                crate::INDEX_SEQ_HASH_TAG,
+                TagValue::String(prov.seq_hash.clone()),
+            ),
+            (
+                crate::INDEX_NAME_HASH_TAG,
+                TagValue::String(prov.name_hash.clone()),
+            ),
+            (
+                crate::INDEX_SEQ_HASH512_TAG,
+                TagValue::String(prov.seq_hash512.clone()),
+            ),
+            (
+                crate::INDEX_NAME_HASH512_TAG,
+                TagValue::String(prov.name_hash512.clone()),
+            ),
+            (
+                crate::INDEX_DECOY_SEQ_HASH_TAG,
+                TagValue::String(prov.decoy_seq_hash.clone()),
+            ),
+            (
+                crate::INDEX_DECOY_NAME_HASH_TAG,
+                TagValue::String(prov.decoy_name_hash.clone()),
+            ),
+            (
+                crate::KEEP_DUPLICATES_TAG,
+                TagValue::U8(prov.keep_duplicates as u8),
+            ),
+        ]);
+    }
     // Score interpretation, only meaningful for the scored (SA) profile. Reserved
     // as the default (raw AS) and backpatched at finalize if the write run scored
     // by the deterministic error model instead (see [`crate::SCORE_KIND_TAG`]).

--- a/crates/salmon-rad/src/schema.rs
+++ b/crates/salmon-rad/src/schema.rs
@@ -127,11 +127,18 @@ pub fn build_prelude(
                 crate::INDEX_DECOY_NAME_HASH_TAG,
                 TagValue::String(prov.decoy_name_hash.clone()),
             ),
-            (
-                crate::KEEP_DUPLICATES_TAG,
-                TagValue::U8(prov.keep_duplicates as u8),
-            ),
         ]);
+        // Only when the index recorded it: an absent tag reads as unknown, while
+        // a written `0` would read as a definite "duplicates were collapsed".
+        if let Some(keep) = prov.keep_duplicates {
+            file_tag_values.push((crate::KEEP_DUPLICATES_TAG, TagValue::U8(keep as u8)));
+        }
+    }
+    if !provenance.source_programs.is_empty() {
+        file_tag_values.push((
+            crate::SOURCE_PROGRAMS_TAG,
+            TagValue::String(provenance.source_programs.join("\n")),
+        ));
     }
     // Score interpretation, only meaningful for the scored (SA) profile. Reserved
     // as the default (raw AS) and backpatched at finalize if the write run scored

--- a/crates/salmon-rad/src/writer.rs
+++ b/crates/salmon-rad/src/writer.rs
@@ -25,9 +25,10 @@
 //! unordered bag and salmon's determinism comes from order-independent
 //! aggregation downstream, not from file order.
 
+use anyhow::Context;
 use std::fs::File;
 use std::io::BufWriter;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use libradicl::chunk::ChunkBuf;
 use libradicl::header::RadPrelude;
@@ -40,6 +41,10 @@ use crate::{schema, RadProfile, BAKED_ABUND, BAKED_FLD, BAKED_LIBFMT, BAKED_SCOR
 
 /// Shared, thread-safe RAD output sink for one file.
 pub struct RadOutputWriter {
+    /// where the finished file should end up
+    final_path: PathBuf,
+    /// where bytes are actually written until `finalize` renames it
+    partial_path: PathBuf,
     /// The underlying file, wrapped so that appends from many threads are safe.
     ccw: ConcurrentChunkWriter<BufWriter<File>>,
     /// Which profile records are written in (decides the per-hit layout).
@@ -62,6 +67,19 @@ pub struct RadOutputWriter {
     codec: ChunkCodec,
 }
 
+/// The sibling path a RAD file is written to before it is finalized.
+///
+/// Keeping it next to the destination (rather than in a temp dir) means the
+/// final rename is within one filesystem, so it is atomic; a cross-device rename
+/// would degrade to a copy and reintroduce the partial-file window this exists
+/// to close. The pid keeps concurrent runs targeting the same output from
+/// colliding.
+fn partial_path_for(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".partial-{}", std::process::id()));
+    path.with_file_name(name)
+}
+
 impl RadOutputWriter {
     /// Create a RAD file at `path`, writing the prelude + file tags for the
     /// given profile. `ref_names`/`ref_lengths` cover the full reference table.
@@ -78,13 +96,25 @@ impl RadOutputWriter {
     ) -> anyhow::Result<Self> {
         let (prelude, file_tag_map): (RadPrelude, _) =
             schema::build_prelude(profile, is_paired, ref_names, ref_lengths, fld_len, codec);
+        // Write to a sibling temporary path and rename onto `path` only once the
+        // run has finalized successfully. A partial RAD therefore never appears
+        // under the name the user asked for, so a later `--rad` run cannot pick
+        // one up believing it is complete. Rename rather than delete-on-error,
+        // because rename is atomic and also covers `SIGKILL`, where no cleanup
+        // code of ours would run at all.
+        let partial_path = partial_path_for(path);
         // `BufWriter` batches small writes into large ones; without it every
         // chunk append would become a separate system call.
-        let file = BufWriter::new(File::create(path)?);
+        let file = BufWriter::new(
+            File::create(&partial_path)
+                .with_context(|| format!("creating RAD output file {}", partial_path.display()))?,
+        );
         // Writing the prelude here means the file is valid (if empty) from the
         // moment it is created.
         let fw = RadFileWriter::new(file, &prelude, &file_tag_map)?;
         Ok(Self {
+            final_path: path.to_path_buf(),
+            partial_path,
             ccw: ConcurrentChunkWriter::new(fw),
             ctx: SalmonBulkContext { profile },
             fld_len,
@@ -142,7 +172,13 @@ impl RadOutputWriter {
     /// Append a fully-framed chunk (from [`FragmentChunkBuf::take_bytes`]) to the
     /// file. Thread-safe: takes `&self`, so every worker can call it directly.
     pub fn append_chunk_bytes(&self, bytes: &[u8]) -> anyhow::Result<()> {
-        self.ccw.append_chunk_bytes(bytes)
+        self.ccw.append_chunk_bytes(bytes).with_context(|| {
+            format!(
+                "writing RAD chunk to {}\n  \
+                 the incomplete file has been left there; it is NOT usable as `--rad` input",
+                self.partial_path.display()
+            )
+        })
     }
 
     /// Backpatch any baked FLD / abundances + the `baked_flags` marker, then flush
@@ -191,11 +227,40 @@ impl RadOutputWriter {
                 flags |= BAKED_SCORE_KIND;
             }
         }
-        if flags != 0 {
-            w.backpatch_file_tag_value(crate::BAKED_FLAGS_TAG, &TagValue::U8(flags))?;
-        }
+        // Reaching here means every chunk was written and the header is about to
+        // be patched, so record completeness alongside whatever else was baked.
+        // See `WRITE_COMPLETE`: readers treat this as confirmatory, never required.
+        flags |= crate::WRITE_COMPLETE;
+        w.backpatch_file_tag_value(crate::BAKED_FLAGS_TAG, &TagValue::U8(flags))?;
         // Writes the final chunk count into the header and flushes the file.
-        w.finalize()?;
+        let buf = w
+            .finalize()
+            .with_context(|| format!("finalizing {}", self.partial_path.display()))?;
+        // `into_inner` flushes, and unlike dropping the `BufWriter` it reports a
+        // failure to do so rather than swallowing it.
+        let file = buf.into_inner().map_err(|e| {
+            anyhow::anyhow!(
+                "flushing {}: {}",
+                self.partial_path.display(),
+                e.into_error()
+            )
+        })?;
+        // Flush to the device before the rename makes this the user-visible
+        // output. On NFS in particular a deferred `ENOSPC` surfaces only here, so
+        // dropping the handle instead would discard exactly the error this fix
+        // exists to report (salmon#1105).
+        file.sync_all()
+            .with_context(|| format!("flushing {} to disk", self.partial_path.display()))?;
+        // Only now does the output take the name the user asked for. Any failure
+        // before this point leaves the bytes under the `.partial-*` name, where a
+        // later `--rad` run will not mistake them for a complete file.
+        std::fs::rename(&self.partial_path, &self.final_path).with_context(|| {
+            format!(
+                "renaming {} to {}",
+                self.partial_path.display(),
+                self.final_path.display()
+            )
+        })?;
         Ok(())
     }
 }

--- a/crates/salmon-rad/src/writer.rs
+++ b/crates/salmon-rad/src/writer.rs
@@ -63,6 +63,12 @@ pub struct RadOutputWriter {
     /// non-default score interpretation (see [`crate::SCORE_KIND_TAG`]); only the
     /// scored (SA) profile reserves the slot, so set only in that profile.
     pending_score_kind: Option<u8>,
+    /// Mapping-pass counters, known only once the pass ends.
+    pending_counters: Option<crate::MapCounters>,
+    /// Whether index identity was written at create time. The tags are written
+    /// up front but `baked_flags` is only patched at finalize, so this carries
+    /// the fact across; without it a reader would ignore the tags it can see.
+    has_index_prov: bool,
     /// chunk compression codec applied by worker buffers (advertised in the header).
     codec: ChunkCodec,
 }
@@ -93,9 +99,17 @@ impl RadOutputWriter {
         profile: RadProfile,
         fld_len: usize,
         codec: ChunkCodec,
+        provenance: &crate::WriterProvenance,
     ) -> anyhow::Result<Self> {
-        let (prelude, file_tag_map): (RadPrelude, _) =
-            schema::build_prelude(profile, is_paired, ref_names, ref_lengths, fld_len, codec);
+        let (prelude, file_tag_map): (RadPrelude, _) = schema::build_prelude(
+            profile,
+            is_paired,
+            ref_names,
+            ref_lengths,
+            fld_len,
+            codec,
+            provenance,
+        );
         // Write to a sibling temporary path and rename onto `path` only once the
         // run has finalized successfully. A partial RAD therefore never appears
         // under the name the user asked for, so a later `--rad` run cannot pick
@@ -124,6 +138,8 @@ impl RadOutputWriter {
             pending_abund: None,
             pending_libfmt: None,
             pending_score_kind: None,
+            pending_counters: None,
+            has_index_prov: provenance.index.is_some(),
             codec,
         })
     }
@@ -165,6 +181,14 @@ impl RadOutputWriter {
     /// the header at finalize. Only valid on the scored (selective-alignment)
     /// profile, whose prelude reserves the slot; a no-op-worthy default
     /// ([`crate::SCORE_KIND_AS`]) need not be set (absent ⇒ that default).
+    /// Record what the mapping pass observed, to be baked at finalize.
+    ///
+    /// Without this a requant cannot report a mapping rate: the file holds only
+    /// the fragments that mapped, so it would report 100% by construction.
+    pub fn set_map_counters(&mut self, counters: crate::MapCounters) {
+        self.pending_counters = Some(counters);
+    }
+
     pub fn set_score_kind(&mut self, score_kind: u8) {
         self.pending_score_kind = Some(score_kind);
     }
@@ -195,6 +219,8 @@ impl RadOutputWriter {
         let pending_abund = self.pending_abund;
         let pending_libfmt = self.pending_libfmt;
         let pending_score_kind = self.pending_score_kind;
+        let pending_counters = self.pending_counters;
+        let has_index_prov = self.has_index_prov;
         // Unwrap the concurrent wrapper back into a plain writer; this succeeds
         // only once every worker handle is gone, which is what makes the
         // in-place patching below safe.
@@ -226,6 +252,21 @@ impl RadOutputWriter {
                 w.backpatch_file_tag_value(crate::SCORE_KIND_TAG, &TagValue::U8(k))?;
                 flags |= BAKED_SCORE_KIND;
             }
+        }
+        if let Some(c) = pending_counters {
+            for (tag, value) in [
+                (crate::NUM_PROCESSED_TAG, c.num_processed),
+                (crate::NUM_DOVETAIL_TAG, c.num_dovetail),
+                (crate::NUM_FILTERED_VM_TAG, c.num_filtered_vm),
+                (crate::NUM_BELOW_THRESH_VM_TAG, c.num_below_threshold_vm),
+                (crate::NUM_DECOY_FRAGMENTS_TAG, c.num_decoy_fragments),
+            ] {
+                w.backpatch_file_tag_value(tag, &TagValue::U64(value))?;
+            }
+            flags |= crate::BAKED_MAP_COUNTERS;
+        }
+        if has_index_prov {
+            flags |= crate::BAKED_INDEX_PROV;
         }
         // Reaching here means every chunk was written and the header is about to
         // be patched, so record completeness alongside whatever else was baked.

--- a/crates/salmon-rad/tests/roundtrip.rs
+++ b/crates/salmon-rad/tests/roundtrip.rs
@@ -97,6 +97,19 @@ fn read_all(
     (prelude, ref_lengths, ctx, recs)
 }
 
+/// Read one file tag by name from a written RAD file.
+fn read_file_tag(path: &std::path::Path, name: &str) -> TagValue {
+    let mut data = Vec::new();
+    std::fs::File::open(path)
+        .unwrap()
+        .read_to_end(&mut data)
+        .unwrap();
+    let mut rc = Cursor::new(data);
+    let prelude = RadPrelude::from_bytes(&mut rc).unwrap();
+    let ftm = prelude.file_tags.parse_tags_from_bytes(&mut rc).unwrap();
+    ftm.get(name).unwrap().clone()
+}
+
 fn check_roundtrip(profile: RadProfile, expected_detect: RadInputProfile) {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     let recs = sample_records(profile);
@@ -219,4 +232,86 @@ fn concurrent_writer_counts_chunks() {
     let (prelude, _, _, got) = read_all(tmp.path());
     assert_eq!(prelude.hdr.num_chunks, 4, "one chunk per thread");
     assert_eq!(got.len(), 4, "all four records present");
+}
+
+/// A RAD file must only take the name the user asked for once it is complete.
+///
+/// Regression test for salmon#1105: a run that died mid-write (a full disk) left
+/// a truncated file at the requested path, and a later `--rad` run consumed it
+/// as if it were whole.
+#[test]
+fn abandoned_write_never_claims_the_final_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.rad");
+    let names = ["t0", "t1", "t2"];
+    let lens = [100u32, 200, 300];
+
+    let w = RadOutputWriter::create(
+        &path,
+        &names,
+        &lens,
+        true,
+        RadProfile::SelectiveAlignment,
+        1024,
+        ChunkCodec::None,
+    )
+    .unwrap();
+    let ctx: SalmonBulkContext = *w.context();
+    let mut cb = FragmentChunkBuf::with_capacity_codec(1024, ChunkCodec::None);
+    for r in &sample_records(RadProfile::SelectiveAlignment) {
+        cb.write(r, &ctx).unwrap();
+    }
+    w.append_chunk_bytes(&cb.take_bytes().unwrap()).unwrap();
+    // Simulates the run dying before finalize: chunks are on disk, but the
+    // header was never backpatched.
+    drop(w);
+
+    assert!(
+        !path.exists(),
+        "an unfinalized write must not appear at the requested path"
+    );
+    let partials: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("out.rad.partial-"))
+        .collect();
+    assert_eq!(
+        partials.len(),
+        1,
+        "the incomplete bytes should remain under a `.partial-*` name, found {partials:?}"
+    );
+}
+
+/// `finalize` renames the partial into place and marks the file complete.
+#[test]
+fn finalize_renames_and_marks_complete() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.rad");
+    write_file_codec(
+        &path,
+        RadProfile::SelectiveAlignment,
+        &sample_records(RadProfile::SelectiveAlignment),
+        ChunkCodec::None,
+    );
+
+    assert!(
+        path.exists(),
+        "finalize should rename the partial into place"
+    );
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .filter(|n| n.contains(".partial-"))
+        .collect();
+    assert!(leftovers.is_empty(), "partial left behind: {leftovers:?}");
+
+    let flags = match read_file_tag(&path, salmon_rad::BAKED_FLAGS_TAG) {
+        TagValue::U8(v) => v,
+        other => panic!("baked_flags should be a u8, got {other:?}"),
+    };
+    assert_ne!(
+        flags & salmon_rad::WRITE_COMPLETE,
+        0,
+        "a finalized file should carry the confirmatory completeness bit"
+    );
 }

--- a/crates/salmon-rad/tests/roundtrip.rs
+++ b/crates/salmon-rad/tests/roundtrip.rs
@@ -11,6 +11,23 @@ use salmon_rad::{
     RadOutputWriter, RadProfile, SalmonBulkContext, SalmonBulkRecord, FRAG_LEN_UNPAIRED,
 };
 
+/// Writer provenance standing in for a mapping pass, so the round-trip covers
+/// the provenance tags rather than only the shapes that omit them.
+fn test_prov() -> salmon_rad::WriterProvenance {
+    salmon_rad::WriterProvenance {
+        mapping_type: salmon_rad::MappingType::Mapping,
+        index: Some(salmon_rad::IndexProvenance {
+            seq_hash: "seqhash".into(),
+            name_hash: "namehash".into(),
+            seq_hash512: "seqhash512".into(),
+            name_hash512: "namehash512".into(),
+            decoy_seq_hash: String::new(),
+            decoy_name_hash: String::new(),
+            keep_duplicates: false,
+        }),
+    }
+}
+
 fn sample_records(profile: RadProfile) -> Vec<SalmonBulkRecord> {
     let score = |s: i32| if profile.has_scores() { s } else { 0 };
     vec![
@@ -61,7 +78,17 @@ fn write_file_codec(
 ) {
     let names = ["t0", "t1", "t2"];
     let lens = [100u32, 200, 300];
-    let w = RadOutputWriter::create(path, &names, &lens, true, profile, 1024, codec).unwrap();
+    let w = RadOutputWriter::create(
+        path,
+        &names,
+        &lens,
+        true,
+        profile,
+        1024,
+        codec,
+        &test_prov(),
+    )
+    .unwrap();
     let ctx: SalmonBulkContext = *w.context();
     let mut cb = FragmentChunkBuf::with_capacity_codec(1024, codec);
     for r in recs {
@@ -202,6 +229,7 @@ fn concurrent_writer_counts_chunks() {
         RadProfile::Sketch,
         1024,
         ChunkCodec::None,
+        &test_prov(),
     )
     .unwrap();
     let ctx: SalmonBulkContext = *w.context();
@@ -254,6 +282,7 @@ fn abandoned_write_never_claims_the_final_path() {
         RadProfile::SelectiveAlignment,
         1024,
         ChunkCodec::None,
+        &test_prov(),
     )
     .unwrap();
     let ctx: SalmonBulkContext = *w.context();
@@ -314,4 +343,96 @@ fn finalize_renames_and_marks_complete() {
         0,
         "a finalized file should carry the confirmatory completeness bit"
     );
+}
+
+/// A requant can only reproduce the mapping run's `meta_info.json` if the RAD
+/// records what the mapping pass *saw*, which its records cannot show: a RAD
+/// holds only the fragments that mapped.
+#[test]
+fn mapping_pass_provenance_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.rad");
+    let names = ["t0", "t1", "t2"];
+    let lens = [100u32, 200, 300];
+
+    let mut w = RadOutputWriter::create(
+        &path,
+        &names,
+        &lens,
+        true,
+        RadProfile::SelectiveAlignment,
+        1024,
+        ChunkCodec::None,
+        &test_prov(),
+    )
+    .unwrap();
+    let ctx: SalmonBulkContext = *w.context();
+    let mut cb = FragmentChunkBuf::with_capacity_codec(1024, ChunkCodec::None);
+    for r in &sample_records(RadProfile::SelectiveAlignment) {
+        cb.write(r, &ctx).unwrap();
+    }
+    w.append_chunk_bytes(&cb.take_bytes().unwrap()).unwrap();
+    // Only two of these fragments were written, out of ten the pass observed.
+    w.set_map_counters(salmon_rad::MapCounters {
+        num_processed: 10,
+        num_dovetail: 3,
+        num_filtered_vm: 4,
+        num_below_threshold_vm: 5,
+        num_decoy_fragments: 6,
+    });
+    w.finalize().unwrap();
+
+    let u64_tag = |name: &str| match read_file_tag(&path, name) {
+        TagValue::U64(v) => v,
+        other => panic!("{name} should be a u64, got {other:?}"),
+    };
+    assert_eq!(u64_tag(salmon_rad::NUM_PROCESSED_TAG), 10);
+    assert_eq!(u64_tag(salmon_rad::NUM_DOVETAIL_TAG), 3);
+    assert_eq!(u64_tag(salmon_rad::NUM_FILTERED_VM_TAG), 4);
+    assert_eq!(u64_tag(salmon_rad::NUM_BELOW_THRESH_VM_TAG), 5);
+    assert_eq!(u64_tag(salmon_rad::NUM_DECOY_FRAGMENTS_TAG), 6);
+
+    let flags = match read_file_tag(&path, salmon_rad::BAKED_FLAGS_TAG) {
+        TagValue::U8(v) => v,
+        other => panic!("baked_flags should be a u8, got {other:?}"),
+    };
+    assert_ne!(flags & salmon_rad::BAKED_MAP_COUNTERS, 0);
+    assert_ne!(flags & salmon_rad::BAKED_INDEX_PROV, 0);
+
+    match read_file_tag(&path, salmon_rad::INDEX_SEQ_HASH_TAG) {
+        TagValue::String(v) => assert_eq!(v, "seqhash"),
+        other => panic!("index_seq_hash should be a string, got {other:?}"),
+    }
+    match read_file_tag(&path, salmon_rad::MAPPING_TYPE_TAG) {
+        TagValue::String(v) => assert_eq!(v, "mapping"),
+        other => panic!("mapping_type should be a string, got {other:?}"),
+    }
+}
+
+/// A writer that records no counters must leave the flag clear, so a reader can
+/// tell "the pass observed none of these" from "nobody filled the slot" — the
+/// slots are reserved as zeros, so the values alone cannot say.
+#[test]
+fn unbaked_counters_are_distinguishable_from_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.rad");
+    write_file_codec(
+        &path,
+        RadProfile::SelectiveAlignment,
+        &sample_records(RadProfile::SelectiveAlignment),
+        ChunkCodec::None,
+    );
+    let flags = match read_file_tag(&path, salmon_rad::BAKED_FLAGS_TAG) {
+        TagValue::U8(v) => v,
+        other => panic!("baked_flags should be a u8, got {other:?}"),
+    };
+    assert_eq!(
+        flags & salmon_rad::BAKED_MAP_COUNTERS,
+        0,
+        "counters were never set, so the flag must stay clear"
+    );
+    assert!(matches!(
+        read_file_tag(&path, salmon_rad::NUM_PROCESSED_TAG),
+        TagValue::U64(0)
+    ));
 }

--- a/crates/salmon-rad/tests/roundtrip.rs
+++ b/crates/salmon-rad/tests/roundtrip.rs
@@ -23,8 +23,9 @@ fn test_prov() -> salmon_rad::WriterProvenance {
             name_hash512: "namehash512".into(),
             decoy_seq_hash: String::new(),
             decoy_name_hash: String::new(),
-            keep_duplicates: false,
+            keep_duplicates: Some(false),
         }),
+        source_programs: vec![],
     }
 }
 
@@ -126,6 +127,12 @@ fn read_all(
 
 /// Read one file tag by name from a written RAD file.
 fn read_file_tag(path: &std::path::Path, name: &str) -> TagValue {
+    read_file_tag_opt(path, name).unwrap_or_else(|| panic!("missing file tag {name}"))
+}
+
+/// Like `read_file_tag`, but `None` when the tag is absent — the distinction the
+/// unknown-vs-false cases turn on.
+fn read_file_tag_opt(path: &std::path::Path, name: &str) -> Option<TagValue> {
     let mut data = Vec::new();
     std::fs::File::open(path)
         .unwrap()
@@ -134,7 +141,7 @@ fn read_file_tag(path: &std::path::Path, name: &str) -> TagValue {
     let mut rc = Cursor::new(data);
     let prelude = RadPrelude::from_bytes(&mut rc).unwrap();
     let ftm = prelude.file_tags.parse_tags_from_bytes(&mut rc).unwrap();
-    ftm.get(name).unwrap().clone()
+    ftm.get(name).cloned()
 }
 
 fn check_roundtrip(profile: RadProfile, expected_detect: RadInputProfile) {
@@ -435,4 +442,84 @@ fn unbaked_counters_are_distinguishable_from_zero() {
         read_file_tag(&path, salmon_rad::NUM_PROCESSED_TAG),
         TagValue::U64(0)
     ));
+}
+
+/// `keep_duplicates` must survive as three distinct states, not two: an index
+/// that predates recording it is *unknown*, and reporting that as `false` would
+/// state as fact something no one observed.
+#[test]
+fn unknown_keep_duplicates_is_not_written_as_false() {
+    for (keep, expect_tag) in [
+        (Some(true), Some(1u8)),
+        (Some(false), Some(0)),
+        (None, None),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.rad");
+        let mut prov = test_prov();
+        prov.index.as_mut().unwrap().keep_duplicates = keep;
+
+        let w = RadOutputWriter::create(
+            &path,
+            &["t0", "t1", "t2"],
+            &[100u32, 200, 300],
+            true,
+            RadProfile::SelectiveAlignment,
+            1024,
+            ChunkCodec::None,
+            &prov,
+        )
+        .unwrap();
+        w.finalize().unwrap();
+
+        let got = match read_file_tag_opt(&path, salmon_rad::KEEP_DUPLICATES_TAG) {
+            Some(TagValue::U8(v)) => Some(v),
+            None => None,
+            other => panic!("keep_duplicates should be a u8 or absent, got {other:?}"),
+        };
+        assert_eq!(got, expect_tag, "for keep_duplicates = {keep:?}");
+    }
+}
+
+/// A BAM-derived RAD carries the aligner's `@PG` chain verbatim, so a requant
+/// can report how the alignments were produced rather than only that they were
+/// alignments. Tab-separated fields must survive the join/split round trip.
+#[test]
+fn source_programs_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.rad");
+    let lines = vec![
+        "@PG\tID:bowtie2\tPN:bowtie2\tVN:2.4.5\tCL:bowtie2-align-s --wrapper basic-0 -x idx"
+            .to_string(),
+        "@PG\tID:samtools\tPN:samtools\tPP:bowtie2\tVN:1.17\tCL:samtools view -b".to_string(),
+    ];
+    let prov = salmon_rad::WriterProvenance {
+        mapping_type: salmon_rad::MappingType::Alignment,
+        index: None,
+        source_programs: lines.clone(),
+    };
+    let w = RadOutputWriter::create(
+        &path,
+        &["t0", "t1", "t2"],
+        &[100u32, 200, 300],
+        true,
+        RadProfile::SelectiveAlignment,
+        1024,
+        ChunkCodec::None,
+        &prov,
+    )
+    .unwrap();
+    w.finalize().unwrap();
+
+    match read_file_tag(&path, salmon_rad::SOURCE_PROGRAMS_TAG) {
+        TagValue::String(v) => {
+            let got: Vec<&str> = v.split('\n').collect();
+            assert_eq!(got, lines, "the @PG chain must survive verbatim");
+        }
+        other => panic!("source_programs should be a string, got {other:?}"),
+    }
+    match read_file_tag(&path, salmon_rad::MAPPING_TYPE_TAG) {
+        TagValue::String(v) => assert_eq!(v, "alignment"),
+        other => panic!("mapping_type should be a string, got {other:?}"),
+    }
 }

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -288,8 +288,9 @@ Three salmon-relevant details on top of the base format:
   | `num_alignments_below_threshold_vm` | below-threshold alignments among mapped fragments |
   | `num_decoy_fragments` | fragments whose best mapping was to a decoy |
   | `index_seq_hash`, `index_name_hash`, and the `512` / `decoy` variants | identity of the index the mappings were made against |
-  | `keep_duplicates` | how that index was built |
+  | `keep_duplicates` | how that index was built (omitted if the index predates recording it) |
   | `mapping_type` | `mapping`, `pseudo` or `alignment` |
+  | `source_programs` | the source BAM's `@PG` lines, verbatim, for an alignment-derived RAD |
 
   The counters are only final at end of pass, so their slots are reserved and
   backpatched at finalize; the `BAKED_MAP_COUNTERS` bit in `baked_flags` says
@@ -300,10 +301,14 @@ Three salmon-relevant details on top of the base format:
   selective-alignment profile although its fragments came from an aligner.
 
   Quantifying a RAD that lacks these — a piscem RAD, or one written by salmon
-  before 2.5.0 — still works. salmon warns, names the affected fields, and sets
-  `meta_info_complete: false` in `meta_info.json` with the list repeated in
-  `incomplete_meta_info_fields`, so a result read long after the run still says
-  which of its numbers are placeholders.
+  before 2.5.0 — still works. salmon warns, names the affected fields, and
+  records the gap in `meta_info.json` (see below).
+
+- **Alignment provenance.** A RAD built from a BAM carries that BAM's `@PG`
+  header chain verbatim, so a requant can report *how* the alignments were made
+  — the aligner, its version and its command line — rather than only that they
+  were alignments. It reappears as `alignment_provenance` in `meta_info.json`,
+  for both `-a` and a requant of a BAM-derived RAD.
 - **Chunk compression (`chunk_codec`).** With compression enabled (the default;
   see `--radCompress`), each chunk's record payload is compressed independently
   and the `nbytes` field is the **compressed** size; the uncompressed size is
@@ -312,6 +317,31 @@ Three salmon-relevant details on top of the base format:
   (uncompressed)**, so every RAD produced before this feature, and every piscem
   RAD, reads as uncompressed automatically. Decompression happens in the reader,
   so record parsing downstream is identical for compressed and uncompressed RADs.
+
+### Metadata completeness
+
+Every `meta_info.json` carries `meta_info_complete`. When `false`,
+`incomplete_meta_info_fields` lists each field a complete description would have
+carried, together with the upstream that could not supply it and why:
+
+```json
+"meta_info_complete": false,
+"incomplete_meta_info_fields": [
+  {
+    "field": "keep_duplicates",
+    "source": "index",
+    "reason": "this index predates recording how it was built; rebuild the index to record it"
+  }
+]
+```
+
+`source` is `index`, `rad` or `bam`. The point is to distinguish "this run
+observed nothing" from "nobody could tell this run", and to name what to fix.
+Fields that are *not applicable* are not listed: alignment mode has no salmon
+index, so its absent index hashes are by design rather than a gap.
+
+Values that are unknown are omitted rather than guessed, so `keep_duplicates`
+being absent means exactly that — not `false`.
 
 ## Mapping alignment output
 

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -290,7 +290,7 @@ Three salmon-relevant details on top of the base format:
   | `index_seq_hash`, `index_name_hash`, and the `512` / `decoy` variants | identity of the index the mappings were made against |
   | `keep_duplicates` | how that index was built (omitted if the index predates recording it) |
   | `mapping_type` | `mapping`, `pseudo` or `alignment` |
-  | `source_programs` | the source BAM's `@PG` lines, verbatim, for an alignment-derived RAD |
+  | `source_programs` | the source BAM's `@PG` lines, for an alignment-derived RAD |
 
   The counters are only final at end of pass, so their slots are reserved and
   backpatched at finalize; the `BAKED_MAP_COUNTERS` bit in `baked_flags` says
@@ -305,10 +305,19 @@ Three salmon-relevant details on top of the base format:
   records the gap in `meta_info.json` (see below).
 
 - **Alignment provenance.** A RAD built from a BAM carries that BAM's `@PG`
-  header chain verbatim, so a requant can report *how* the alignments were made
+  header chain, so a requant can report *how* the alignments were made
   — the aligner, its version and its command line — rather than only that they
   were alignments. It reappears as `alignment_provenance` in `meta_info.json`,
   for both `-a` and a requant of a BAM-derived RAD.
+
+  The chain is stored as one string tag holding the `@PG` lines joined by
+  newlines. RAD imposes no restriction on the content — a string tag is an
+  explicit length followed by bytes — so the only constraints come from that
+  representation, and both are handled rather than assumed away: tabs, newlines
+  and backslashes inside a value are escaped so the framing stays unambiguous and
+  reversible, and because the length prefix is a `u16`, a chain longer than 64 KiB
+  has whole trailing records dropped (with a warning) rather than being allowed to
+  wrap the length and corrupt the file.
 - **Chunk compression (`chunk_codec`).** With compression enabled (the default;
   see `--radCompress`), each chunk's record payload is compressed independently
   and the `nbytes` field is the **compressed** size; the uncompressed size is

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -267,7 +267,7 @@ sequence of `[u32 nbytes][u32 nrec][records…]` chunks) is libradicl's contract
 salmon writes a bulk profile that piscem `map-bulk` can also produce and read.
 See the [RAD I/O guide](../../guides/rad-and-determinism/) for usage.
 
-Two salmon-relevant details on top of the base format:
+Three salmon-relevant details on top of the base format:
 
 - **Baked header tags.** A salmon-written RAD records, as file-level tags, an
   order-independent fragment-length distribution, initial abundances, and the
@@ -275,6 +275,35 @@ Two salmon-relevant details on top of the base format:
   these to quantify in a single pass and to apply `-l A` concordance filtering
   without re-inference; a piscem RAD carries none of them and is handled with an
   extra derivation pass.
+- **Mapping-pass provenance.** A RAD holds only the fragments that *mapped*, so
+  nothing in the records can say how many were *observed*. Without that, a
+  requant reports a 100% mapping rate by construction. salmon therefore records
+  what its mapping pass saw, as file-level tags:
+
+  | tag | meaning |
+  | --- | --- |
+  | `num_processed` | fragments observed, mapped or not |
+  | `num_dovetail_fragments` | fragments whose mappings were dovetailed |
+  | `num_fragments_filtered_vm` | fragments dropped by the score filter |
+  | `num_alignments_below_threshold_vm` | below-threshold alignments among mapped fragments |
+  | `num_decoy_fragments` | fragments whose best mapping was to a decoy |
+  | `index_seq_hash`, `index_name_hash`, and the `512` / `decoy` variants | identity of the index the mappings were made against |
+  | `keep_duplicates` | how that index was built |
+  | `mapping_type` | `mapping`, `pseudo` or `alignment` |
+
+  The counters are only final at end of pass, so their slots are reserved and
+  backpatched at finalize; the `BAKED_MAP_COUNTERS` bit in `baked_flags` says
+  they were filled, since a reserved slot and a genuine count of zero are
+  otherwise indistinguishable. The index identity is known up front and written
+  directly, flagged by `BAKED_INDEX_PROV`. `mapping_type` is recorded rather than
+  inferred from the record profile, because a BAM-derived RAD is written in the
+  selective-alignment profile although its fragments came from an aligner.
+
+  Quantifying a RAD that lacks these — a piscem RAD, or one written by salmon
+  before 2.5.0 — still works. salmon warns, names the affected fields, and sets
+  `meta_info_complete: false` in `meta_info.json` with the list repeated in
+  `incomplete_meta_info_fields`, so a result read long after the run still says
+  which of its numbers are placeholders.
 - **Chunk compression (`chunk_codec`).** With compression enabled (the default;
   see `--radCompress`), each chunk's record payload is compressed independently
   and the `nbytes` field is the **compressed** size; the uncompressed size is

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -337,6 +337,13 @@ carried, together with the upstream that could not supply it and why:
 
 `source` is `index`, `rad` or `bam`. The point is to distinguish "this run
 observed nothing" from "nobody could tell this run", and to name what to fix.
+
+`@PG` is optional in SAM and many tools write none, so an alignment input with no
+`@PG` chain is an ordinary outcome rather than an error — but it is still recorded
+(`alignment_provenance`, source `bam`), as is a chain that names its programs
+without carrying any `CL` field
+(`alignment_provenance[].command_line`). Both are reported identically whether
+the alignments are read from a BAM directly or through a BAM-derived RAD.
 Fields that are *not applicable* are not listed: alignment mode has no salmon
 index, so its absent index hashes are by design rather than a gap.
 


### PR DESCRIPTION
Follow-up to the three-way counter run in #1105. **Stacked on #1106** — it touches the same writer, so review that one first; the diff here will shrink once it merges.

## The problem

A RAD holds only the fragments that *mapped*, so nothing in the records can say how many were *seen*. Measured on 10M human fragments:

| | num_processed | num_mapped | percent_mapped |
|---|---|---|---|
| online (reads) | 10,000,000 | 9,221,625 | 92.22% |
| `--deterministic --writeRad` | 9,221,625 | 9,221,625 | **100.00%** |
| `--rad` input | 9,221,625 | 9,221,625 | **100.00%** |

`--deterministic` is the worse of the two, because it *knew*:

```
deterministic: mapped 9221625 / 10000000 fragments (92.22%); quantifying from intermediate RAD
...
9221625 fragments from intermediate RAD, 9221625 quantified (100.00%)
```

It computes the true rate, logs it, then quantifies through the intermediate RAD and lets that pass's counters overwrite it.

The structural cause is a second, cut-down `MetaInfo` in `salmon-align`, written for `-a` BAM mode where "no index hashes since there is no index" is true — then reused by the `--rad` path, where it isn't. Hence empty index hashes and absent `keep_duplicates` / `num_orphan`.

## What is recorded

Two groups, by when they become known. Index identity and `mapping_type` are known before the first record, so they are written outright; the five counters are only final at end of pass, so their slots are reserved and backpatched at finalize, exactly like the FLD.

| tag | why it cannot be derived |
| --- | --- |
| `num_processed` | the root cause; every mapping-rate figure depends on it |
| `num_dovetail_fragments` | a property of the pass, not of its output |
| `num_fragments_filtered_vm` | filtered fragments were never written |
| `num_alignments_below_threshold_vm` | same |
| `num_decoy_fragments` | decoys are filtered before write |
| `index_*_hash`, `keep_duplicates` | the `--rad` path loads no index at all |
| `mapping_type` | not inferable from the profile (below) |

Two `baked_flags` bits (`BAKED_MAP_COUNTERS`, `BAKED_INDEX_PROV`) say the values are real — a reserved slot and a genuine count of zero are otherwise indistinguishable. A test caught that I had defined the second bit but never set it; since the reader gates on it, the index tags would have been written and then silently ignored.

`mapping_type` is recorded rather than inferred from the record profile because the two disagree: a BAM-derived RAD is written in the selective-alignment profile although its fragments came from an aligner.

`num_orphan` is deliberately **not** baked. Fragment type is in the records (`LEFT_ORPHAN`/`RIGHT_ORPHAN` is exactly the mapping pass's `PairedEndLeft|PairedEndRight`), so it is counted on read and works for a piscem RAD too. That also fixes `lib_format_counts.json`, which the RAD path never wrote at all and which `--deterministic` filled with every mapped fragment counted as concordant — `record_discrete` never tallied orphans.

## When the RAD does not carry it

The run proceeds — refusing to quantify a piscem RAD over reporting metadata would be a poor trade. It warns, naming the affected fields, and `meta_info.json` records the same thing durably:

```json
"meta_info_complete": false,
"incomplete_meta_info_fields": ["num_processed", "percent_mapped", ...]
```

so a result read long after the run still says which of its numbers are placeholders. The reads path always reports `true`.

## Verification

On 10M human fragments, against a RAD written by this build:

- `--rad` requant vs the online mapping run: **identical on all 40 comparable fields**
- `--rad` vs `--deterministic`: **identical on all 45** (run identity excluded)
- `percent_mapped` 92.21625 (was 100.0); `num_processed` 10,000,000 (was 9,221,625); index hashes, `mapping_type: mapping`, `num_orphan: 623154` all recovered
- `lib_format_counts.json` now agrees across all three: concordant 8,598,471 / orphan 623,154 / format IU

The five remaining online-vs-requant differences are genuine online/deterministic inference differences (FLD mean/sd/source, eq-class count, EM iterations), not lost data.

Control: quantifying a RAD written *before* this change warns as designed, sets `meta_info_complete: false`, lists all 13 fields — and still recovers `num_orphan` and writes `lib_format_counts.json`, since those come from the records.

`-a` BAM output is unchanged: the recovered fields are `skip_serializing_if` and stay absent rather than being guessed.

`cargo fmt`, `clippy --workspace --all-targets -D warnings`, and the full suite are clean; four new round-trip tests in `salmon-rad`.

## Noted, not fixed here

`keep_duplicates` is hardcoded `false` on **every** path, including reads mode, because `info.json` does not persist it. This carries through faithfully whatever the mapping run reported; making it truthful is an index-format change and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKxqH6k1sbmDC1bpNso3zr