### PR TITLE
perf(map): drop the per-fragment and per-call maps from the hot paths

### DIFF
--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -2197,7 +2197,12 @@ mod group_tests {
     /// `push_sorted` skips the comparison, so it is only correct when something
     /// upstream ordered the input. The `debug_assert` is what holds a caller to
     /// that promise rather than silently mis-grouping the fragment.
+    // `debug_assert!` compiles out under `--release`, which is how CI runs the
+    // suite, so this can only ever pass where debug assertions are live. Gating
+    // it is the point of the assert: it is a development-time guard, not a
+    // runtime check the release build pays for.
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "out-of-order placement")]
     fn push_sorted_rejects_an_out_of_order_placement() {
         let mut o: TidOrdered<CorePlacement> = TidOrdered::default();

--- a/crates/salmon-map/src/collect.rs
+++ b/crates/salmon-map/src/collect.rs
@@ -32,7 +32,7 @@
 //! anchors increase colinearly with the reference coordinate. The resulting
 //! chains are stamped with `is_fw = false` so a later stage can map them back.
 
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
 
 use piscem_rs::index::contig_table::EntryEncoding;
 use piscem_rs::index::reference_index::ReferenceIndex;
@@ -224,8 +224,23 @@ pub fn best_per_target(mut candidates: Vec<MappingCandidate>) -> Vec<MappingCand
             .covered_read_bases()
             .cmp(&a.chain.covered_read_bases())
     });
-    let mut seen = AHashSet::new();
-    candidates.retain(|c| seen.insert((c.tid, c.is_fw)));
+    // Keep the first candidate seen per `(tid, is_fw)`, scanning the already-kept
+    // prefix rather than building a hash set.
+    //
+    // The set was allocated and dropped on every call to deduplicate a handful of
+    // candidates; at this size a linear scan over what has been kept is cheaper
+    // than hashing each key, and needs no allocation and no scratch parameter.
+    // The kept elements stay in their original relative order, so the
+    // highest-coverage-first ordering established above survives.
+    let mut kept = 0usize;
+    for i in 0..candidates.len() {
+        let key = (candidates[i].tid, candidates[i].is_fw);
+        if candidates[..kept].iter().all(|c| (c.tid, c.is_fw) != key) {
+            candidates.swap(i, kept);
+            kept += 1;
+        }
+    }
+    candidates.truncate(kept);
     candidates
 }
 

--- a/crates/salmon-map/src/lib.rs
+++ b/crates/salmon-map/src/lib.rs
@@ -72,7 +72,9 @@ pub use mapper::{
 pub use mem::Mem;
 pub use pair::{join_reads_and_filter, JointMapping, PairingConfig};
 pub use salmon_core::RefProvider;
-pub use score::{filter_sketch_decoys, finalize_mappings, RawMapping, ScoreConfig, ScoredMapping};
+pub use score::{
+    filter_sketch_decoys, finalize_mappings, DedupScratch, RawMapping, ScoreConfig, ScoredMapping,
+};
 pub use sketch::{
     map_read_pair_sketch, map_read_pair_sketch_into, map_single_read_sketch,
     map_single_read_sketch_into, SketchScratch,

--- a/crates/salmon-map/src/mapper.rs
+++ b/crates/salmon-map/src/mapper.rs
@@ -48,7 +48,9 @@ pub enum SeedMode {
     UniMem,
 }
 use crate::pair::{join_reads_and_filter, PairingConfig};
-use crate::score::{finalize_mappings_counted_into, RawMapping, ScoreConfig, ScoredMapping};
+use crate::score::{
+    finalize_mappings_counted_into, DedupScratch, RawMapping, ScoreConfig, ScoredMapping,
+};
 use salmon_core::RefProvider;
 
 /// Full mapper configuration.
@@ -143,7 +145,15 @@ pub fn map_single_read<'idx, R: RefProvider>(
     cfg: &MapConfig,
 ) -> Vec<ScoredMapping> {
     let mut out = Vec::new();
-    map_single_read_into(&mut out, index, hs, refs, read, cfg);
+    map_single_read_into(
+        &mut out,
+        index,
+        hs,
+        refs,
+        read,
+        cfg,
+        &mut DedupScratch::default(),
+    );
     out
 }
 
@@ -156,6 +166,7 @@ pub fn map_single_read_into<'idx, R: RefProvider>(
     refs: &R,
     read: &[u8],
     cfg: &MapConfig,
+    scratch: &mut DedupScratch,
 ) {
     let cands = consensus_filter(
         best_per_target(collect_candidates(
@@ -216,7 +227,8 @@ pub fn map_single_read_into<'idx, R: RefProvider>(
             below += 1;
         }
     }
-    let (decoy_dominated, below_final) = finalize_mappings_counted_into(out, raw, &cfg.score);
+    let (decoy_dominated, below_final) =
+        finalize_mappings_counted_into(out, raw, &cfg.score, scratch);
     set_last_map_stats(MapStats {
         had_candidates,
         decoy_dominated,
@@ -235,7 +247,16 @@ pub fn map_read_pair<'idx, R: RefProvider>(
     cfg: &MapConfig,
 ) -> Vec<ScoredMapping> {
     let mut out = Vec::new();
-    map_read_pair_into(&mut out, index, hs, refs, r1, r2, cfg);
+    map_read_pair_into(
+        &mut out,
+        index,
+        hs,
+        refs,
+        r1,
+        r2,
+        cfg,
+        &mut DedupScratch::default(),
+    );
     out
 }
 
@@ -249,6 +270,7 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
     r1: &[u8],
     r2: &[u8],
     cfg: &MapConfig,
+    scratch: &mut DedupScratch,
 ) {
     let cf = cfg.collect.consensus_fraction;
     // NOTE: deliberately do NOT collapse to one chain per (tid, is_fw) before
@@ -405,7 +427,8 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
     {
         raw.retain(|m| matches!(m.status, MateStatus::PairedEndPaired));
     }
-    let (decoy_dominated, below_final) = finalize_mappings_counted_into(out, raw, &cfg.score);
+    let (decoy_dominated, below_final) =
+        finalize_mappings_counted_into(out, raw, &cfg.score, scratch);
     set_last_map_stats(MapStats {
         had_candidates,
         decoy_dominated,

--- a/crates/salmon-map/src/score.rs
+++ b/crates/salmon-map/src/score.rs
@@ -24,8 +24,6 @@
 //! equivalence class. This mirrors salmon's `MappingScoreInfo` /
 //! `filterAndCollectAlignments`.
 
-use ahash::AHashMap;
-
 use salmon_core::{LibraryFormat, MateStatus, RefProvider};
 
 /// A validated mapping before final collapse/weighting.
@@ -149,8 +147,98 @@ pub fn finalize_mappings_counted(
     cfg: &ScoreConfig,
 ) -> (Vec<ScoredMapping>, bool, u32) {
     let mut out = Vec::new();
-    let (decoy_dominated, num_below) = finalize_mappings_counted_into(&mut out, raw, cfg);
+    // Allocating variant already, so a fresh scratch costs it nothing relative
+    // to the `Vec` it returns.
+    let (decoy_dominated, num_below) =
+        finalize_mappings_counted_into(&mut out, raw, cfg, &mut DedupScratch::default());
     (out, decoy_dominated, num_below)
+}
+
+/// Above this many raw mappings the prefix scan's `O(k·n)` starts to lose to a
+/// hash table.
+///
+/// Measured (criterion, mappings hitting half as many distinct transcripts): the
+/// scan wins 1.6x at n=60, 1.2x at n=80 and 1.07x at n=100, then loses 1.28x at
+/// n=128 and 1.70x at n=160. 112 is the midpoint of the crossing interval.
+/// Fragments are typically 1 to 20 mappings, so the scan is the normal path and
+/// the table is there to bound the tail — `--maxReadOcc` caps `n`, but well above
+/// where the scan stays cheapest.
+const DEDUP_HASH_THRESHOLD: usize = 112;
+
+// Both paths must stay reachable in a real run: below this a typical fragment
+// (1 to 20 mappings) takes the scan, and above it a `--maxReadOcc`-sized one
+// reaches the table. A threshold outside this range would make one of them dead
+// code that nothing exercises.
+const _: () = assert!(DEDUP_HASH_THRESHOLD > 20 && DEDUP_HASH_THRESHOLD < 200);
+
+/// Reusable table for the large-fragment deduplication path.
+///
+/// Owned by the caller rather than held in a thread-local. Measured on 200
+/// mappings: threading it costs 768ns against 839ns through a `thread_local`
+/// (the lazy-init check and `RefCell` borrow, which a `HashTable` cannot avoid
+/// because it has a `Drop`) and 1468ns allocating a fresh table per fragment.
+/// So reuse is what matters most, and the parameter is worth the ~10% over TLS
+/// given `QuantProcessor` already owns a scratch struct to put it in.
+///
+/// Empty until a fragment exceeds [`DEDUP_HASH_THRESHOLD`], so a run that never
+/// sees one never allocates.
+#[derive(Default)]
+pub struct DedupScratch {
+    table: hashbrown::HashTable<RawMapping>,
+}
+
+/// Fixed seeds: the survivors' order does not affect results, but a stable
+/// hasher keeps a given input hashing the same way from run to run, which makes
+/// this path reproducible if that ever starts to matter.
+fn dedup_hasher() -> ahash::RandomState {
+    ahash::RandomState::with_seeds(0x5119_1B3D, 0xA5F1_2C07, 0x2D4E_9A11, 0x7C3B_60E5)
+}
+
+/// Deduplicate in place by scanning the already-kept prefix. No allocation and
+/// no hashing; best when a fragment has few mappings, which is the usual case.
+fn dedup_by_scan(raw: &mut Vec<RawMapping>) {
+    let mut kept = 0usize;
+    for i in 0..raw.len() {
+        let (tid, score) = (raw[i].tid, raw[i].score);
+        match raw[..kept].iter().position(|m| m.tid == tid) {
+            Some(j) => {
+                if score > raw[j].score {
+                    raw[j] = raw[i];
+                }
+            }
+            None => {
+                raw.swap(i, kept);
+                kept += 1;
+            }
+        }
+    }
+    raw.truncate(kept);
+}
+
+/// Deduplicate through a reused hash table, for fragments with enough mappings
+/// that scanning the kept prefix costs more than hashing each key.
+fn dedup_by_table(raw: &mut Vec<RawMapping>, scratch: &mut DedupScratch) {
+    let state = dedup_hasher();
+    let hash_of = |tid: u32| state.hash_one(tid);
+    let table = &mut scratch.table;
+    table.clear();
+    for &m in raw.iter() {
+        let hv = hash_of(m.tid);
+        match table.find_mut(hv, |e| e.tid == m.tid) {
+            // Strictly greater, so equal scores keep the earlier arrival — the
+            // same tie rule `dedup_by_scan` applies.
+            Some(e) => {
+                if m.score > e.score {
+                    *e = m;
+                }
+            }
+            None => {
+                table.insert_unique(hv, m, |e| hash_of(e.tid));
+            }
+        }
+    }
+    raw.clear();
+    raw.extend(table.iter().copied());
 }
 
 /// Like [`finalize_mappings_counted`] but writes into a caller-provided buffer
@@ -160,6 +248,7 @@ pub fn finalize_mappings_counted_into(
     out: &mut Vec<ScoredMapping>,
     raw: Vec<RawMapping>,
     cfg: &ScoreConfig,
+    scratch: &mut DedupScratch,
 ) -> (bool, u32) {
     out.clear();
     if raw.is_empty() {
@@ -167,30 +256,37 @@ pub fn finalize_mappings_counted_into(
     }
 
     // One mapping per transcript: keep the highest score.
-    let mut best_per_tid: AHashMap<u32, RawMapping> = AHashMap::new();
-    for m in raw {
-        best_per_tid
-            .entry(m.tid)
-            .and_modify(|e| {
-                if m.score > e.score {
-                    *e = m;
-                }
-            })
-            .or_insert(m);
+    //
+    // The tie rule is load-bearing under both strategies below: replace only on a
+    // *strictly* greater score, so among equal scores on one transcript the first
+    // in arrival order survives. Those records carry different positions, so
+    // picking a different one changes the fragment's bias and fragment-length
+    // weights — measured on 10M human fragments, enough to move fragments across
+    // range-factorization bin boundaries and change 55 equivalence classes.
+    //
+    // The *order* of the survivors, by contrast, does not matter: this replaced a
+    // hash map seeded per process (`ahash` `runtime-rng`), and quantification is
+    // byte-identical across runs regardless of the order it yielded them in.
+    let mut raw = raw;
+    if raw.len() <= DEDUP_HASH_THRESHOLD {
+        dedup_by_scan(&mut raw);
+    } else {
+        dedup_by_table(&mut raw, scratch);
     }
+    let best_per_tid = raw;
 
     let best_valid = best_per_tid
-        .values()
+        .iter()
         .filter(|m| !m.is_decoy)
         .map(|m| m.score)
         .max();
-    let had_decoy = best_per_tid.values().any(|m| m.is_decoy);
+    let had_decoy = best_per_tid.iter().any(|m| m.is_decoy);
     let Some(best_valid) = best_valid else {
         // only decoy mappings -> dropped, dominated by a decoy
         return (true, 0);
     };
     let best_decoy = best_per_tid
-        .values()
+        .iter()
         .filter(|m| m.is_decoy)
         .map(|m| m.score)
         .max();
@@ -206,7 +302,7 @@ pub fn finalize_mappings_counted_into(
     let _ = had_decoy;
 
     let mut num_below = 0u32;
-    for m in best_per_tid.into_values().filter(|m| !m.is_decoy) {
+    for m in best_per_tid.into_iter().filter(|m| !m.is_decoy) {
         let weight = if cfg.hard_filter {
             if m.score == best_valid {
                 1.0
@@ -308,6 +404,66 @@ pub fn filter_sketch_decoys<R: RefProvider>(
 
 #[cfg(test)]
 mod tests {
+
+    /// A threshold means two implementations of one rule, so they must agree —
+    /// including on the tie rule, which is what makes the survivors identical
+    /// rather than merely equivalent. Getting that wrong changed 55 equivalence
+    /// classes on a 10M-fragment human run while every sample-data check passed.
+    #[test]
+    fn both_dedup_paths_agree_including_on_ties() {
+        let mk = |tid: u32, score: i32, pos: i32| RawMapping {
+            tid,
+            is_fw: true,
+            status: MateStatus::SingleEnd,
+            score,
+            fragment_len: 0,
+            read_len: 100,
+            is_decoy: false,
+            ref_pos: pos,
+            fw_pos: pos,
+            rc_pos: pos,
+            format: None,
+            r1_pos: pos,
+            r2_pos: -1,
+            r2_fw: false,
+            r1_score: score,
+        };
+        // Deliberately loaded with ties: equal (tid, score) at different
+        // positions, which is precisely where a survivor can differ.
+        let cases: Vec<Vec<RawMapping>> = vec![
+            vec![],
+            vec![mk(1, -1, 10)],
+            vec![mk(1, -1, 10), mk(1, -1, 20)],
+            vec![mk(1, -5, 10), mk(1, -1, 20), mk(1, -5, 30)],
+            vec![mk(3, -2, 1), mk(1, -2, 2), mk(3, -2, 3), mk(1, -9, 4)],
+            (0..250i32)
+                .map(|i| mk((i % 40) as u32, -(i % 7), i))
+                .collect(),
+        ];
+        // One scratch across every case, as a worker reuses it across fragments:
+        // a stale table would show up here.
+        let mut scratch = DedupScratch::default();
+        for case in cases {
+            let (mut a, mut b) = (case.clone(), case.clone());
+            dedup_by_scan(&mut a);
+            dedup_by_table(&mut b, &mut scratch);
+            // Order is not part of the contract, the survivors are.
+            a.sort_by_key(|m| m.tid);
+            b.sort_by_key(|m| m.tid);
+            let key = |v: &[RawMapping]| {
+                v.iter()
+                    .map(|m| (m.tid, m.score, m.ref_pos))
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(
+                key(&a),
+                key(&b),
+                "paths disagreed on {} mappings",
+                case.len()
+            );
+        }
+    }
+
     use super::*;
 
     fn raw(tid: u32, score: i32, is_decoy: bool) -> RawMapping {

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -309,6 +309,9 @@ pub(crate) struct RecordScratch {
     log_fps: CompatAligned<f64>,
     /// `(tid, conditional probability)` before duplicate-tid merging
     pairs: Vec<(u32, f64)>,
+    /// reusable table for deduplicating a fragment with many raw mappings; stays
+    /// empty unless a fragment is large enough to take the mapper's hashed path
+    dedup: salmon_map::DedupScratch,
 }
 
 pub(crate) struct QuantProcessor<'a> {
@@ -716,6 +719,8 @@ fn record(
         bias_w,
         log_fps,
         pairs,
+        // Belongs to the mapping step, not to `record`.
+        dedup: _,
     } = scratch;
 
     // Sample the observed library format for auto-detection (auto mode only).
@@ -1209,6 +1214,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     s1.as_ref(),
                     s2.as_ref(),
                     sh.map_cfg,
+                    &mut scratch.dedup,
                 );
             }
             // Sketch mappings carry no per-hit decoy flag and bypass the
@@ -1362,7 +1368,15 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     sh.max_read_occ,
                 );
             } else {
-                map_single_read_into(&mut placements, idx, hs, sh.salmon, s.as_ref(), sh.map_cfg);
+                map_single_read_into(
+                    &mut placements,
+                    idx,
+                    hs,
+                    sh.salmon,
+                    s.as_ref(),
+                    sh.map_cfg,
+                    &mut scratch.dedup,
+                );
             }
             // Sketch decoy policy (see the paired-end branch): drop decoy tids /
             // decoy-dominated fragments that SA mode handles inside finalize.


### PR DESCRIPTION
Part of #1085 — its map-side half. The quant-side half landed with #1099.

**This is the first change out of this audit with an unambiguous end-to-end win.** 10M human fragments, reads path, `-p 16`, interleaved, warm-up discarded:

| | mean | sd |
| --- | --- | --- |
| develop | 28.845 s | 0.317 |
| this PR | **28.156 s** | 0.218 |

**−0.689 s (−2.39%), t = −5.28**, 95% CI −0.950 … −0.428, faster in **9 of 9 rounds**. Worth stating against the run of nulls in #1092: every other structural item measured |t| ≲ 2 with a CI straddling zero. This one does not.

It is also the size the microbenchmark predicts — dedup runs once per fragment, and at typical n the scan is 7–8× faster than allocating a map (8.2 ns vs 61.0 ns at n=4); ~50 ns × 10M ≈ 0.5 s.

## What changed

**Deduplicating raw mappings by transcript** allocated an `AHashMap` per fragment to handle what is typically 1 to 20 entries. Now a hybrid, split at the measured crossover:

| n / distinct | AHashMap | prefix scan | reused table |
| --- | --- | --- | --- |
| 4 / 4 | 61.0 ns | **8.2** | 38.5 |
| 20 / 12 | 231.5 | **29.1** | 104.7 |
| 60 / 30 | 513.9 | **173.6** | 270.4 |
| 100 / 50 | 851.9 | **399.7** | 429.3 |
| 128 / 64 | 1325 | 752.3 | **586.7** |
| 160 / 80 | 1439 | 1004.5 | **591.5** |

`DEDUP_HASH_THRESHOLD = 112`, the midpoint of the crossing interval, with a `const` assertion that it stays in a range where both paths are reachable in a real run.

**`best_per_target`** allocated an `AHashSet` per call; it now scans the kept prefix in place, preserving both the survivor and the highest-coverage-first ordering.

## The part that took two attempts

The tie rule is load-bearing. The map replaced an entry only on a **strictly** greater score, so among equal scores on one transcript the first in arrival order survived — and those records carry different positions, so a different survivor shifts the fragment's bias and fragment-length weights.

My first attempt sorted by `(tid, score, ref_pos)`. Every `sample_data` check passed, and it **silently changed 55 equivalence classes** on 10M human fragments (407,855 vs 407,800) — small enough to miss, large enough to matter. Only the human-scale byte comparison caught it.

Both paths now apply the original rule, with a test asserting they agree on cases loaded with ties, negative-controlled by flipping the table path to `>=` (fails on a 2-mapping case).

Conversely the survivors' *order* is **not** part of the contract, which is worth recording: the map being replaced was seeded per process (`ahash` `runtime-rng`), and develop is byte-identical across separate runs regardless, so the order it yielded cannot be load-bearing.

## Scratch, not thread-local

`DedupScratch` is threaded through 4 signatures rather than held in a `thread_local`. On 200 mappings:

| | |
| --- | --- |
| threaded parameter | **768 ns** |
| `thread_local` | 839 ns |
| fresh allocation per fragment | 1468 ns |

Reuse is what matters most — allocating on demand is 1.9× worse — and the parameter recovers the remaining ~10% that the lazy-init check and `RefCell` borrow cost (a `HashTable` has a `Drop`, so a bare const-init TLS is not available). `QuantProcessor` already owns a `RecordScratch` from #1099, so it has a natural home; the two convenience wrappers that allocate their own `out` allocate a scratch too, which costs them nothing relative to what they return.

Hashing is `ahash` with fixed seeds. `hashbrown::HashTable` takes the hash from the caller and has no default hasher, so `std`'s SipHash is not reachable here.

## Verification

- `quant.sf` **byte-identical** to develop on 10M human fragments (407,800 eq-classes, 9,221,625 mapped)
- byte-identical on `sample_data` across plain / `--seqBias --gcBias --posBias` / `--softclip` / `--sketch`
- full suite, `clippy --workspace --all-targets -D warnings`, fmt clean

## Not touched

`cfg.chain.clone()`, which #1085 lists among "4 or more Vecs per fragment". `ChainConfig` is `{i32, i32, f32, usize}` — a ~24-byte POD copy, not heap traffic. Same false positive as the `PiscemStreamingQuery` item already withdrawn in that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKxqH6k1sbmDC1bpNso3zr