### PR TITLE
perf(quant): reuse positional-bias buffers across transcripts

### DIFF
--- a/crates/salmon-model/src/bias.rs
+++ b/crates/salmon-model/src/bias.rs
@@ -53,18 +53,28 @@ const POS_SMOOTH_FRAC: f64 = 0.1;
 /// constant to numerator and denominator leaves well-measured ratios essentially
 /// unchanged while pulling ill-measured ones toward the neutral value.
 pub fn positional_factor(obs: &[f64], exp: &[f64]) -> Vec<f64> {
+    let mut out = Vec::new();
+    positional_factor_into(obs, exp, &mut out);
+    out
+}
+
+/// [`positional_factor`] writing into a caller-provided buffer (cleared first),
+/// so a per-worker `Vec` can be reused across transcripts instead of allocating
+/// a fresh result for each one.
+///
+/// Computes exactly what [`positional_factor`] does; that function is now a thin
+/// wrapper, so the two cannot drift apart.
+pub fn positional_factor_into(obs: &[f64], exp: &[f64], out: &mut Vec<f64>) {
+    out.clear();
     let n = exp.len();
     if n == 0 {
-        return Vec::new();
+        return;
     }
     // Scaling the constant to the mean makes the smoothing strength independent
     // of the arbitrary units the densities happen to be in.
     let mean_exp: f64 = exp.iter().sum::<f64>() / n as f64;
     let c = (POS_SMOOTH_FRAC * mean_exp).max(f64::MIN_POSITIVE);
-    obs.iter()
-        .zip(exp)
-        .map(|(&o, &e)| (o + c) / (e + c))
-        .collect()
+    out.extend(obs.iter().zip(exp).map(|(&o, &e)| (o + c) / (e + c)));
 }
 
 /// The enabled bias terms for one transcript's effective-length correction.

--- a/crates/salmon-model/src/lib.rs
+++ b/crates/salmon-model/src/lib.rs
@@ -60,7 +60,8 @@ pub mod spline;
 // Re-exports so callers can write `salmon_model::SBModel` rather than naming the
 // submodule; the modules above remain the real homes.
 pub use bias::{
-    build_expected_pos, corrected_effective_length_full, positional_factor, BiasInputs,
+    build_expected_pos, corrected_effective_length_full, positional_factor, positional_factor_into,
+    BiasInputs,
 };
 pub use fld::FragLengthSource;
 pub use fld::{

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -958,9 +958,24 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
                 .context("writing bias_models.txt")?;
         }
 
+        // Per-worker scratch for the positional-bias factors. Without it each
+        // transcript allocated six `Vec<f64>` of its own length — four for the
+        // projected obs/exp densities and two for the smoothed factors — inside
+        // a `par_iter` over the whole transcriptome. `map_init` hands each rayon
+        // worker one set to refill, so the allocation count goes from six per
+        // transcript to six per worker.
+        #[derive(Default)]
+        struct PosScratch {
+            o5: Vec<f64>,
+            e5: Vec<f64>,
+            o3: Vec<f64>,
+            e3: Vec<f64>,
+            pf: Vec<f64>,
+            pr: Vec<f64>,
+        }
         let corrected: Vec<f64> = (0..num_refs)
             .into_par_iter()
-            .map(|tid| {
+            .map_init(PosScratch::default, |scratch, tid| {
                 // Decoys (the contiguous tail at `first_decoy_index`) are never
                 // quantified or reported, so their bias-corrected effective length
                 // is unused. Skipping them here avoids a second, single-threaded
@@ -976,28 +991,36 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
                 let s = salmon.ref_seq(tid as u32);
                 let ref_len = s.len();
                 // Per-position 5'/3' positional-bias factors (obs/exp projected).
-                let pos_vecs: Option<(Vec<f64>, Vec<f64>)> =
-                    pos_models.as_ref().map(|(ofw, orc, efw, erc)| {
-                        let lc = length_class.as_ref().unwrap()[tid];
-                        let (mut o5, mut e5) = (vec![0.0; ref_len], vec![0.0; ref_len]);
-                        let (mut o3, mut e3) = (vec![0.0; ref_len], vec![0.0; ref_len]);
-                        ofw[lc].project_weights(&mut o5);
-                        efw[lc].project_weights(&mut e5);
-                        orc[lc].project_weights(&mut o3);
-                        erc[lc].project_weights(&mut e3);
-                        // additively-smoothed obs/exp (no hard floor; neutral tails)
-                        let pf = salmon_model::positional_factor(&o5, &e5);
-                        let pr = salmon_model::positional_factor(&o3, &e3);
-                        (pf, pr)
-                    });
+                // `project_weights` derives its output length from the slice it is
+                // given, so each buffer is resized to this transcript before use.
+                if let Some((ofw, orc, efw, erc)) = pos_models.as_ref() {
+                    let lc = length_class.as_ref().unwrap()[tid];
+                    for b in [
+                        &mut scratch.o5,
+                        &mut scratch.e5,
+                        &mut scratch.o3,
+                        &mut scratch.e3,
+                    ] {
+                        // Grows or shrinks to exactly `ref_len`; the fill value is
+                        // irrelevant since `project_weights` overwrites every slot.
+                        b.resize(ref_len, 0.0);
+                    }
+                    ofw[lc].project_weights(&mut scratch.o5);
+                    efw[lc].project_weights(&mut scratch.e5);
+                    orc[lc].project_weights(&mut scratch.o3);
+                    erc[lc].project_weights(&mut scratch.e3);
+                    // additively-smoothed obs/exp (no hard floor; neutral tails)
+                    salmon_model::positional_factor_into(&scratch.o5, &scratch.e5, &mut scratch.pf);
+                    salmon_model::positional_factor_into(&scratch.o3, &scratch.e3, &mut scratch.pr);
+                }
                 let bias = salmon_model::BiasInputs {
                     seq: seq_tab.as_ref().map(|(f, r)| (f, r)),
                     gc: gc_ratio_model
                         .as_ref()
                         .map(|g| (g, store.unwrap().view(tid))),
-                    pos: pos_vecs
+                    pos: pos_models
                         .as_ref()
-                        .map(|(pf, pr)| (pf.as_slice(), pr.as_slice())),
+                        .map(|_| (scratch.pf.as_slice(), scratch.pr.as_slice())),
                 };
                 salmon_model::corrected_effective_length_full(
                     s,


### PR DESCRIPTION
Addresses the positional-bias allocation item in #1091 — the last item there triaged as *address*.

### Change

The bias-corrected effective-length pass allocated **six `Vec<f64>` per transcript** inside its `par_iter` over the whole transcriptome: four for the projected 5'/3' obs/exp densities, plus two more returned by `positional_factor`. On a human index under `--posBias` that is roughly 1.5M transcript-length-sized allocations per correction round.

`map_init` now gives each rayon worker one `PosScratch` to refill, so the count goes from six per *transcript* to six per *worker*. `positional_factor_into` writes into a caller-provided buffer, and `positional_factor` is now a thin wrapper around it — so the two cannot drift apart, and the align-mode caller needs no change.

The four projection buffers are `resize`d to each transcript before use, since `project_weights` derives its output length from the slice it is handed.

### Numerically identical

Verified at `-p 1`, where the pipeline is deterministic:

| run | result |
| --- | --- |
| sample data, `--posBias` alone | `quant.sf` byte-identical |
| sample data, `--posBias --seqBias --gcBias` | byte-identical |
| GRCh38 decoy index (194 decoys), all three bias models | byte-identical |
| 10M human fragments, all three bias models | byte-identical |

The **EffectiveLength** column — what this code actually computes — was also compared on its own, identical in both composed runs.

At `-p 16` that column differs, but this is pre-existing and not attributable here: develop differs from **itself** run-to-run in 186,065 rows, against 189,913 rows across arms. That is the known online-phase threading wobble.

### Performance — null

10M human fragments, `--posBias --seqBias --gcBias`, `-p 16`, interleaved, warm-up discarded:

```
  develop  39.859s
  this PR  39.747s
  delta    -0.28%     paired t=-0.54   95% CI [-0.528,+0.304]s   faster in 5/8
```

Not a win. The allocations are real, but ~1.5M of them amount to well under a second against a 40-second run, and they only occur under `--posBias` at all. I am putting this up because the issue asked for it and it is tightly scoped and provably output-preserving — not on a performance claim. Entirely reasonable to decline it on the grounds that a null result does not justify the churn.

With this, every item on #1091 is either landed, deferred, or rejected.
