### PR TITLE
perf(rad): tally RAD records per worker, merge once per thread

### DIFF
--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -774,21 +774,56 @@ struct RadTallies {
     orphans: AtomicU64,
 }
 
-impl RadTallies {
+/// One worker's private copy of [`RadTallies`], merged into the shared atomics
+/// once when the worker finishes.
+///
+/// Each of these used to be a `fetch_add` on an `AtomicU64` shared by every
+/// worker — up to three per record. Relaxed ordering makes an individual
+/// increment cheap, but the cost was never the ordering; it was the cache line.
+/// Every thread writing the same word serialises behind a coherence transfer, so
+/// the tax grows with `-p` and is invisible at low thread counts. This is the
+/// same pattern `BiasLocal` already uses in the fused pass, and the one the
+/// read-based path uses for its per-fragment counters.
+///
+/// Safe to localise here in a way the quant-side `num_processed`/`num_mapped`
+/// are not: nothing reads these while the run is in flight. They are consumed
+/// once, after every worker has joined, via `into_inner()`.
+#[derive(Default)]
+struct LocalTallies {
+    records: u64,
+    mapped: u64,
+    orphans: u64,
+}
+
+impl LocalTallies {
     /// Takes the decision rather than the placements: `process_rad_fragment`
     /// already walks them and already knows which survived, so working it out
     /// again here would be a second pass — and reading it off `placements[0]`
     /// only worked while the placements happened to arrive in a particular
     /// order, which the fused pass no longer guarantees.
-    fn tally(&self, outcome: FragmentOutcome) {
-        self.records.fetch_add(1, Ordering::Relaxed);
+    #[inline]
+    fn tally(&mut self, outcome: FragmentOutcome) {
+        self.records += 1;
         if outcome == FragmentOutcome::Unmapped {
             return;
         }
-        self.mapped.fetch_add(1, Ordering::Relaxed);
+        self.mapped += 1;
         if outcome == FragmentOutcome::MappedOrphan {
-            self.orphans.fetch_add(1, Ordering::Relaxed);
+            self.orphans += 1;
         }
+    }
+
+    /// Add this worker's tallies to the shared atomics: one `fetch_add` per
+    /// counter per thread, instead of one per counter per record.
+    fn merge_into(&self, shared: &RadTallies) {
+        let add = |a: &AtomicU64, v: u64| {
+            if v != 0 {
+                a.fetch_add(v, Ordering::Relaxed);
+            }
+        };
+        add(&shared.records, self.records);
+        add(&shared.mapped, self.mapped);
+        add(&shared.orphans, self.orphans);
     }
 }
 
@@ -984,6 +1019,7 @@ where
                 // allocation per fragment.
                 let mut pls: Vec<RadPlacement> = Vec::new();
                 let mut scratch = RadScratch::default();
+                let mut local = LocalTallies::default();
                 for mc in chunks {
                     for chunk in mc.iter() {
                         for rec in &chunk.reads {
@@ -995,10 +1031,11 @@ where
                                 cfg,
                                 &mut scratch,
                             );
-                            tallies.tally(outcome);
+                            local.tally(outcome);
                         }
                     }
                 }
+                local.merge_into(tallies);
             });
         }
         // Producer: fill the queue until the file is exhausted (blocks).
@@ -1474,6 +1511,7 @@ where
             let merged = &merged;
             s.spawn(move || {
                 let mut local = BiasLocal::new(seq, gc, pos, cond_gc_bins, gc_bins);
+                let mut local_tallies = LocalTallies::default();
                 // Reused for every record this worker sees.
                 let mut pls: Vec<RadPlacement> = Vec::new();
                 let mut scratch = RadScratch::default();
@@ -1492,7 +1530,7 @@ where
                                 cfg,
                                 &mut scratch,
                             );
-                            tallies.tally(outcome);
+                            local_tallies.tally(outcome);
                             collect_bias_fragment(
                                 &pls,
                                 PlacementOrder::ByTid,
@@ -1503,6 +1541,7 @@ where
                         }
                     }
                 }
+                local_tallies.merge_into(tallies);
                 merged.lock().unwrap().merge(&local);
             });
         }


### PR DESCRIPTION
Closes #1084.

#1099 handled the read-based path: five of the seven per-fragment counters became per-worker `u64`s merged once per thread. Two remain shared there and are structurally required — `num_mapped` and `num_processed` are *read* while the run is in flight (the `use_aux` gate and the CLI progress bar), so a thread-local tally merged at thread end would read zero all run. That is documented on the issue.

This PR does the one acceptance criterion that was never addressed: **the RAD worker loops**.

### What changed

`RadTallies::tally` performed up to three shared-atomic RMWs per record — `records`, `mapped`, `orphans` — in both `run_rad_pass` and the fused `run_rad_eq_and_bias_pass`. `LocalTallies` accumulates the same three counts in plain `u64`s and folds them into the shared atomics once per worker, guarded by `if v != 0`. That is the pattern `BiasLocal` already uses in the fused pass.

These are safe to localise in a way the quant-side pair is not: **nothing reads them while the run is in flight**. They are consumed once, after every worker has joined, through `into_inner()`.

### Correctness

10M human fragments from a salmon RAD, at `-p 1`, `-p 8` and `-p 16`, against develop:

- every `meta_info.json` counter identical in all six runs — `num_processed` 9,221,625 · `num_mapped` 9,221,625 · `num_orphan` 623,154 · `percent_mapped` 100.0
- `quant.sf` identical at every thread count

So the merge is thread-count independent as well as correct.

### Performance

Interleaved A/B against develop, 10M-fragment RAD, warm-up round discarded, at the thread counts the issue asks for:

| threads | develop | this PR | delta | t | 95% CI | faster |
| ---: | ---: | ---: | ---: | ---: | :---: | :---: |
| 1 | 23.994s | 24.295s | **+1.25%** | +3.70 | [+0.138, +0.463]s | 5/18 |
| 8 | 13.460s | 13.035s | **−3.16%** | −4.76 | [−0.604, −0.247]s | 15/18 |
| 32 | 12.124s | 11.947s | **−1.46%** | −2.06 | [−0.349, −0.005]s | 9/14 |

At 8 and 32 threads this is a real win, and the direction matches the issue's contention argument — which is notable, because almost every other structural item in #1092 measured null.

**The `-p 1` row is a genuine anomaly and I am not going to explain it away.** With a single worker there is no contention to remove, so the honest expectation is "neutral", not "1.25% slower" at t=3.70. I do not have a mechanism for it beyond code layout — adding a struct and a merge call perturbs inlining and alignment, which routinely moves timings a percent or so with no logical cause. An order-swap control is running (the main run always executed develop first) and I will post the result here. If it is a real regression at `-p 1` it is worth weighing against the gains at 8 and 32, since `--rad -p 1` is not a common configuration but is not absurd either.
