### PR TITLE
chore(deps): take libradicl 0.17 and let it own the tag-length limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "libradicl"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94299a663c37ed5a8ad1d759cae19af9b9bbd520aa90d8997457efe2bb5bd5ce"
+checksum = "7518c918544220380ff5ff33b243771a8757872150dd280e6cc9355cddf3043b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1641,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "libradicl-macros"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9705ac0ed56e352381bec395e8822831b922f32a3857b04edf04017e912cb5a4"
+checksum = "9974b750aed4376bb9e67feede0446f5fbba1f3bcf398bf155e5ddee34828824"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ cf1-rs = "0.5"
 piscem-rs = "0.6.4"
 # RAD-format I/O (chunk compression + backpatchable file tags); the `zstd`
 # feature enables zstd-compressed RAD chunks (lz4 is always available).
-libradicl = { version = "0.16", features = ["zstd"] }
+libradicl = { version = "0.17", features = ["zstd"] }
 
 # dev / test helpers
 tempfile = "3"

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -1559,25 +1559,31 @@ pub fn source_program_lines(header: &noodles_sam::Header) -> Vec<String> {
         })
         .collect();
 
-    // A RAD string tag is length-prefixed with a `u16`, and that length is cast
-    // rather than checked, so an over-long value wraps and corrupts the file
-    // instead of failing. Drop whole trailing records until the chain fits: a
-    // shortened chain is a poor outcome, an unreadable RAD a far worse one.
-    while !lines.is_empty() && joined_len(&lines) > salmon_rad::MAX_FILE_TAG_STRING_LEN {
+    // libradicl bounds an over-long tag value rather than letting it wrap the
+    // length field, but it bounds by *bytes*, which here would cut a record in
+    // half and leave a `@PG` line whose command is silently wrong. Dropping whole
+    // trailing records instead keeps every record that survives intact and
+    // truthful, so ask whether the chain fits and shorten it ourselves.
+    while !lines.is_empty() && !chain_fits(&lines) {
         let dropped = lines.pop().unwrap_or_default();
         tracing::warn!(
-            "the @PG chain is longer than the {} bytes a RAD string tag holds; \
-             dropping its trailing record ({}...) so the file stays readable",
-            salmon_rad::MAX_FILE_TAG_STRING_LEN,
+            "the @PG chain is longer than a RAD string tag can hold; dropping its \
+             trailing record ({}...) so no record is left half-written",
             dropped.chars().take(60).collect::<String>()
         );
     }
     lines
 }
 
-/// Length of the newline-joined form the RAD tag actually stores.
-fn joined_len(lines: &[String]) -> usize {
-    lines.iter().map(String::len).sum::<usize>() + lines.len().saturating_sub(1)
+/// Whether the joined `@PG` chain fits a RAD string tag.
+///
+/// Asks the format rather than restating its width: the limit belongs to
+/// libradicl, and hard-coding it here is how the two would drift.
+fn chain_fits(lines: &[String]) -> bool {
+    salmon_rad::value_fits(
+        &libradicl::rad_types::TagValue::String(lines.join("\n")),
+        &libradicl::rad_types::RadType::String,
+    )
 }
 
 /// Escape the characters that frame the joined `@PG` representation.

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -1067,10 +1067,13 @@ fn overlong_pg_chain_is_trimmed_to_what_a_rad_tag_holds() {
     let header: noodles_sam::Header = sam.parse().unwrap();
     let lines = salmon_align::source_program_lines(&header);
 
-    let joined_len = lines.iter().map(String::len).sum::<usize>() + lines.len().saturating_sub(1);
+    // Asks libradicl, so the test cannot drift from the format's actual limit.
     assert!(
-        joined_len <= salmon_rad::MAX_FILE_TAG_STRING_LEN,
-        "the joined chain ({joined_len} bytes) must fit a u16 length"
+        salmon_rad::value_fits(
+            &libradicl::rad_types::TagValue::String(lines.join("\n")),
+            &libradicl::rad_types::RadType::String,
+        ),
+        "the joined chain must fit what a RAD string tag can hold"
     );
     assert!(
         !lines.is_empty() && lines.len() < 8,

--- a/crates/salmon-rad/src/lib.rs
+++ b/crates/salmon-rad/src/lib.rs
@@ -46,6 +46,7 @@ pub mod record;
 pub mod schema;
 pub mod writer;
 
+use libradicl::rad_types::{RadType, TagValue};
 /// Re-exported so consumers can select a RAD chunk compression codec without a
 /// direct libradicl dependency.
 pub use libradicl::ChunkCodec;
@@ -241,12 +242,17 @@ pub const INDEX_DECOY_NAME_HASH_TAG: &str = "index_decoy_name_hash";
 /// Written only when the index actually recorded it; absent means unknown,
 /// which a reader must not collapse to `false`.
 pub const KEEP_DUPLICATES_TAG: &str = "keep_duplicates";
-/// The longest string a RAD file tag can hold.
+/// Whether `value` can be written under `tag_type` without being shortened.
 ///
-/// A string tag is written as a `u16` length followed by its bytes, and that
-/// length is cast rather than checked, so anything longer wraps and corrupts the
-/// file rather than failing to write. Producers must fit their values to this.
-pub const MAX_FILE_TAG_STRING_LEN: usize = u16::MAX as usize;
+/// A thin pass-through to [`libradicl::rad_types::TagValue::fits`], re-exported
+/// so producers here ask the format how much it can hold rather than restating a
+/// width that is libradicl's to know. Since 0.17 an over-long value is bounded
+/// rather than allowed to wrap the length field, but bounding is silent, so a
+/// producer that would rather shorten deliberately — dropping whole records
+/// instead of cutting one in half — asks first.
+pub fn value_fits(value: &TagValue, tag_type: &RadType) -> bool {
+    value.fits(tag_type)
+}
 
 /// File-tag name: the `@PG` header records of the BAM these fragments came from,
 /// verbatim, one per line.


### PR DESCRIPTION
0.17 carries the two fixes we asked for upstream (COMBINE-lab/libradicl#50, PRs #51 and #52): an over-long tag value is bounded rather than allowed to wrap its length field and desynchronize the stream, and the `_reporting` writers return a `#[must_use]` outcome so a silent shortening has to be acknowledged.

## What changes here

With the format able to answer for itself, salmon stops restating the limit.

- `salmon_rad::MAX_FILE_TAG_STRING_LEN` — a `u16::MAX` this crate had no business knowing — is replaced by `salmon_rad::value_fits`, a pass-through to `TagValue::fits`
- the `@PG` bounding loop asks that instead of comparing against a hard-coded width
- the test asks it too, so it cannot drift from the format either

## Why the chain is still shortened here

Worth stating, since the upstream fix might look like it makes this redundant: libradicl bounds by **bytes**, which for a newline-joined `@PG` chain would cut a record in half and leave a line whose command is silently wrong. Dropping whole trailing records keeps every record that survives intact and truthful.

So the upstream fix is the **backstop** — it guarantees no producer can corrupt a file — and the record-wise shortening is the **mechanism** for this particular payload. They are not alternatives.

## Verification

- **RAD output is byte-identical** across the bump (same `md5` writing the same input under 0.16 and 0.17), so nothing about what salmon emits has moved
- full suite, `clippy --workspace --all-targets -D warnings` and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKxqH6k1sbmDC1bpNso3zr