### PR TITLE
perf(map): reuse the per-fragment raw mapping and revcomp buffers

### DIFF
--- a/crates/salmon-map/src/align.rs
+++ b/crates/salmon-map/src/align.rs
@@ -111,7 +111,7 @@ pub(crate) fn revcomp(s: &[u8]) -> Vec<u8> {
 
 /// Reverse-complement `s` into `out` (cleared first), reusing its allocation.
 #[inline]
-fn revcomp_into(s: &[u8], out: &mut Vec<u8>) {
+pub(crate) fn revcomp_into(s: &[u8], out: &mut Vec<u8>) {
     out.clear();
     out.extend(s.iter().rev().map(|&b| comp(b)));
 }

--- a/crates/salmon-map/src/lib.rs
+++ b/crates/salmon-map/src/lib.rs
@@ -73,7 +73,8 @@ pub use mem::Mem;
 pub use pair::{join_reads_and_filter, JointMapping, PairingConfig};
 pub use salmon_core::RefProvider;
 pub use score::{
-    filter_sketch_decoys, finalize_mappings, DedupScratch, RawMapping, ScoreConfig, ScoredMapping,
+    filter_sketch_decoys, finalize_mappings, DedupScratch, MapScratch, RawMapping, ScoreConfig,
+    ScoredMapping,
 };
 pub use sketch::{
     map_read_pair_sketch, map_read_pair_sketch_into, map_single_read_sketch,

--- a/crates/salmon-map/src/mapper.rs
+++ b/crates/salmon-map/src/mapper.rs
@@ -26,7 +26,7 @@ use piscem_rs::index::reference_index::ReferenceIndex;
 use piscem_rs::mapping::hit_searcher::HitSearcher;
 use salmon_core::{LibraryFormat, MateStatus, ReadOrientation, ReadStrandedness, ReadType};
 
-use crate::align::{align_chain, align_in_window, revcomp, AlignConfig};
+use crate::align::{align_chain, align_in_window, AlignConfig};
 use crate::collect::{
     best_per_target, collect_read_mems, consensus_filter, MappingCandidate, MemCollectorConfig,
 };
@@ -49,7 +49,7 @@ pub enum SeedMode {
 }
 use crate::pair::{join_reads_and_filter, PairingConfig};
 use crate::score::{
-    finalize_mappings_counted_into, DedupScratch, RawMapping, ScoreConfig, ScoredMapping,
+    finalize_mappings_counted_into, MapScratch, RawMapping, ScoreConfig, ScoredMapping,
 };
 use salmon_core::RefProvider;
 
@@ -152,7 +152,7 @@ pub fn map_single_read<'idx, R: RefProvider>(
         refs,
         read,
         cfg,
-        &mut DedupScratch::default(),
+        &mut MapScratch::default(),
     );
     out
 }
@@ -166,7 +166,7 @@ pub fn map_single_read_into<'idx, R: RefProvider>(
     refs: &R,
     read: &[u8],
     cfg: &MapConfig,
-    scratch: &mut DedupScratch,
+    scratch: &mut MapScratch,
 ) {
     let cands = consensus_filter(
         best_per_target(collect_candidates(
@@ -181,7 +181,11 @@ pub fn map_single_read_into<'idx, R: RefProvider>(
     );
     let had_candidates = !cands.is_empty();
     let mut below = 0u32;
-    let mut raw = Vec::with_capacity(cands.len());
+    // Reused across fragments; `finalize_mappings_counted_into` consumes it by
+    // draining, so it comes back empty for the next one.
+    let raw = &mut scratch.raw;
+    raw.clear();
+    raw.reserve(cands.len());
     for c in cands {
         if let Some(aln) = align_chain(read, refs.ref_seq(c.tid), &c.chain, &cfg.align) {
             if aln.valid {
@@ -228,7 +232,7 @@ pub fn map_single_read_into<'idx, R: RefProvider>(
         }
     }
     let (decoy_dominated, below_final) =
-        finalize_mappings_counted_into(out, raw, &cfg.score, scratch);
+        finalize_mappings_counted_into(out, raw, &cfg.score, &mut scratch.dedup);
     set_last_map_stats(MapStats {
         had_candidates,
         decoy_dominated,
@@ -255,7 +259,7 @@ pub fn map_read_pair<'idx, R: RefProvider>(
         r1,
         r2,
         cfg,
-        &mut DedupScratch::default(),
+        &mut MapScratch::default(),
     );
     out
 }
@@ -270,7 +274,7 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
     r1: &[u8],
     r2: &[u8],
     cfg: &MapConfig,
-    scratch: &mut DedupScratch,
+    scratch: &mut MapScratch,
 ) {
     let cf = cfg.collect.consensus_fraction;
     // NOTE: deliberately do NOT collapse to one chain per (tid, is_fw) before
@@ -301,7 +305,8 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
         .any(|j| matches!(j.status, MateStatus::PairedEndPaired));
     let dovetail = crate::pair::dovetail_rejected() && !has_concordant_pair;
     let mut below = 0u32;
-    let mut raw = Vec::new();
+    let raw = &mut scratch.raw;
+    raw.clear();
     for j in joints {
         match j.status {
             MateStatus::PairedEndPaired => {
@@ -379,7 +384,7 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
             MateStatus::PairedEndLeft => {
                 let anchor = j.left.as_ref().unwrap();
                 push_orphan_or_recovered(
-                    &mut raw,
+                    raw,
                     index_seq(refs, j.tid),
                     r1,
                     r2,
@@ -388,12 +393,13 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
                     refs,
                     cfg,
                     j.tid,
+                    &mut scratch.revcomp,
                 );
             }
             MateStatus::PairedEndRight => {
                 let anchor = j.right.as_ref().unwrap();
                 push_orphan_or_recovered(
-                    &mut raw,
+                    raw,
                     index_seq(refs, j.tid),
                     r2,
                     r1,
@@ -402,6 +408,7 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
                     refs,
                     cfg,
                     j.tid,
+                    &mut scratch.revcomp,
                 );
             }
             MateStatus::SingleEnd => {}
@@ -428,7 +435,7 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
         raw.retain(|m| matches!(m.status, MateStatus::PairedEndPaired));
     }
     let (decoy_dominated, below_final) =
-        finalize_mappings_counted_into(out, raw, &cfg.score, scratch);
+        finalize_mappings_counted_into(out, raw, &cfg.score, &mut scratch.dedup);
     set_last_map_stats(MapStats {
         had_candidates,
         decoy_dominated,
@@ -546,6 +553,7 @@ fn push_orphan_or_recovered<R: RefProvider>(
     refs: &R,
     cfg: &MapConfig,
     tid: u32,
+    revcomp_buf: &mut Vec<u8>,
 ) {
     let Some(anchor_aln) = align_chain(anchor_read, refseq, &anchor.chain, &cfg.align) else {
         return;
@@ -556,7 +564,9 @@ fn push_orphan_or_recovered<R: RefProvider>(
     let is_decoy = refs.is_decoy(tid);
 
     if cfg.recover_orphans {
-        if let Some((partner_score, frag_len)) = recover_mate(partner_read, refseq, anchor, cfg) {
+        if let Some((partner_score, frag_len)) =
+            recover_mate(partner_read, refseq, anchor, cfg, revcomp_buf)
+        {
             raw.push(RawMapping {
                 tid,
                 is_fw: anchor.is_fw,
@@ -649,6 +659,7 @@ fn recover_mate(
     refseq: &[u8],
     anchor: &MappingCandidate,
     cfg: &MapConfig,
+    revcomp_buf: &mut Vec<u8>,
 ) -> Option<(i32, i32)> {
     let max_frag = cfg.pair.max_fragment_len;
     let reflen = refseq.len() as i32;
@@ -662,9 +673,9 @@ fn recover_mate(
         if win_end <= win_start {
             return None;
         }
-        let q = revcomp(partner_read);
+        crate::align::revcomp_into(partner_read, revcomp_buf);
         let aln = align_in_window(
-            &q,
+            revcomp_buf,
             &refseq[win_start as usize..win_end as usize],
             &cfg.align,
         )?;

--- a/crates/salmon-map/src/mapper.rs
+++ b/crates/salmon-map/src/mapper.rs
@@ -181,10 +181,14 @@ pub fn map_single_read_into<'idx, R: RefProvider>(
     );
     let had_candidates = !cands.is_empty();
     let mut below = 0u32;
-    // Reused across fragments; `finalize_mappings_counted_into` consumes it by
-    // draining, so it comes back empty for the next one.
+    // Reused across fragments. Arrives empty: `finalize_mappings_counted_into`
+    // drains it on every return path, and nothing between here and that call can
+    // return early, so there is no second reset on this side.
     let raw = &mut scratch.raw;
-    raw.clear();
+    debug_assert!(
+        raw.is_empty(),
+        "scratch.raw was not drained by the last call"
+    );
     raw.reserve(cands.len());
     for c in cands {
         if let Some(aln) = align_chain(read, refs.ref_seq(c.tid), &c.chain, &cfg.align) {
@@ -305,8 +309,12 @@ pub fn map_read_pair_into<'idx, R: RefProvider>(
         .any(|j| matches!(j.status, MateStatus::PairedEndPaired));
     let dovetail = crate::pair::dovetail_rejected() && !has_concordant_pair;
     let mut below = 0u32;
+    // Arrives empty; see the note in `map_single_read_into`.
     let raw = &mut scratch.raw;
-    raw.clear();
+    debug_assert!(
+        raw.is_empty(),
+        "scratch.raw was not drained by the last call"
+    );
     for j in joints {
         match j.status {
             MateStatus::PairedEndPaired => {

--- a/crates/salmon-map/src/score.rs
+++ b/crates/salmon-map/src/score.rs
@@ -149,8 +149,9 @@ pub fn finalize_mappings_counted(
     let mut out = Vec::new();
     // Allocating variant already, so a fresh scratch costs it nothing relative
     // to the `Vec` it returns.
+    let mut raw = raw;
     let (decoy_dominated, num_below) =
-        finalize_mappings_counted_into(&mut out, raw, cfg, &mut DedupScratch::default());
+        finalize_mappings_counted_into(&mut out, &mut raw, cfg, &mut DedupScratch::default());
     (out, decoy_dominated, num_below)
 }
 
@@ -170,6 +171,22 @@ const DEDUP_HASH_THRESHOLD: usize = 112;
 // reaches the table. A threshold outside this range would make one of them dead
 // code that nothing exercises.
 const _: () = assert!(DEDUP_HASH_THRESHOLD > 20 && DEDUP_HASH_THRESHOLD < 200);
+
+/// Reusable buffers for one worker's mapping of one fragment.
+///
+/// Everything here is cleared and refilled per fragment rather than allocated,
+/// so a worker allocates once and then maps for the rest of the run. Held in one
+/// struct so the mapping entry points take a single scratch parameter rather
+/// than one per buffer.
+#[derive(Default)]
+pub struct MapScratch {
+    /// validated mappings for this fragment, before scoring and collapse
+    pub(crate) raw: Vec<RawMapping>,
+    /// reverse complement of a mate during orphan recovery
+    pub(crate) revcomp: Vec<u8>,
+    /// dedup table for fragments with many mappings
+    pub(crate) dedup: DedupScratch,
+}
 
 /// Reusable table for the large-fragment deduplication path.
 ///
@@ -244,9 +261,12 @@ fn dedup_by_table(raw: &mut Vec<RawMapping>, scratch: &mut DedupScratch) {
 /// Like [`finalize_mappings_counted`] but writes into a caller-provided buffer
 /// (cleared first), so a per-thread `Vec` can be reused across reads instead of
 /// allocating a fresh result each time. Returns `(decoy_dominated, num_below)`.
+///
+/// `raw` is consumed in place and left empty on every return path, so the caller
+/// can refill the same buffer for the next fragment.
 pub fn finalize_mappings_counted_into(
     out: &mut Vec<ScoredMapping>,
-    raw: Vec<RawMapping>,
+    raw: &mut Vec<RawMapping>,
     cfg: &ScoreConfig,
     scratch: &mut DedupScratch,
 ) -> (bool, u32) {
@@ -267,13 +287,12 @@ pub fn finalize_mappings_counted_into(
     // The *order* of the survivors, by contrast, does not matter: this replaced a
     // hash map seeded per process (`ahash` `runtime-rng`), and quantification is
     // byte-identical across runs regardless of the order it yielded them in.
-    let mut raw = raw;
     if raw.len() <= DEDUP_HASH_THRESHOLD {
-        dedup_by_scan(&mut raw);
+        dedup_by_scan(raw);
     } else {
-        dedup_by_table(&mut raw, scratch);
+        dedup_by_table(raw, scratch);
     }
-    let best_per_tid = raw;
+    let best_per_tid = &mut *raw;
 
     let best_valid = best_per_tid
         .iter()
@@ -283,6 +302,7 @@ pub fn finalize_mappings_counted_into(
     let had_decoy = best_per_tid.iter().any(|m| m.is_decoy);
     let Some(best_valid) = best_valid else {
         // only decoy mappings -> dropped, dominated by a decoy
+        best_per_tid.clear();
         return (true, 0);
     };
     let best_decoy = best_per_tid
@@ -296,13 +316,14 @@ pub fn finalize_mappings_counted_into(
     // unless `--allowDecoyOrphans` asks us to keep the transcript placement(s).
     if let Some(bd) = best_decoy {
         if (best_valid as f64) < cfg.decoy_thresh * (bd as f64) && !cfg.allow_decoy_orphans {
+            best_per_tid.clear();
             return (true, 0);
         }
     }
     let _ = had_decoy;
 
     let mut num_below = 0u32;
-    for m in best_per_tid.into_iter().filter(|m| !m.is_decoy) {
+    for m in best_per_tid.drain(..).filter(|m| !m.is_decoy) {
         let weight = if cfg.hard_filter {
             if m.score == best_valid {
                 1.0
@@ -574,6 +595,42 @@ mod tests {
     fn only_decoy_is_unmapped() {
         let m = finalize_mappings(vec![raw(0, 100, true)], &ScoreConfig::default());
         assert!(m.is_empty());
+    }
+
+    #[test]
+    /// The caller reuses its `raw` buffer across fragments, so every return path
+    /// must leave it empty. A path that forgot to drain would leak the previous
+    /// fragment's placements into the next one — silently wrong, not a crash.
+    fn raw_buffer_is_emptied_on_every_path() {
+        let cfg = ScoreConfig::default();
+        let mut out = Vec::new();
+        let mut scratch = DedupScratch::default();
+        let mut buf: Vec<RawMapping> = Vec::new();
+
+        let mut run = |buf: &mut Vec<RawMapping>, what: &str| -> usize {
+            finalize_mappings_counted_into(&mut out, buf, &cfg, &mut scratch);
+            assert!(buf.is_empty(), "`raw` left non-empty by the {what} path");
+            out.len()
+        };
+
+        // empty input
+        run(&mut buf, "empty-input");
+
+        // decoy-only -> unmapped
+        buf.push(raw(0, 100, true));
+        run(&mut buf, "decoy-only");
+
+        // a decoy dominating a transcript below the threshold
+        buf.extend([raw(0, 50, false), raw(1, 100, true)]);
+        run(&mut buf, "decoy-dominated");
+
+        // the ordinary path
+        buf.extend([raw(0, 100, false), raw(1, 100, false)]);
+        assert_eq!(run(&mut buf, "normal"), 2);
+
+        // enough placements to take the hashed dedup path rather than the scan
+        buf.extend((0..DEDUP_HASH_THRESHOLD as u32 + 8).map(|t| raw(t, 100, false)));
+        run(&mut buf, "hashed-dedup");
     }
 
     // --- sketch-mode decoy filtering ---

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -309,9 +309,10 @@ pub(crate) struct RecordScratch {
     log_fps: CompatAligned<f64>,
     /// `(tid, conditional probability)` before duplicate-tid merging
     pairs: Vec<(u32, f64)>,
-    /// reusable table for deduplicating a fragment with many raw mappings; stays
-    /// empty unless a fragment is large enough to take the mapper's hashed path
-    dedup: salmon_map::DedupScratch,
+    /// reusable buffers the mapper fills per fragment: raw mappings, the mate
+    /// reverse complement used in orphan recovery, and the dedup table for
+    /// fragments large enough to take the hashed path
+    map: salmon_map::MapScratch,
 }
 
 pub(crate) struct QuantProcessor<'a> {
@@ -720,7 +721,7 @@ fn record(
         log_fps,
         pairs,
         // Belongs to the mapping step, not to `record`.
-        dedup: _,
+        map: _,
     } = scratch;
 
     // Sample the observed library format for auto-detection (auto mode only).
@@ -1214,7 +1215,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     s1.as_ref(),
                     s2.as_ref(),
                     sh.map_cfg,
-                    &mut scratch.dedup,
+                    &mut scratch.map,
                 );
             }
             // Sketch mappings carry no per-hit decoy flag and bypass the
@@ -1375,7 +1376,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     sh.salmon,
                     s.as_ref(),
                     sh.map_cfg,
-                    &mut scratch.dedup,
+                    &mut scratch.map,
                 );
             }
             // Sketch decoy policy (see the paired-end branch): drop decoy tids /


### PR DESCRIPTION
Closes #1085.

Stacked on #1113 — please merge that first; the base here is
`perf/1085-map-side-allocs`, so this diff shows only the new work.

#1085 listed four hot-path allocations. #1113 handled the two that measured
(the per-fragment `AHashMap` in `finalize_mappings_counted_into` and the
per-call `AHashSet` in `best_per_target`, together −2.39%, t=−5.28, faster in
9/9 rounds). This PR closes out the rest, so nothing in the issue is left
undecided.

### What changed

`MapScratch` gathers the mapper's per-fragment buffers into one struct that a
worker allocates once and then refills for the rest of the run. The mapping
entry points take one scratch parameter instead of three.

| buffer | before | now |
| --- | --- | --- |
| `raw` | fresh `Vec` per fragment | reused; `finalize_mappings_counted_into` drains it |
| `revcomp` | one `Vec` per orphan candidate examined | reused via `revcomp_into` |
| `dedup` | already threaded through from #1113 | folded into `MapScratch` |

`finalize_mappings_counted_into` now takes `raw: &mut Vec<RawMapping>` and
leaves it empty on every return path — including the two decoy early-returns,
which previously just returned and now clear explicitly. A new test drives all
five paths (empty input, decoy-only, decoy-dominated, ordinary, hashed-dedup)
and asserts the buffer comes back empty; removing either `clear()` makes it
fail with the path named.

### Correctness

Byte-identical against the #1113 build: sample data plain / bias / sketch, and
10M human fragments at `-p 1` — `quant.sf`, the eq-class file, and the
`meta_info.json` counters.

### Performance — null

10M human fragments at `-p 16`, interleaved A/B against the #1113 build, ten
rounds with the warm-up discarded:

```
  #1113 base   28.025s  sd=0.202
  + this PR    27.945s  sd=0.142
  delta        -0.080s  (-0.29%)
  paired       t=-0.92   95% CI  -0.255 .. +0.094 s
  faster in 4/9 rounds
```

That is not a win. The allocations are real, but at this scale they are
invisible against the alignment work around them — the same result the other
structural allocation changes in this series produced, and the reason #1113
was worth separating out. I am keeping this only for the invariant it
establishes (a worker allocates its mapping buffers once), not on a
performance claim. Happy to drop it if you would rather not take a change that
does not measure.

### Deliberately not changed

**The per-read `candidates` `Vec`** (#1085 item 2).
`join_reads_and_filter(left: Vec<MappingCandidate>, right: Vec<MappingCandidate>, ..)`
takes both by value and *moves* candidates into the `JointMapping`s it returns.
Each `MappingCandidate` owns a `MemChain`, so retaining the caller's buffers
would require cloning those chains — more work than the allocation saves. This
is a design change to the pairing interface, not a buffer swap, so it is out of
scope here.

**`cfg.chain.clone()` per read.** A false positive: `ChainConfig` is plain
`Copy` scalars, so the clone is a stack copy of a few words with no allocation.
