### PR TITLE
deps: paraseq-temp 0.5.0-pre.2 (parked worker pool, upstream 0.5.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,9 +2268,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "piscem-rs"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e9d61329e506636f779f403afda39d2f05b4a0f5d3d98aed6e7d357ad0c9ea"
+checksum = "47ce11e2c76b30cae05c1b6d0a4d72d042d820c5a66301c257b7ed91c827d951"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3250,7 +3250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "paraseq-temp"
-version = "0.5.0-pre.1"
+version = "0.5.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632e453d770914dc2da8e7184cd6c7d01a031f17fa334145404acf4a6cebad3b"
+checksum = "e46e492f850391b70aa1a63e47fe34d85b5c3473cfd355b4819706fa1730d05a"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -3250,7 +3250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ cf1-rs = "0.5"
 # budget shared between gzip decoding and mapping, solved from live measurement
 # rather than split by a fixed guess. `rapidgzip` enables the parallel decoder
 # that budget is worth dividing in the first place.
-piscem-rs = { version = "0.9.1", features = ["rapidgzip"] }
+piscem-rs = { version = "0.9.2", features = ["rapidgzip"] }
 # The control law piscem-rs 0.9.0 is built on. Taken directly so salmon can
 # implement `Consumer` for its own mapping pool; must resolve to the same
 # version piscem-rs uses or the trait would not match across the boundary.

--- a/crates/salmon-quant/tests/pool_resize_flush_safety.rs
+++ b/crates/salmon-quant/tests/pool_resize_flush_safety.rs
@@ -138,18 +138,37 @@ fn run(churn: bool) -> (u64, Vec<u32>, u64) {
     let pool = ThreadPool::with_max(MAX_THREADS, MAX_THREADS);
     let done = Arc::new(AtomicBool::new(false));
 
-    // Drive the pool up and down throughout the run, so workers retire and
-    // respawn repeatedly while records are still being read.
+    // Drive the pool up and down throughout the run, so workers park and
+    // resume repeatedly while records are still being read. Each shrink is
+    // held until its effect is *observed* (live workers at or under the
+    // target), so the count returned is proof the pool reacted, not merely
+    // that set_threads was called.
+    let observed_shrinks = Arc::new(AtomicU64::new(0));
     let resizer = churn.then(|| {
         let pool = pool.clone();
         let done = Arc::clone(&done);
+        let observed = Arc::clone(&observed_shrinks);
         std::thread::spawn(move || {
             let sizes = [MAX_THREADS, 3, 11, 1, MAX_THREADS, 2, 7];
             let mut i = 0usize;
             while !done.load(Ordering::Acquire) {
-                pool.set_threads(sizes[i % sizes.len()]);
+                let t = sizes[i % sizes.len()];
+                pool.set_threads(t);
+                if t < MAX_THREADS {
+                    // Wait (bounded) for the pool to actually park down to the
+                    // target; batches are tiny here, so convergence is fast.
+                    for _ in 0..2_000 {
+                        if done.load(Ordering::Acquire) {
+                            break;
+                        }
+                        if pool.total_live() <= t {
+                            observed.fetch_add(1, Ordering::Relaxed);
+                            break;
+                        }
+                        std::thread::sleep(std::time::Duration::from_micros(50));
+                    }
+                }
                 i += 1;
-                std::thread::sleep(std::time::Duration::from_micros(300));
             }
         })
     });
@@ -169,7 +188,15 @@ fn run(churn: bool) -> (u64, Vec<u32>, u64) {
     let counted = shared.counted.load(Ordering::Relaxed);
     let flushed = shared.flushed.lock().unwrap().clone();
     let completions = shared.completions.load(Ordering::Relaxed);
-    (counted, flushed, completions)
+    // Every spawned worker completes exactly once -- parked workers included,
+    // woken at end of input. More completions than the spawn set would mean
+    // respawning is back; fewer would mean a worker was lost (and with it,
+    // any state it had not flushed).
+    assert!(
+        completions <= MAX_THREADS as u64,
+        "{completions} thread completions for a {MAX_THREADS}-worker pool"
+    );
+    (counted, flushed, observed_shrinks.load(Ordering::Relaxed))
 }
 
 /// Control: with a fixed pool nothing retires early, so this is the baseline
@@ -184,21 +211,27 @@ fn fixed_pool_counts_and_flushes_everything() {
     assert_eq!(flushed.len(), RECORDS, "output buffer lost records");
 }
 
-/// The real check: workers retiring mid-run must commit both their counters and
-/// their pending output.
+/// The real check: state observable outside a worker must survive resizing.
+///
+/// Under the parked pool (paraseq-temp 0.5.0-pre.2) a shrunk-away worker
+/// parks with its thread and per-worker state intact, rather than exiting --
+/// so the hazard shifts from "a retiring worker must flush before dying" to
+/// "output must be committed at batch boundaries (a parked worker's buffer
+/// sleeps with it) and every spawned worker must complete exactly once at end
+/// of input, parked or not."
 #[test]
-fn retired_workers_commit_counters_and_output() {
-    let (counted, flushed, completions) = run(true);
+fn resized_workers_commit_counters_and_output() {
+    let (counted, flushed, observed_shrinks) = run(true);
 
     assert_eq!(
         counted, RECORDS as u64,
         "thread-local counters were lost or double-counted across a resize: a \
-         retiring worker either skipped on_thread_complete or committed twice"
+         worker either skipped on_thread_complete or committed twice"
     );
     assert_eq!(
         flushed.len(),
         RECORDS,
-        "a retiring worker dropped its pending output buffer: {} of {} records \
+        "a resized worker dropped its pending output buffer: {} of {} records \
          reached the shared sink",
         flushed.len(),
         RECORDS
@@ -210,20 +243,21 @@ fn retired_workers_commit_counters_and_output() {
     assert_eq!(
         unique.len(),
         RECORDS,
-        "records were duplicated across a retire/respawn cycle"
+        "records were duplicated across a park/resume cycle"
     );
     for id in 0..RECORDS as u32 {
         assert!(unique.contains(&id), "record {id} never reached the sink");
     }
 
-    // Guard against a vacuous pass. If the churn never actually retired anyone,
-    // the assertions above hold trivially and this test proves nothing -- the
-    // same shape of mistake that let a decoder verdict ship three times without
-    // ever changing behaviour.
+    // Guard against a vacuous pass. Under the parked design worker
+    // *incarnations* can no longer exceed the ceiling (that bound is the
+    // design), so churn is evidenced differently: each shrink was held until
+    // the pool was OBSERVED at or under its target. Zero observations would
+    // mean the pool ignored every resize and this test exercised nothing.
     assert!(
-        completions > MAX_THREADS as u64,
-        "only {completions} worker incarnations completed with a ceiling of \
-         {MAX_THREADS}: no worker retired mid-run, so this test exercised \
-         nothing and its green result is meaningless"
+        observed_shrinks >= 5,
+        "only {observed_shrinks} shrinks took observable effect: the pool is \
+         not reacting to set_threads, so this test exercised nothing and its \
+         green result is meaningless"
     );
 }


### PR DESCRIPTION
Moves to the pre.2 republication: upstream paraseq's **released 0.5.0** plus the redesigned resizable pool ([noamteyssier/paraseq#78](https://github.com/noamteyssier/paraseq/pull/78) — fixed spawn set with parking, worker count bounded by construction). Lockfile-only for the dependency; piscem-rs 0.9.1's requirement admits pre.2.

`pool_resize_flush_safety` is reworked for parked semantics: the old non-vacuity guard counted worker incarnations exceeding the ceiling, which parking makes impossible **by design** — it failed for exactly the right reason. The new guard requires each shrink to be *observed* taking effect (pool at/under target), ≥5 times per run.

**Evaluated end to end** at `-p 64 --decoder parallel` on 26.1M real read pairs: SA 58s / sketch 35s / SA+det 58s / sketch+det 32s, all mapped counts identical to every prior run — and `quant.sf` **byte-identical** (238,443 rows) between serial and parallel decoders under `--deterministic`. 278 workspace tests, clippy clean.

No version bump; release deferred until this has soaked. Companion PR: COMBINE-lab/piscem-rs#5.