### PR TITLE
feat(quant): --spliced, mapping output in genome coordinates (stacked on #1141, #1142)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ name = "salmon-quant"
 version = "2.6.0"
 dependencies = [
  "anyhow",
+ "bramble-rs",
  "crossbeam-channel",
  "flate2",
  "jiff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59dbb09ed53f8e4f314e353dc6c1853ae5b4c480a668a422657804a544ea9f65"
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "mem_dbg"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +2856,7 @@ dependencies = [
  "flate2",
  "jiff",
  "libradicl",
+ "md-5",
  "noodles-bam",
  "noodles-bgzf",
  "noodles-sam",

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -532,8 +532,8 @@ struct QuantArgs {
     /// Write the names of unmapped fragments to aux_info/unmapped_names.txt.
     #[arg(long = "writeUnmappedNames")]
     write_unmapped_names: bool,
-    /// Write per-mapping SAM records to this file. Records carry a base-level
-    /// CIGAR with NM and MD, describing the alignment the record reports.
+    /// Write per-mapping SAM records to this file. Records carry base qualities,
+    /// a base-level CIGAR with NM and MD, and the mate and placement tags.
     /// `--writeSam` is an accepted alias, naming the format explicitly to pair
     /// with `--writeBam`.
     #[arg(
@@ -915,10 +915,17 @@ struct QuantArgs {
     /// sampled BAM (requires --sampleOut).
     #[arg(short = 'u', long = "sampleUnaligned")]
     sample_unaligned: bool,
-    /// [accepted; not yet implemented] write qualities into the sampled BAM
-    /// (only meaningful with --sampleOut / --writeMappings).
+    /// [accepted for salmon compatibility; has no effect] base qualities are not
+    /// optional output. They are written into every record whenever the input
+    /// carries them, with or without this flag.
     #[arg(long = "writeQualities")]
     write_qualities: bool,
+    /// Read group to declare in the mapping output's header, as tab-separated
+    /// KEY:value fields with a mandatory ID (for example
+    /// `ID:sample1\tSM:sample1\tPL:ILLUMINA`). A literal \t is accepted in place
+    /// of a tab. Every record is then tagged RG:Z:<ID>.
+    #[arg(long = "rgLine", value_name = "LINE")]
+    rg_line: Option<String>,
     /// [accepted; not yet implemented] hit-filtering policy (BEFORE/AFTER/BOTH/
     /// NONE) for selective alignment; the Rust port filters after chaining.
     #[arg(long = "hitFilterPolicy")]
@@ -2105,8 +2112,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if args.eqclasses.is_some() {
         tracing::warn!("--eqclasses (quantify from a precomputed equivalence-class file) is not yet implemented and is ignored; mapping/alignment input is used instead.");
     }
-    if args.sample_out || args.sample_unaligned || args.write_qualities {
-        tracing::warn!("--sampleOut/--sampleUnaligned/--writeQualities (posterior-sampled BAM output) are accepted but not yet implemented and have no effect.");
+    if args.sample_out || args.sample_unaligned {
+        tracing::warn!("--sampleOut/--sampleUnaligned (posterior-sampled BAM output) are accepted but not yet implemented and have no effect.");
     }
     if args.hit_filter_policy.is_some() {
         tracing::warn!("--hitFilterPolicy is accepted but not yet implemented and has no effect: the Rust port filters hits after chaining (salmon's AFTER default).");
@@ -2704,6 +2711,16 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         "-2 given without -1: mates must be supplied as a pair (-1 <mates_1> -2 <mates_2>). \
          For single-end reads use -r."
     );
+
+    // Parse the read group up front: a malformed --rgLine should fail before any
+    // mapping work, not after it, and the header is written the moment the
+    // output file is opened.
+    let read_group = args
+        .rg_line
+        .as_deref()
+        .map(salmon_quant::mapping_record::ReadGroup::parse)
+        .transpose()
+        .context("parsing --rgLine")?;
     anyhow::ensure!(
         !args.mates1.is_empty() || !args.unmated.is_empty(),
         "no reads provided: pass -1/-2 (paired), -r (single-end), -a (BAM), or --rad (RAD)"
@@ -2862,6 +2879,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.dump_eq = args.dump_eq;
     opts.dump_eq_weights = args.dump_eq_weights;
     opts.write_unmapped_names = args.write_unmapped_names;
+    opts.read_group = read_group;
     opts.write_mappings = args.write_mappings;
     opts.write_bam = args.write_bam;
     opts.bam_compress_threads = args.bam_compress_threads;
@@ -3547,6 +3565,15 @@ mod tests {
         assert_eq!(q.dump_eq_weights, defaults.dump_eq_weights);
         assert_eq!(q.no_length_correction, defaults.no_length_correction);
         assert_eq!(q.no_frag_length_dist, defaults.no_frag_length_dist);
+    }
+
+    /// `--rgLine` reaches the parser as a plain string, so the shell-friendly
+    /// escaped-tab spelling has to survive to where it is parsed rather than
+    /// being mangled by clap.
+    #[test]
+    fn rg_line_is_taken_verbatim() {
+        let args = quant_args(&["--rgLine", "ID:s1\\tSM:sample"]).unwrap();
+        assert_eq!(args.rg_line.as_deref(), Some("ID:s1\\tSM:sample"));
     }
 
     /// `--sampleUnaligned` keeps its salmon short form, since it is the flag

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -921,6 +921,12 @@ struct QuantArgs {
     /// carries them, with or without this flag.
     #[arg(long = "writeQualities")]
     write_qualities: bool,
+    /// Report mapping output in genome coordinates instead of transcript ones,
+    /// with N operations at exon junctions the way a spliced genome aligner
+    /// writes them. Needs --annotation for the exon structures and --genome for
+    /// the chromosome lengths the header must declare.
+    #[arg(long = "spliced")]
+    spliced: bool,
     /// Read group to declare in the mapping output's header, as tab-separated
     /// KEY:value fields with a mandatory ID (for example
     /// `ID:sample1\tSM:sample1\tPL:ILLUMINA`). A literal \t is accepted in place
@@ -2716,6 +2722,25 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
          For single-end reads use -r."
     );
 
+    // --spliced rewrites the whole reference table, so its inputs are checked
+    // before mapping starts rather than when the first record is written.
+    if args.spliced {
+        anyhow::ensure!(
+            args.write_mappings.is_some() || args.write_bam.is_some(),
+            "--spliced has no effect without --writeMappings/--writeSam or --writeBam: it changes \
+             how mapping output is written, and there is none"
+        );
+        anyhow::ensure!(
+            args.annotation.is_some(),
+            "--spliced needs --annotation: exon junctions come from the annotation, and a \
+             transcriptome index does not record them"
+        );
+        anyhow::ensure!(
+            args.genome.is_some(),
+            "--spliced needs --genome: the header has to declare each chromosome's length, which \
+             an annotation does not state"
+        );
+    }
     // Parse the read group up front: a malformed --rgLine should fail before any
     // mapping work, not after it, and the header is written the moment the
     // output file is opened.
@@ -2884,6 +2909,9 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.dump_eq_weights = args.dump_eq_weights;
     opts.write_unmapped_names = args.write_unmapped_names;
     opts.write_unaligned = args.sample_unaligned;
+    opts.spliced_output = args.spliced;
+    opts.annotation = args.annotation.clone();
+    opts.genome_fasta = args.genome.clone();
     opts.read_group = read_group;
     opts.write_mappings = args.write_mappings;
     opts.write_bam = args.write_bam;

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -532,9 +532,10 @@ struct QuantArgs {
     /// Write the names of unmapped fragments to aux_info/unmapped_names.txt.
     #[arg(long = "writeUnmappedNames")]
     write_unmapped_names: bool,
-    /// Write per-mapping SAM records to this file (spoofed CIGAR, like salmon's
-    /// standard `--writeMappings`). `--writeSam` is an accepted alias, naming
-    /// the format explicitly to pair with `--writeBam`.
+    /// Write per-mapping SAM records to this file. Records carry a base-level
+    /// CIGAR with NM and MD, describing the alignment the record reports.
+    /// `--writeSam` is an accepted alias, naming the format explicitly to pair
+    /// with `--writeBam`.
     #[arg(
         short = 'z',
         long = "writeMappings",
@@ -542,7 +543,8 @@ struct QuantArgs {
         conflicts_with = "write_bam"
     )]
     write_mappings: Option<PathBuf>,
-    /// Write per-mapping BAM records to this file. Mutually exclusive with
+    /// Write per-mapping BAM records to this file: the same records as
+    /// --writeMappings, BGZF-compressed. Mutually exclusive with
     /// --writeMappings/--writeSam.
     #[arg(long = "writeBam", conflicts_with = "write_mappings")]
     write_bam: Option<PathBuf>,
@@ -3545,6 +3547,16 @@ mod tests {
         assert_eq!(q.dump_eq_weights, defaults.dump_eq_weights);
         assert_eq!(q.no_length_correction, defaults.no_length_correction);
         assert_eq!(q.no_frag_length_dist, defaults.no_frag_length_dist);
+    }
+
+    /// `--sampleUnaligned` keeps its salmon short form, since it is the flag
+    /// users already have in their scripts.
+    #[test]
+    fn sample_unaligned_has_both_spellings() {
+        for flag in ["--sampleUnaligned", "-u"] {
+            assert!(quant_args(&[flag]).unwrap().sample_unaligned, "{flag}");
+        }
+        assert!(!quant_args(&[]).unwrap().sample_unaligned);
     }
 
     /// `--writeSam` is a spelling of `--writeMappings`, giving SAM output a

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -911,8 +911,9 @@ struct QuantArgs {
     /// alignments (alignment mode).
     #[arg(short = 's', long = "sampleOut")]
     sample_out: bool,
-    /// [accepted; not yet implemented] also include unaligned reads in the
-    /// sampled BAM (requires --sampleOut).
+    /// Also write a record for every fragment that did not map, flagged 0x4, so
+    /// the mapping output covers the whole library rather than only the part
+    /// that mapped. Applies to --writeMappings/--writeSam and --writeBam.
     #[arg(short = 'u', long = "sampleUnaligned")]
     sample_unaligned: bool,
     /// [accepted for salmon compatibility; has no effect] base qualities are not
@@ -2112,8 +2113,11 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if args.eqclasses.is_some() {
         tracing::warn!("--eqclasses (quantify from a precomputed equivalence-class file) is not yet implemented and is ignored; mapping/alignment input is used instead.");
     }
-    if args.sample_out || args.sample_unaligned {
-        tracing::warn!("--sampleOut/--sampleUnaligned (posterior-sampled BAM output) are accepted but not yet implemented and have no effect.");
+    if args.sample_out {
+        tracing::warn!("--sampleOut (a BAM of posterior-sampled alignments) is accepted but not yet implemented and has no effect. --sampleUnaligned now works on its own, against --writeMappings/--writeBam.");
+    }
+    if args.sample_unaligned && args.write_mappings.is_none() && args.write_bam.is_none() {
+        tracing::warn!("--sampleUnaligned has no effect without --writeMappings/--writeSam or --writeBam: there is no mapping output to add the unaligned records to.");
     }
     if args.hit_filter_policy.is_some() {
         tracing::warn!("--hitFilterPolicy is accepted but not yet implemented and has no effect: the Rust port filters hits after chaining (salmon's AFTER default).");
@@ -2879,6 +2883,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.dump_eq = args.dump_eq;
     opts.dump_eq_weights = args.dump_eq_weights;
     opts.write_unmapped_names = args.write_unmapped_names;
+    opts.write_unaligned = args.sample_unaligned;
     opts.read_group = read_group;
     opts.write_mappings = args.write_mappings;
     opts.write_bam = args.write_bam;

--- a/crates/salmon-index/src/lib.rs
+++ b/crates/salmon-index/src/lib.rs
@@ -65,6 +65,18 @@ const INFO_FILE: &str = "info.json";
 const REFSEQ_FILE: &str = "refseq.bin";
 /// Per-reference offsets into `REFSEQ_FILE` (`num_refs + 1` entries).
 const REFSEQ_OFFSETS_FILE: &str = "refseq_offsets.json";
+/// Reference offsets whose base was not ACGT in the input and was replaced to
+/// make the sequence k-mer-able. Pairs of `(tid, offset)`, little-endian `u32`,
+/// sorted, behind a `u64` count.
+///
+/// The index has to align against a cleaned sequence, but a record describing
+/// that alignment should not claim the reference had a base it never had. Keeping
+/// the positions costs one entry per ambiguous base (four across the whole
+/// GENCODE v44 human transcriptome) and lets `NM`, `MD` and the `@SQ M5` speak
+/// about the reference the user actually supplied.
+///
+/// Absent in indexes built before this existed, which load as "none recorded".
+const AMBIGUOUS_FILE: &str = "ambiguous.bin";
 
 /// On-disk salmon index *format* version written into `info.json` by this build.
 /// Distinct from `salmon_version` (the software release string): this is bumped
@@ -387,6 +399,10 @@ struct RefHashes {
 struct PreprocessResult {
     /// non-ACGT bases replaced with pseudo-random ACGT
     replaced: u64,
+    /// per written reference, the offsets whose base was replaced. Keyed by name
+    /// rather than by position because the index assigns its own reference order
+    /// later, and matching on names cannot drift from it.
+    ambiguous: Vec<(Vec<u8>, Vec<u32>)>,
     /// `(retained_name, duplicate_name)` pairs in discovery order. Without
     /// `--keepDuplicates` the duplicate was *not* written to the cleaned FASTA (so
     /// it is absent from the index); with `--keepDuplicates` every transcript is
@@ -462,6 +478,7 @@ fn preprocess_fasta(
             .with_context(|| format!("creating {}", out_path.display()))?,
     );
     let mut replaced = 0u64;
+    let mut ambiguous: Vec<(Vec<u8>, Vec<u32>)> = Vec::new();
     let mut polya_clipped = 0u64;
     let mut polya_dropped: Vec<Vec<u8>> = Vec::new();
     let mut short_decoys_dropped: Vec<Vec<u8>> = Vec::new();
@@ -537,9 +554,13 @@ fn preprocess_fasta(
             // assembly gaps. The refseq store keeps the raw bytes and the aligner
             // encodes N as a mismatch (dna5 code 4), so a read aligning over a decoy
             // N-run simply scores it as a mismatch.
+            // Offsets replaced in this record, kept so a later alignment can say
+            // the reference base was unknown rather than report the substitute.
+            let mut replaced_here: Vec<u32> = Vec::new();
             if !is_decoy {
-                for b in seq.iter_mut() {
+                for (offset, b) in seq.iter_mut().enumerate() {
                     if !matches!(*b, b'A' | b'C' | b'G' | b'T' | b'a' | b'c' | b'g' | b't') {
+                        replaced_here.push(offset as u32);
                         // A linear congruential generator: multiply, add, and take
                         // high bits. `wrapping_*` means overflow wraps around
                         // rather than panicking, which is the intended arithmetic.
@@ -592,6 +613,13 @@ fn preprocess_fasta(
                 continue;
             }
 
+            // Clipping can cut the tail off, taking replaced offsets with it, and
+            // only a record that is actually written has a reference to belong to.
+            replaced_here.retain(|&o| (o as usize) < seq.len());
+            if !replaced_here.is_empty() {
+                ambiguous.push((name.to_vec(), replaced_here));
+            }
+
             // Write the record in canonical two-line form (header, then the whole
             // sequence unwrapped), which is what the downstream builder expects.
             out.write_all(b">")?;
@@ -604,6 +632,7 @@ fn preprocess_fasta(
     out.flush()?;
     Ok(PreprocessResult {
         replaced,
+        ambiguous,
         duplicate_clusters,
         polya_clipped,
         polya_dropped,
@@ -950,6 +979,8 @@ pub fn build(opts: &IndexBuildOptions) -> Result<IndexInfo> {
 
     // Persist the (cleaned) reference sequences (piscem does not retain them) so
     // the selective-alignment step fetches windows matching the indexed k-mers.
+    write_ambiguous_positions(&opts.output_dir, &pre.ambiguous, &idx)
+        .context("writing the ambiguous-base position table")?;
     write_refseq_store(&opts.output_dir, std::slice::from_ref(&cleaned), &idx)
         .context("writing reference sequence store")?;
 
@@ -1021,6 +1052,67 @@ fn processed_name(id: &[u8], gencode: bool) -> &[u8] {
 ///
 /// Order matters: the sequences are written in the *index's* id order, not the
 /// FASTA's, because that is how every later lookup indexes them.
+/// Read the ambiguous-base table, or empty when the index predates it.
+///
+/// A missing file is not an error: an index built before this was recorded
+/// simply cannot say, and the output then matches what it always produced.
+fn read_ambiguous_positions(dir: &Path) -> Result<(Vec<u32>, Vec<u32>)> {
+    let path = dir.join(AMBIGUOUS_FILE);
+    let Ok(bytes) = std::fs::read(&path) else {
+        return Ok((Vec::new(), Vec::new()));
+    };
+    if bytes.len() < 8 {
+        anyhow::bail!("{AMBIGUOUS_FILE} is truncated");
+    }
+    let count = u64::from_le_bytes(bytes[..8].try_into().expect("8 bytes")) as usize;
+    if bytes.len() != 8 + count * 8 {
+        anyhow::bail!(
+            "{AMBIGUOUS_FILE} declares {count} entries but is {} bytes",
+            bytes.len()
+        );
+    }
+    let mut tids = Vec::with_capacity(count);
+    let mut offsets = Vec::with_capacity(count);
+    for entry in bytes[8..].chunks_exact(8) {
+        tids.push(u32::from_le_bytes(entry[..4].try_into().expect("4 bytes")));
+        offsets.push(u32::from_le_bytes(entry[4..].try_into().expect("4 bytes")));
+    }
+    Ok((tids, offsets))
+}
+
+/// Record which reference offsets held a base the index had to replace.
+///
+/// Names are resolved to reference ids here rather than during preprocessing,
+/// because the index assigns its own order and a table keyed by position would
+/// drift from it silently. A name the index does not carry is one whose record
+/// was dropped later, and is simply not recorded.
+fn write_ambiguous_positions(
+    dir: &Path,
+    ambiguous: &[(Vec<u8>, Vec<u32>)],
+    idx: &ReferenceIndex,
+) -> Result<()> {
+    use std::collections::HashMap;
+    let by_name: HashMap<&[u8], u32> = (0..idx.num_refs())
+        .map(|tid| (idx.ref_name(tid).as_bytes(), tid as u32))
+        .collect();
+    let mut pairs: Vec<(u32, u32)> = Vec::new();
+    for (name, offsets) in ambiguous {
+        if let Some(&tid) = by_name.get(name.as_slice()) {
+            pairs.extend(offsets.iter().map(|&offset| (tid, offset)));
+        }
+    }
+    pairs.sort_unstable();
+    let mut buf = Vec::with_capacity(8 + pairs.len() * 8);
+    buf.extend_from_slice(&(pairs.len() as u64).to_le_bytes());
+    for (tid, offset) in &pairs {
+        buf.extend_from_slice(&tid.to_le_bytes());
+        buf.extend_from_slice(&offset.to_le_bytes());
+    }
+    std::fs::write(dir.join(AMBIGUOUS_FILE), &buf)
+        .with_context(|| format!("writing {AMBIGUOUS_FILE}"))?;
+    Ok(())
+}
+
 fn write_refseq_store(dir: &Path, transcripts: &[PathBuf], idx: &ReferenceIndex) -> Result<()> {
     use std::collections::HashMap;
 
@@ -1088,6 +1180,15 @@ pub struct SalmonIndex {
     ref_offsets: Vec<u64>,
     /// whether the reference sequence bytes were loaded
     refseq_loaded: bool,
+    /// Reference ids of the bases the build had to replace, ascending, parallel
+    /// to [`Self::ambiguous_off`]. Held as two arrays rather than pairs so one
+    /// reference's offsets can be handed out as a slice.
+    ///
+    /// Empty for an index built before these were recorded, which reads as "none
+    /// known" rather than "none exist": the output is then what it always was.
+    ambiguous_tid: Vec<u32>,
+    /// Offsets within the corresponding reference.
+    ambiguous_off: Vec<u32>,
 }
 
 /// Load just the per-reference forward sequences from an index directory, in
@@ -1182,16 +1283,35 @@ impl SalmonIndex {
         } else {
             (Vec::new(), Vec::new())
         };
+        // Cheap enough to read unconditionally: it is empty for almost every
+        // index, and a caller that skipped the sequences still gets a consistent
+        // answer from `ambiguous_offsets`.
+        let (ambiguous_tid, ambiguous_off) = read_ambiguous_positions(dir)?;
         Ok(Self {
             inner,
             info,
             refseq,
             ref_offsets,
             refseq_loaded: load_refseq,
+            ambiguous_tid,
+            ambiguous_off,
         })
     }
 
     /// Whether the reference sequence bytes were loaded (see [`load_with_opts`](Self::load_with_opts)).
+    /// Offsets within reference `tid` whose base the build replaced, ascending.
+    ///
+    /// Empty for almost every reference: across the whole GENCODE v44 human
+    /// transcriptome there are four such bases. Callers can therefore treat the
+    /// empty case as the fast path without measuring.
+    pub fn ambiguous_offsets(&self, tid: usize) -> &[u32] {
+        let tid = tid as u32;
+        // Sorted by `(tid, offset)`, so one reference's offsets are contiguous.
+        let start = self.ambiguous_tid.partition_point(|&t| t < tid);
+        let end = self.ambiguous_tid.partition_point(|&t| t <= tid);
+        &self.ambiguous_off[start..end]
+    }
+
     pub fn refseq_loaded(&self) -> bool {
         self.refseq_loaded
     }
@@ -1310,6 +1430,38 @@ fn read_info(dir: &Path) -> Result<IndexInfo> {
 
 #[cfg(test)]
 mod tests {
+    /// The ambiguous-base table has to survive a write/read round trip, and an
+    /// index built before it existed has to keep loading.
+    #[test]
+    fn ambiguous_positions_round_trip_and_tolerate_absence() {
+        let dir = tempfile::tempdir().unwrap();
+        // Absent: not an error, and nothing recorded.
+        assert_eq!(
+            super::read_ambiguous_positions(dir.path()).unwrap(),
+            (Vec::new(), Vec::new())
+        );
+        let pairs: Vec<(u32, u32)> = vec![(0, 5), (0, 9), (7, 2)];
+        let mut buf = (pairs.len() as u64).to_le_bytes().to_vec();
+        for (tid, offset) in &pairs {
+            buf.extend_from_slice(&tid.to_le_bytes());
+            buf.extend_from_slice(&offset.to_le_bytes());
+        }
+        std::fs::write(dir.path().join(super::AMBIGUOUS_FILE), &buf).unwrap();
+        let (tids, offsets) = super::read_ambiguous_positions(dir.path()).unwrap();
+        assert_eq!(tids, vec![0, 0, 7]);
+        assert_eq!(offsets, vec![5, 9, 2]);
+    }
+
+    /// A truncated table is a corrupt index, not something to read past.
+    #[test]
+    fn a_truncated_ambiguous_table_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut buf = 3u64.to_le_bytes().to_vec();
+        buf.extend_from_slice(&[0, 0, 0, 0]);
+        std::fs::write(dir.path().join(super::AMBIGUOUS_FILE), &buf).unwrap();
+        assert!(super::read_ambiguous_positions(dir.path()).is_err());
+    }
+
     use super::*;
     use std::io::Write;
 

--- a/crates/salmon-map/src/lib.rs
+++ b/crates/salmon-map/src/lib.rs
@@ -52,6 +52,7 @@ pub mod extend;
 pub mod mapper;
 pub mod mem;
 pub mod pair;
+pub mod realize;
 pub mod score;
 pub mod sketch;
 
@@ -71,6 +72,9 @@ pub use mapper::{
 };
 pub use mem::Mem;
 pub use pair::{join_reads_and_filter, JointMapping, PairingConfig};
+pub use realize::{
+    push_op, realize, reference_span, CigarOp, CigarOpKind, RealizeScratch, RealizedAlignment,
+};
 pub use salmon_core::RefProvider;
 pub use score::{
     filter_sketch_decoys, finalize_mappings, DedupScratch, MapScratch, RawMapping, ScoreConfig,

--- a/crates/salmon-map/src/realize.rs
+++ b/crates/salmon-map/src/realize.rs
@@ -263,6 +263,16 @@ fn ungapped_is_optimal(mismatches: i32, cfg: &AlignConfig) -> bool {
 /// rate usually leaves at least one of the two probes clean.
 const PROBE: usize = 20;
 
+/// How many probe hits are worth looking at.
+///
+/// A probe is useful because it is rare: one hit names the read's start. A probe
+/// that matches dozens of places inside a few hundred bases is sitting in a
+/// tandem repeat or a low-complexity stretch, where it says nothing about which
+/// of those places the read came from. Past this many hits the extra ones carry
+/// no information, and collecting them turns a linear scan into a quadratic one
+/// on exactly the sequence that produces the most of them.
+const MAX_CANDIDATES: usize = 32;
+
 /// Candidate starts for `query` near `approx_pos`, found by locating an exact
 /// probe from the read inside the surrounding window.
 ///
@@ -290,6 +300,9 @@ fn probe_candidates(query: &[u8], ref_seq: &[u8], approx_pos: i32, reach: i32, o
             continue;
         };
         for (index, candidate) in window.windows(PROBE).enumerate() {
+            if out.len() >= MAX_CANDIDATES {
+                return;
+            }
             if candidate == probe {
                 let start = low as i32 + index as i32 - offset as i32;
                 if start >= 0 && !out.contains(&start) {
@@ -1073,6 +1086,30 @@ mod tests {
         assert_eq!(cigar_string(&out), "100M");
         assert_eq!(out.ref_start, 200);
         assert_eq!(out.edit_distance, 0);
+    }
+
+    /// A probe sitting in a tandem repeat matches everywhere, and collecting every
+    /// hit is both useless and quadratic. Low-complexity stretches are ordinary
+    /// in real transcripts, so the bound has to hold rather than be argued away.
+    #[test]
+    fn a_repeat_does_not_produce_unbounded_candidates() {
+        let mut reference = vec![b'A'; 200];
+        reference.extend(std::iter::repeat_n(*b"AC", 200).flatten());
+        reference.extend(nonrepeating(200));
+        let read: Vec<u8> = std::iter::repeat_n(*b"AC", 50).flatten().collect();
+        let mut candidates = Vec::new();
+        probe_candidates(
+            &read,
+            &reference,
+            250,
+            read.len() as i32 + 32,
+            &mut candidates,
+        );
+        assert!(
+            candidates.len() <= MAX_CANDIDATES,
+            "a repeat produced {} candidates",
+            candidates.len()
+        );
     }
 
     /// When no anchor produces an alignment the mapper would have accepted, the

--- a/crates/salmon-map/src/realize.rs
+++ b/crates/salmon-map/src/realize.rs
@@ -1,0 +1,1219 @@
+//! Base-level alignment realization for SAM/BAM output.
+//!
+//! # Why this is separate from [`crate::align`]
+//!
+//! Mapping only ever needs a *score*: is this candidate placement good enough to
+//! keep? [`crate::align`] therefore runs ksw2 in `KSW_EZ_SCORE_ONLY` mode, which
+//! skips the traceback matrix entirely, the single largest cost in a banded DP.
+//! That is the right trade for the hot path, where the aligner runs once per
+//! candidate across every read in the library.
+//!
+//! Writing a SAM or BAM record needs more than a score. A record has to say *how*
+//! the read lines up: where each insertion and deletion falls (the CIGAR), how
+//! many bases differ from the reference (`NM`), and which reference bases they
+//! were (`MD`). None of that survives a score-only DP.
+//!
+//! So this module re-derives the alignment, with traceback, for the placements
+//! that actually get written. That is a much smaller set than the candidates the
+//! mapper scored: only the placements that survived filtering, and only when
+//! `--writeMappings`/`--writeBam` is on. A run without mapping output never calls
+//! into this module at all, so the mapping hot path is untouched.
+//!
+//! # What "realizing" a placement means
+//!
+//! The mapper hands over an approximate start position on a transcript. This
+//! module aligns the read against a window starting there and reports:
+//!
+//! * the CIGAR, with real `I`/`D` operations where the read has indels and `S`
+//!   where it overhangs a transcript end,
+//! * `ref_start`, the leftmost reference base the alignment actually consumes,
+//! * `NM`, the edit distance (mismatches + inserted + deleted bases),
+//! * `MD`, the string that lets a reader reconstruct the reference from the read.
+//!
+//! # Gap placement
+//!
+//! ksw2 is run *without* `KSW_EZ_RIGHT` here, unlike the scoring path. That flag
+//! right-aligns gaps; SAM convention (and every downstream variant caller) wants
+//! them left-aligned, so the CIGAR this module produces is the conventional one
+//! even though the score it implies is identical either way.
+
+use crate::align::AlignConfig;
+
+/// A CIGAR operation code, using the BAM numeric encoding so that both writers
+/// and the genome projector can share one vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CigarOpKind {
+    /// `M`: consumes read and reference (match *or* mismatch, SAM's `M` does not
+    /// distinguish them; `MD`/`NM` carry that information).
+    Match = 0,
+    /// `I`: bases present in the read, absent from the reference.
+    Insertion = 1,
+    /// `D`: bases present in the reference, absent from the read.
+    Deletion = 2,
+    /// `N`: reference skipped without the read crossing it. Only produced by the
+    /// genome projector, for introns; a transcriptome alignment never has one.
+    Skip = 3,
+    /// `S`: bases present in the read but not aligned, and still stored in `SEQ`.
+    SoftClip = 4,
+}
+
+impl CigarOpKind {
+    /// The SAM letter for this operation.
+    pub fn letter(self) -> char {
+        match self {
+            Self::Match => 'M',
+            Self::Insertion => 'I',
+            Self::Deletion => 'D',
+            Self::Skip => 'N',
+            Self::SoftClip => 'S',
+        }
+    }
+
+    /// Whether this operation advances the position in the read.
+    pub fn consumes_read(self) -> bool {
+        matches!(self, Self::Match | Self::Insertion | Self::SoftClip)
+    }
+
+    /// Whether this operation advances the position on the reference.
+    pub fn consumes_reference(self) -> bool {
+        matches!(self, Self::Match | Self::Deletion | Self::Skip)
+    }
+}
+
+/// One CIGAR operation: a kind and how many bases it covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CigarOp {
+    pub kind: CigarOpKind,
+    pub len: u32,
+}
+
+impl CigarOp {
+    pub fn new(kind: CigarOpKind, len: u32) -> Self {
+        Self { kind, len }
+    }
+}
+
+/// Append `op`, merging it into the previous operation when they are the same
+/// kind. Zero-length operations are dropped: they are legal to *produce* while
+/// stitching an alignment together but illegal to write into a record.
+pub fn push_op(ops: &mut Vec<CigarOp>, kind: CigarOpKind, len: u32) {
+    if len == 0 {
+        return;
+    }
+    match ops.last_mut() {
+        Some(last) if last.kind == kind => last.len += len,
+        _ => ops.push(CigarOp::new(kind, len)),
+    }
+}
+
+/// A realized alignment: everything a SAM/BAM record needs beyond the fields the
+/// mapper already knows.
+///
+/// Buffers are owned so one instance can be reused across every record a worker
+/// writes; [`RealizedAlignment::clear`] resets it without freeing.
+#[derive(Debug, Default, Clone)]
+pub struct RealizedAlignment {
+    /// CIGAR operations, in reference order (5'→3' on the forward strand).
+    pub ops: Vec<CigarOp>,
+    /// Leftmost reference position the alignment consumes, 0-based.
+    pub ref_start: i32,
+    /// Edit distance: mismatches plus inserted plus deleted bases (SAM `NM`).
+    pub edit_distance: u32,
+    /// SAM `MD`: matched run lengths, mismatched reference bases, and `^`-prefixed
+    /// deleted reference stretches.
+    pub md: String,
+    /// Alignment score of the realized alignment under the configured affine
+    /// scoring. Reported separately from the mapper's `AS` so the two never get
+    /// confused.
+    pub score: i32,
+}
+
+impl RealizedAlignment {
+    pub fn clear(&mut self) {
+        self.ops.clear();
+        self.ref_start = 0;
+        self.edit_distance = 0;
+        self.md.clear();
+        self.score = 0;
+    }
+}
+
+/// Scratch buffers for [`realize`], so realizing a record allocates nothing after
+/// the first call on a given worker.
+#[derive(Default)]
+pub struct RealizeScratch {
+    aligner: ksw2rs::Aligner,
+    query_codes: Vec<u8>,
+    target_codes: Vec<u8>,
+    /// The read in reference-forward orientation.
+    oriented: Vec<u8>,
+    /// Candidate starts from the probe search, reused across records.
+    candidates: Vec<i32>,
+}
+
+/// DNA5 code for a base: `A,C,G,T` → `0..3`, anything else → `4`.
+fn dna5(base: u8) -> u8 {
+    match base {
+        b'A' | b'a' => 0,
+        b'C' | b'c' => 1,
+        b'G' | b'g' => 2,
+        b'T' | b't' => 3,
+        _ => 4,
+    }
+}
+
+fn complement(base: u8) -> u8 {
+    match base {
+        b'A' | b'a' => b'T',
+        b'C' | b'c' => b'G',
+        b'G' | b'g' => b'C',
+        b'T' | b't' => b'A',
+        _ => b'N',
+    }
+}
+
+/// 5x5 DNA5 scoring matrix, matching [`crate::align`]'s.
+fn dna5_matrix(cfg: &AlignConfig) -> [i8; 25] {
+    let mut mat = [-cfg.mismatch_pen; 25];
+    for i in 0..5 {
+        mat[i * 5 + i] = cfg.match_score;
+    }
+    mat[24] = 0;
+    mat
+}
+
+/// Two bases count as a match for `MD`/`NM` only if they are the same known base.
+/// An `N` on either side is a mismatch, which is what samtools' own `calmd` does.
+fn bases_match(read: u8, reference: u8) -> bool {
+    let (r, t) = (read.to_ascii_uppercase(), reference.to_ascii_uppercase());
+    r == t && matches!(r, b'A' | b'C' | b'G' | b'T')
+}
+
+/// Realize the placement of `read` at approximately `approx_pos` on `ref_seq`.
+///
+/// `is_forward` says whether the read aligns to the reference's forward strand;
+/// when it does not, the reverse complement is what gets aligned, which is also
+/// what SAM stores in `SEQ`. `approx_pos` is the mapper's implied start and may
+/// fall outside the reference: a negative position means the read overhangs the
+/// 5' end, and a position plus read length beyond the reference means it
+/// overhangs the 3' end. Both become soft clips.
+///
+/// Returns `false`, leaving `out` cleared, when no alignment can be formed at all
+/// (an empty read or reference, or a window that lands entirely off the
+/// reference). Callers fall back to the spoofed CIGAR in that case.
+#[allow(clippy::too_many_arguments)]
+pub fn realize(
+    read: &[u8],
+    is_forward: bool,
+    ref_seq: &[u8],
+    ambiguous: &[u32],
+    approx_pos: i32,
+    cfg: &AlignConfig,
+    scratch: &mut RealizeScratch,
+    out: &mut RealizedAlignment,
+) -> bool {
+    out.clear();
+    if read.is_empty() || ref_seq.is_empty() {
+        return false;
+    }
+
+    // SEQ is stored on the reference's forward strand, so that is the orientation
+    // every coordinate below is expressed in.
+    scratch.oriented.clear();
+    if is_forward {
+        scratch.oriented.extend_from_slice(read);
+    } else {
+        scratch
+            .oriented
+            .extend(read.iter().rev().map(|&b| complement(b)));
+    }
+    let query = std::mem::take(&mut scratch.oriented);
+    let realized = realize_anchored(&query, ref_seq, ambiguous, approx_pos, cfg, scratch, out);
+    scratch.oriented = query;
+    realized
+}
+
+/// Mismatches when the read is laid down ungapped at `pos`, or `None` when it
+/// would not fit inside the reference there.
+fn ungapped_mismatches(query: &[u8], ref_seq: &[u8], pos: i32) -> Option<i32> {
+    if pos < 0 || pos as usize + query.len() > ref_seq.len() {
+        return None;
+    }
+    let reference = &ref_seq[pos as usize..pos as usize + query.len()];
+    Some(
+        query
+            .iter()
+            .zip(reference)
+            .filter(|(&read, &base)| !bases_match(read, base))
+            .count() as i32,
+    )
+}
+
+/// Whether an ungapped alignment with `mismatches` is provably optimal: no
+/// alignment containing a gap can score better. See [`realize_oriented`] for the
+/// derivation.
+fn ungapped_is_optimal(mismatches: i32, cfg: &AlignConfig) -> bool {
+    mismatches * (cfg.match_score + cfg.mismatch_pen) as i32
+        <= cfg.gap_open_pen as i32 + cfg.gap_extend_pen as i32
+}
+
+/// Length of the exact probe used to locate a misplaced read. Long enough to be
+/// specific over the few hundred bases searched, short enough that a 1% error
+/// rate usually leaves at least one of the two probes clean.
+const PROBE: usize = 20;
+
+/// Candidate starts for `query` near `approx_pos`, found by locating an exact
+/// probe from the read inside the surrounding window.
+///
+/// Comparing the whole read at every offset answers the question but costs the
+/// read length at each one, and the sweep has to reach a read length in either
+/// direction. Searching for one exact substring costs the window instead of the
+/// window times the read, and every occurrence of it names a start directly.
+///
+/// Two probes are taken, a third and two thirds of the way in, because a single
+/// probe landing on a sequencing error finds nothing. Ends are avoided: they are
+/// where reads are worst and where a genuine indel is most likely to sit.
+fn probe_candidates(query: &[u8], ref_seq: &[u8], approx_pos: i32, reach: i32, out: &mut Vec<i32>) {
+    out.clear();
+    if query.len() < PROBE * 2 {
+        return;
+    }
+    let low = (approx_pos - reach).max(0) as usize;
+    let high = ((approx_pos + reach) as usize + query.len()).min(ref_seq.len());
+    if high <= low + PROBE {
+        return;
+    }
+    let window = &ref_seq[low..high];
+    for offset in [query.len() / 3, query.len() * 2 / 3] {
+        let Some(probe) = query.get(offset..offset + PROBE) else {
+            continue;
+        };
+        for (index, candidate) in window.windows(PROBE).enumerate() {
+            if candidate == probe {
+                let start = low as i32 + index as i32 - offset as i32;
+                if start >= 0 && !out.contains(&start) {
+                    out.push(start);
+                }
+            }
+        }
+    }
+}
+
+/// Find where the read actually starts, when it plainly does not start where the
+/// mapper said, and report how many mismatches it has there.
+///
+/// The mapper's position comes from a seed chain, and a mismatch near the read's
+/// 5' end pushes that chain rightwards. A read can also be anchored so close to a
+/// transcript end that it hangs off it, which turns into a soft-clipped record
+/// that quietly throws bases away when the read often belongs further in and
+/// matches in full.
+///
+/// The scan is gated on the read looking badly placed to begin with. A handful of
+/// sequencing errors is not evidence of a wrong anchor, and relocating a read that
+/// is already where it belongs would cost more than it saves.
+fn repair_anchor(
+    query: &[u8],
+    ref_seq: &[u8],
+    approx_pos: i32,
+    cfg: &AlignConfig,
+    candidates: &mut Vec<i32>,
+) -> Option<(i32, i32)> {
+    // A read that does not even fit inside the reference where it was placed is
+    // as badly anchored as one that mismatches everywhere, and is the case most
+    // worth looking at. Treating "does not fit" as "matches nothing" is what lets
+    // the search run there at all.
+    let here = ungapped_mismatches(query, ref_seq, approx_pos).unwrap_or(query.len() as i32);
+    // An eighth of the read differing is far past what sequencing error explains,
+    // and squarely in "this is not where the read goes" territory.
+    if here <= (query.len() as i32) / 8 {
+        return None;
+    }
+    // How far the anchor can be wrong is not a question about indel size, which is
+    // what `indel_margin` bounds. A seed chain on a repeat or a paralogous stretch
+    // can imply a start most of a read length away.
+    let reach = query.len() as i32 + cfg.indel_margin as i32;
+    probe_candidates(query, ref_seq, approx_pos, reach, candidates);
+    let mut best = (here, approx_pos);
+    let consider = |best: &mut (i32, i32), candidate: i32| {
+        if let Some(mismatches) = ungapped_mismatches(query, ref_seq, candidate) {
+            if mismatches < best.0 {
+                *best = (mismatches, candidate);
+            }
+        }
+    };
+    for &candidate in candidates.iter() {
+        consider(&mut best, candidate);
+    }
+    // Both probes can land on a sequencing error, and a read shorter than two
+    // probes has none to offer. That leaves a read the cheap search cannot place,
+    // and the alternative to placing it is a record with no base-level alignment
+    // at all, so it is worth the exhaustive sweep. This runs on a fraction of a
+    // percent of records, which is what makes it affordable.
+    if best.1 == approx_pos {
+        for delta in 1..=reach {
+            consider(&mut best, approx_pos - delta);
+            consider(&mut best, approx_pos + delta);
+            if ungapped_is_optimal(best.0, cfg) {
+                break;
+            }
+        }
+    }
+    (best.1 != approx_pos).then_some((best.1, best.0))
+}
+
+/// Realize at `approx_pos`, repairing the anchor first when the read plainly does
+/// not sit there.
+///
+/// ksw2's extension pins the read's first base to the window's first base, so the
+/// alignment can grow rightwards but never shift left. That is fine when the
+/// mapper's position is the read's true start, and wrong when it is not: the DP
+/// then has no way to express "the read starts earlier" except by opening a
+/// leading insertion, which is both a worse alignment and a false one.
+///
+/// [`repair_anchor`] settles that before the DP runs, by comparison rather than
+/// alignment. What remains afterwards is a safety net for the cases it declines
+/// to act on: a leading insertion of `n` bases is itself the statement that the
+/// read began `n` bases earlier, so shift by that and realize again.
+#[allow(clippy::too_many_arguments)]
+fn realize_anchored(
+    query: &[u8],
+    ref_seq: &[u8],
+    ambiguous: &[u32],
+    approx_pos: i32,
+    cfg: &AlignConfig,
+    scratch: &mut RealizeScratch,
+    out: &mut RealizedAlignment,
+) -> bool {
+    let mut anchor = approx_pos;
+    if !realize_oriented(query, ref_seq, ambiguous, approx_pos, cfg, scratch, out) {
+        return false;
+    }
+    // A repaired anchor is a hypothesis, not a verdict. Reads with a genuine
+    // deletion also look badly placed to an ungapped scan, since every base past
+    // the gap is shifted, so the scan can talk itself into relocating a read that
+    // was where it belonged. Realizing at both anchors and keeping the better
+    // score makes the repair unable to do harm: the worst it can do is cost one
+    // extra alignment on a read that already looked wrong.
+    let mut candidates = std::mem::take(&mut scratch.candidates);
+    let repaired = repair_anchor(query, ref_seq, approx_pos, cfg, &mut candidates);
+    scratch.candidates = candidates;
+    if let Some((repaired, mismatches)) = repaired {
+        let mut alternative = RealizedAlignment::default();
+        if realize_oriented(
+            query,
+            ref_seq,
+            ambiguous,
+            repaired,
+            cfg,
+            scratch,
+            &mut alternative,
+        ) && (alternative.score > out.score || ungapped_is_optimal(mismatches, cfg))
+        {
+            *out = alternative;
+            anchor = repaired;
+        }
+    }
+    // Refuse to publish an alignment the mapper itself would have rejected.
+    //
+    // When the anchor is wrong by more than the search could reach, the banded DP
+    // still returns *an* alignment: a sawtooth of one-base insertions and
+    // deletions that walks the read diagonally across the reference. It is a
+    // valid CIGAR and a completely false claim, and it contradicts the `AS` on
+    // the same record, which came from the mapper and says the read aligned well.
+    // `min_accepted_score` is the mapper's own bar for believing a placement, so
+    // an alignment below it is one this module has no business asserting. Falling
+    // back to the spoofed CIGAR says "no base-level alignment here", which is at
+    // least true.
+    //
+    // The bar is set by the bases the alignment actually claims, not by the whole
+    // read: a read hanging off a transcript end is soft-clipped, and its clipped
+    // bases are not evidence of anything either way.
+    let claimed: u32 = out
+        .ops
+        .iter()
+        .filter(|op| matches!(op.kind, CigarOpKind::Match | CigarOpKind::Insertion))
+        .map(|op| op.len)
+        .sum();
+    if out.score < crate::align::min_accepted_score(claimed as usize, cfg) {
+        out.clear();
+        return false;
+    }
+    let leading_insertion = match out.ops.first() {
+        Some(op) if op.kind == CigarOpKind::Insertion => op.len as i32,
+        _ => 0,
+    };
+    if leading_insertion > 0 && anchor - leading_insertion >= 0 {
+        let mut retried = RealizedAlignment::default();
+        std::mem::swap(out, &mut retried);
+        if realize_oriented(
+            query,
+            ref_seq,
+            ambiguous,
+            anchor - leading_insertion,
+            cfg,
+            scratch,
+            out,
+        ) && out.score >= retried.score
+        {
+            return true;
+        }
+        // The retry did not help, so keep the original rather than a worse one.
+        std::mem::swap(out, &mut retried);
+    }
+    // An insertion at either edge is a legal CIGAR but a meaningless claim: those
+    // bases are not aligned to anything, which is what a soft clip says.
+    clip_edge_insertions(out);
+    true
+}
+
+/// Turn insertions at the very start or end of the alignment into soft clips.
+///
+/// Both consume read bases and no reference, so the CIGAR stays consistent
+/// either way, but only the clip is honest: an insertion says "these bases are
+/// present in the read and absent from the reference at this point", which at
+/// the edge of an alignment is a claim about nothing. It also inflates `NM`,
+/// so the edit distance gives those bases back.
+fn clip_edge_insertions(out: &mut RealizedAlignment) {
+    let mut clipped = 0;
+    let mut clip = |ops: &mut [CigarOp], index: usize| {
+        if let Some(op) = ops.get_mut(index) {
+            if op.kind == CigarOpKind::Insertion {
+                op.kind = CigarOpKind::SoftClip;
+                clipped += op.len;
+            }
+        }
+    };
+    // The edge is the first operation, or the second when a clip already leads.
+    let leading = usize::from(out.ops.first().map(|op| op.kind) == Some(CigarOpKind::SoftClip));
+    clip(&mut out.ops, leading);
+    let last = out.ops.len().saturating_sub(1);
+    let trailing = if out.ops.last().map(|op| op.kind) == Some(CigarOpKind::SoftClip) {
+        last.saturating_sub(1)
+    } else {
+        last
+    };
+    if trailing > leading {
+        clip(&mut out.ops, trailing);
+    }
+    out.edit_distance = out.edit_distance.saturating_sub(clipped);
+    // Converting next to an existing clip leaves two clips in a row.
+    let mut merged: Vec<CigarOp> = Vec::with_capacity(out.ops.len());
+    for op in &out.ops {
+        push_op(&mut merged, op.kind, op.len);
+    }
+    out.ops = merged;
+}
+
+/// Record the ungapped alignment: one `M` run over the whole read, with `NM` and
+/// `MD` derived from a single pass over the bases.
+fn finish_ungapped(
+    query: &[u8],
+    ref_seq: &[u8],
+    window_start: i32,
+    query_len: i32,
+    score: i32,
+    out: &mut RealizedAlignment,
+) {
+    out.ref_start = window_start;
+    out.score = score;
+    push_op(&mut out.ops, CigarOpKind::Match, query_len as u32);
+    fill_md_and_edit_distance(query, ref_seq, &[], out);
+}
+
+/// The body of [`realize`], with the query already in reference orientation.
+#[allow(clippy::too_many_arguments)]
+fn realize_oriented(
+    query: &[u8],
+    ref_seq: &[u8],
+    ambiguous: &[u32],
+    approx_pos: i32,
+    cfg: &AlignConfig,
+    scratch: &mut RealizeScratch,
+    out: &mut RealizedAlignment,
+) -> bool {
+    let ref_len = ref_seq.len() as i32;
+    let query_len = query.len() as i32;
+
+    // A read hanging off the 5' end contributes a leading soft clip; alignment
+    // starts at reference 0 with whatever bases are left.
+    let (leading_clip, window_start) = if approx_pos < 0 {
+        ((-approx_pos).min(query_len), 0)
+    } else {
+        (0, approx_pos.min(ref_len))
+    };
+    let aligned_query = &query[leading_clip as usize..];
+    if aligned_query.is_empty() || window_start >= ref_len {
+        // Nothing of the read reaches the reference: it is all clip, which is not
+        // a record worth spoofing a CIGAR for.
+        return false;
+    }
+
+    // Most records do not need a dynamic program at all. A read placed where the
+    // mapper put it usually lines up base for base, differing only by
+    // substitutions, and for that alignment the CIGAR is a single `M` run whose
+    // `NM` and `MD` fall out of one pass over the bases.
+    //
+    // The question is when that ungapped alignment is not merely plausible but
+    // *optimal*, since anything less would make the output depend on a shortcut.
+    // Affine scoring answers it: any alignment containing a gap pays at least
+    // `gap_open + gap_extend`, and the very best it can do with the rest is match
+    // everywhere, so its score cannot exceed `perfect - (gap_open +
+    // gap_extend)`. The ungapped alignment scores `perfect - mismatches *
+    // (match + mismatch)`. Whenever the second is at least the first, no gapped
+    // alignment can win, and the DP would only spend time rediscovering that.
+    //
+    // At salmon's defaults (match 2, mismatch 4, open 6, extend 2) the rule
+    // admits up to one mismatch, which covers most reads at realistic error
+    // rates. `ungapped_score` is kept for the second shortcut below.
+    // A reference whose bases the build had to replace cannot answer "does this
+    // read match here" from the stored sequence alone, so the shortcuts that rest
+    // on that answer are skipped and the full walk decides. This costs nothing in
+    // practice: it is four references in the human transcriptome.
+    let ungapped_mismatch_count = (leading_clip == 0 && ambiguous.is_empty())
+        .then(|| ungapped_mismatches(query, ref_seq, window_start))
+        .flatten();
+    let ungapped = ungapped_mismatch_count.map(|mismatches| {
+        query_len * cfg.match_score as i32
+            - mismatches * (cfg.match_score + cfg.mismatch_pen) as i32
+    });
+    if let (Some(mismatches), Some(ungapped_score)) = (ungapped_mismatch_count, ungapped) {
+        if ungapped_is_optimal(mismatches, cfg) {
+            finish_ungapped(query, ref_seq, window_start, query_len, ungapped_score, out);
+            return true;
+        }
+    }
+
+    // Give the aligner room past the read length so a net deletion in the read
+    // still has reference to consume.
+    let window_end =
+        (window_start + aligned_query.len() as i32 + cfg.indel_margin as i32).min(ref_len);
+    let window = &ref_seq[window_start as usize..window_end as usize];
+
+    let matrix = dna5_matrix(cfg);
+    encode_into(aligned_query, &mut scratch.query_codes);
+    encode_into(window, &mut scratch.target_codes);
+
+    // Pass 1, score only: find how much of the window the best full-query
+    // alignment consumes (`mqe_t`). ksw2's extension anchors at (0, 0), which is
+    // exactly the "read starts here" constraint we want.
+    let (query_end_target, query_end_reachable, target_end_query, query_end_score) = {
+        let input = ksw2rs::Extz2Input {
+            query: &scratch.query_codes,
+            target: &scratch.target_codes,
+            m: 5,
+            mat: &matrix,
+            q: cfg.gap_open_pen,
+            e: cfg.gap_extend_pen,
+            // salmon's own `dpBandwidth`. It used to have to cover
+            // `indel_margin` as well, because the anchor correction read its
+            // offset off a leading insertion and could not see one wider than
+            // the band. `repair_anchor` now settles the anchor by comparison
+            // before the DP runs, so the band only has to cover genuine indels,
+            // and a banded DP is linear in its width.
+            w: cfg.bandwidth,
+            zdrop: -1,
+            end_bonus: 0,
+            flag: ksw2rs::KSW_EZ_SCORE_ONLY,
+        };
+        let ez = scratch.aligner.align(&input);
+        (ez.mqe_t, ez.mqe > ksw2rs::KSW_NEG_INF, ez.mte_q, ez.mqe)
+    };
+
+    // The DP has now priced the optimal alignment. When that price is the one the
+    // ungapped alignment already pays, the traceback would only redraw a single
+    // `M` run, so skip it: filling and walking the traceback matrix is the
+    // expensive half of a banded alignment, and this is the case where it buys
+    // nothing. Reads with several mismatches but no indel land here.
+    if let Some(ungapped_score) = ungapped {
+        // The optimal full-query alignment ends exactly `query_len` bases into
+        // the window (so it has no net indel) and scores what the ungapped one
+        // scores: the ungapped alignment is therefore an optimal one, and the
+        // conventional choice among any ties.
+        if query_end_reachable
+            && query_end_target == query_len - 1
+            && query_end_score == ungapped_score
+        {
+            finish_ungapped(query, ref_seq, window_start, query_len, ungapped_score, out);
+            return true;
+        }
+    }
+
+    // How much window the traceback pass should align against, and how much of
+    // the read's tail is soft-clipped.
+    //
+    // The read reaching its end inside the window is the normal case. It stops
+    // being the right answer when the read is simply longer than the reference
+    // left to align against: the DP can still "reach the query end" by dumping
+    // every leftover base into an insertion at the last reference position, which
+    // scores worse than clipping and describes an alignment nobody believes. A
+    // read overhanging a transcript's 3' end is exactly that case, so when the
+    // query cannot fit in the window at all, clip the tail instead.
+    let overhangs_reference_end = aligned_query.len() > window.len();
+    let (target_len, trailing_clip) =
+        if query_end_reachable && query_end_target >= 0 && !overhangs_reference_end {
+            ((query_end_target + 1).min(window.len() as i32), 0)
+        } else if target_end_query >= 0 {
+            (
+                window.len() as i32,
+                aligned_query.len() as i32 - (target_end_query + 1),
+            )
+        } else {
+            return false;
+        };
+    if target_len <= 0 || trailing_clip < 0 {
+        return false;
+    }
+    let aligned_query = &aligned_query[..aligned_query.len() - trailing_clip as usize];
+    if aligned_query.is_empty() {
+        return false;
+    }
+
+    // Pass 2, with traceback: a global alignment of the read (minus clips) to the
+    // window prefix picked above. No `KSW_EZ_RIGHT`, so gaps come out
+    // left-aligned as SAM expects.
+    encode_into(aligned_query, &mut scratch.query_codes);
+    let target = &window[..target_len as usize];
+    encode_into(target, &mut scratch.target_codes);
+    let (packed, score) = {
+        let input = ksw2rs::Extz2Input {
+            query: &scratch.query_codes,
+            target: &scratch.target_codes,
+            m: 5,
+            mat: &matrix,
+            q: cfg.gap_open_pen,
+            e: cfg.gap_extend_pen,
+            w: cfg
+                .bandwidth
+                .max((aligned_query.len() as i32 - target_len).abs() + 4),
+            zdrop: -1,
+            end_bonus: 0,
+            flag: 0,
+        };
+        let ez = scratch.aligner.align(&input);
+        (ez.cigar.clone(), ez.score)
+    };
+    if packed.is_empty() {
+        return false;
+    }
+
+    out.ref_start = window_start;
+    out.score = score;
+    push_op(&mut out.ops, CigarOpKind::SoftClip, leading_clip as u32);
+    for entry in &packed {
+        let len = entry >> 4;
+        let kind = match entry & 0xf {
+            0 => CigarOpKind::Match,
+            1 => CigarOpKind::Insertion,
+            2 => CigarOpKind::Deletion,
+            other => {
+                debug_assert!(false, "ksw2 emitted an unexpected CIGAR op {other}");
+                return false;
+            }
+        };
+        push_op(&mut out.ops, kind, len);
+    }
+    push_op(&mut out.ops, CigarOpKind::SoftClip, trailing_clip as u32);
+
+    // A leading or trailing deletion is a legal DP result but a meaningless
+    // record: it claims reference bases outside the read's span. Trim them and
+    // move the start position accordingly.
+    trim_edge_deletions(out);
+    fill_md_and_edit_distance(query, ref_seq, ambiguous, out);
+    true
+}
+
+/// Drop `D`/`N` operations at either end of the CIGAR, shifting `ref_start` past
+/// a leading one.
+fn trim_edge_deletions(out: &mut RealizedAlignment) {
+    while let Some(first) = out.ops.first().copied() {
+        // A leading clip is fine; look past it for a deletion.
+        let index = if first.kind == CigarOpKind::SoftClip {
+            1
+        } else {
+            0
+        };
+        match out.ops.get(index).copied() {
+            Some(op) if matches!(op.kind, CigarOpKind::Deletion | CigarOpKind::Skip) => {
+                out.ref_start += op.len as i32;
+                out.ops.remove(index);
+            }
+            _ => break,
+        }
+    }
+    while let Some(&last) = out.ops.last() {
+        let index = if last.kind == CigarOpKind::SoftClip {
+            out.ops.len().saturating_sub(2)
+        } else {
+            out.ops.len() - 1
+        };
+        match out.ops.get(index).copied() {
+            Some(op) if matches!(op.kind, CigarOpKind::Deletion | CigarOpKind::Skip) => {
+                out.ops.remove(index);
+            }
+            _ => break,
+        }
+    }
+}
+
+/// Walk the finished CIGAR against read and reference to fill in `MD` and `NM`.
+///
+/// `MD` alternates: a count of reference bases that matched, then either the
+/// reference base at a mismatch or `^` followed by the deleted reference bases. A
+/// count is emitted between every pair of those, including zero-length ones, which
+/// is what makes the string unambiguously parseable.
+pub(crate) fn fill_md_and_edit_distance(
+    query: &[u8],
+    ref_seq: &[u8],
+    ambiguous: &[u32],
+    out: &mut RealizedAlignment,
+) {
+    use std::fmt::Write as _;
+
+    let mut read_pos = 0usize;
+    let mut ref_pos = out.ref_start as usize;
+    let mut matched_run = 0u32;
+    let mut edit_distance = 0u32;
+
+    for op in &out.ops {
+        match op.kind {
+            CigarOpKind::Match => {
+                for _ in 0..op.len {
+                    let read_base = query.get(read_pos).copied().unwrap_or(b'N');
+                    // A base the build replaced is reported as the `N` it was, not
+                    // as the substitute the index carries: the record describes the
+                    // reference the user supplied.
+                    let ref_base = if ambiguous.binary_search(&(ref_pos as u32)).is_ok() {
+                        b'N'
+                    } else {
+                        ref_seq.get(ref_pos).copied().unwrap_or(b'N')
+                    };
+                    if bases_match(read_base, ref_base) {
+                        matched_run += 1;
+                    } else {
+                        let _ = write!(out.md, "{matched_run}");
+                        out.md.push(ref_base.to_ascii_uppercase() as char);
+                        matched_run = 0;
+                        edit_distance += 1;
+                    }
+                    read_pos += 1;
+                    ref_pos += 1;
+                }
+            }
+            CigarOpKind::Insertion => {
+                edit_distance += op.len;
+                read_pos += op.len as usize;
+            }
+            CigarOpKind::Deletion => {
+                let _ = write!(out.md, "{matched_run}");
+                matched_run = 0;
+                out.md.push('^');
+                for _ in 0..op.len {
+                    let ref_base = if ambiguous.binary_search(&(ref_pos as u32)).is_ok() {
+                        b'N'
+                    } else {
+                        ref_seq.get(ref_pos).copied().unwrap_or(b'N')
+                    };
+                    out.md.push(ref_base.to_ascii_uppercase() as char);
+                    ref_pos += 1;
+                }
+                edit_distance += op.len;
+            }
+            // An intron is not an edit: the read simply does not cross it, and MD
+            // is defined over the aligned blocks only.
+            CigarOpKind::Skip => ref_pos += op.len as usize,
+            CigarOpKind::SoftClip => read_pos += op.len as usize,
+        }
+    }
+    let _ = write!(out.md, "{matched_run}");
+    out.edit_distance = edit_distance;
+}
+
+fn encode_into(seq: &[u8], out: &mut Vec<u8>) {
+    out.clear();
+    out.reserve(seq.len());
+    out.extend(seq.iter().map(|&b| dna5(b)));
+}
+
+/// How many reference bases a CIGAR spans.
+pub fn reference_span(ops: &[CigarOp]) -> i32 {
+    ops.iter()
+        .filter(|op| op.kind.consumes_reference())
+        .map(|op| op.len as i32)
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> AlignConfig {
+        AlignConfig::default()
+    }
+
+    /// A deterministic sequence with no repeats long enough to give the anchor
+    /// repair a second equally good home for a read. A periodic reference would
+    /// make these tests assert on an arbitrary choice between ties.
+    fn nonrepeating(len: usize) -> Vec<u8> {
+        let mut state: u64 = 0x2545F4914F6CDD1D;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                b"ACGT"[((state >> 33) % 4) as usize]
+            })
+            .collect()
+    }
+
+    fn realize_at(read: &[u8], reference: &[u8], pos: i32) -> RealizedAlignment {
+        let mut scratch = RealizeScratch::default();
+        let mut out = RealizedAlignment::default();
+        assert!(realize(
+            read,
+            true,
+            reference,
+            &[],
+            pos,
+            &config(),
+            &mut scratch,
+            &mut out
+        ));
+        out
+    }
+
+    fn cigar_string(out: &RealizedAlignment) -> String {
+        out.ops
+            .iter()
+            .map(|op| format!("{}{}", op.len, op.kind.letter()))
+            .collect()
+    }
+
+    /// A read that matches the reference exactly is one `M` run, no edits, and an
+    /// `MD` that is just its length.
+    #[test]
+    fn exact_match_has_no_edits() {
+        let reference = b"ACGTACGTACGTACGTACGTACGTACGTACGT";
+        let out = realize_at(&reference[4..24], reference, 4);
+        assert_eq!(cigar_string(&out), "20M");
+        assert_eq!(out.ref_start, 4);
+        assert_eq!(out.edit_distance, 0);
+        assert_eq!(out.md, "20");
+    }
+
+    /// A single substitution stays one `M` run, SAM's `M` covers mismatches, and
+    /// shows up in `NM` and as a reference base in `MD`.
+    #[test]
+    fn substitution_is_reported_in_md_not_cigar() {
+        let reference = b"ACGTACGTACGTACGTACGTACGTACGTACGT";
+        let mut read = reference[4..24].to_vec();
+        read[5] = b'A'; // reference has C here
+        let out = realize_at(&read, reference, 4);
+        assert_eq!(cigar_string(&out), "20M");
+        assert_eq!(out.edit_distance, 1);
+        assert_eq!(out.md, "5C14");
+    }
+
+    /// A deleted reference stretch becomes a `D` operation, is counted in `NM`,
+    /// and is spelled out after a `^` in `MD`.
+    #[test]
+    fn deletion_produces_a_d_operation_and_caret_in_md() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAA";
+        let mut read = Vec::new();
+        read.extend_from_slice(&reference[2..12]);
+        read.extend_from_slice(&reference[15..27]);
+        let out = realize_at(&read, reference, 2);
+        assert_eq!(out.ref_start, 2);
+        assert_eq!(cigar_string(&out), "10M3D12M");
+        assert_eq!(out.edit_distance, 3);
+        assert!(
+            out.md.contains('^'),
+            "MD should mark the deletion: {}",
+            out.md
+        );
+    }
+
+    /// Bases inserted in the read become an `I` operation and count toward `NM`,
+    /// but leave no trace in `MD`, `MD` describes the reference.
+    #[test]
+    fn insertion_produces_an_i_operation() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAA";
+        let mut read = Vec::new();
+        read.extend_from_slice(&reference[2..14]);
+        read.extend_from_slice(b"GTA");
+        read.extend_from_slice(&reference[14..26]);
+        let out = realize_at(&read, reference, 2);
+        assert_eq!(cigar_string(&out), "12M3I12M");
+        assert_eq!(out.edit_distance, 3);
+        assert_eq!(out.md, "24");
+    }
+
+    /// A read hanging off the 5' end of the transcript is clipped, not placed at a
+    /// negative position.
+    #[test]
+    fn overhang_at_the_start_becomes_a_leading_clip() {
+        let reference = b"ACGTACGTACGTACGTACGTACGTACGTACGT";
+        let mut read = b"TTTT".to_vec();
+        read.extend_from_slice(&reference[0..16]);
+        let out = realize_at(&read, reference, -4);
+        assert_eq!(out.ref_start, 0);
+        assert_eq!(cigar_string(&out), "4S16M");
+        assert_eq!(out.edit_distance, 0);
+    }
+
+    /// A read running past the 3' end is clipped there instead of claiming
+    /// reference bases that do not exist.
+    #[test]
+    fn overhang_at_the_end_becomes_a_trailing_clip() {
+        let reference = b"ACGTACGTACGTACGTACGTACGTACGTACGT";
+        let mut read = reference[24..].to_vec();
+        read.extend_from_slice(b"TTTTTT");
+        let out = realize_at(&read, reference, 24);
+        assert_eq!(out.ref_start, 24);
+        assert_eq!(cigar_string(&out), "8M6S");
+    }
+
+    /// A reverse-strand read is realized against the forward reference, matching
+    /// what SAM stores in `SEQ`.
+    #[test]
+    fn reverse_strand_reads_are_realized_on_the_forward_strand() {
+        let reference = b"ACGTACGTTTGGCCAAGGTTACGTACGTACGT";
+        let forward = &reference[6..26];
+        let read: Vec<u8> = forward.iter().rev().map(|&b| complement(b)).collect();
+        let mut scratch = RealizeScratch::default();
+        let mut out = RealizedAlignment::default();
+        assert!(realize(
+            &read,
+            false,
+            reference,
+            &[],
+            6,
+            &config(),
+            &mut scratch,
+            &mut out
+        ));
+        assert_eq!(cigar_string(&out), "20M");
+        assert_eq!(out.edit_distance, 0);
+        assert_eq!(out.md, "20");
+    }
+
+    /// The mapper's position comes from a seed chain, and a mismatch near the
+    /// read's 5' end pushes that chain rightwards. Anchoring the read there
+    /// leaves the DP no way to say "it started earlier" except with a leading
+    /// insertion, which is a worse alignment and a false one. The anchor has to
+    /// be corrected from the alignment itself.
+    #[test]
+    fn a_late_anchor_is_pulled_back_instead_of_becoming_an_insertion() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAAACGTACGTTTGGCCAA";
+        let mut read = reference[4..44].to_vec();
+        read[3] = complement(read[3]);
+        // Hand it a position 8 bases past the read's true start.
+        let out = realize_at(&read, reference, 12);
+        assert_eq!(cigar_string(&out), "40M");
+        assert_eq!(out.ref_start, 4);
+        assert_eq!(out.edit_distance, 1);
+    }
+
+    /// The anchor repair has to see offsets the DP's band cannot, which is the
+    /// whole reason it exists: it slides the read by comparison, so a start that
+    /// is wrong by more than the bandwidth is still found.
+    #[test]
+    fn a_badly_placed_read_is_slid_back_further_than_the_band() {
+        let cfg = config();
+        assert!(
+            cfg.indel_margin as i32 > cfg.bandwidth,
+            "this test is only meaningful when the offset can exceed the band"
+        );
+        let reference = nonrepeating(400);
+        let read = &reference[60..160];
+        // Anchored 25 bases late, well past the bandwidth of 15.
+        assert_eq!(
+            repair_anchor(read, &reference, 85, &cfg, &mut Vec::new()).map(|(p, _)| p),
+            Some(60)
+        );
+        let out = realize_at(read, &reference, 85);
+        assert_eq!(cigar_string(&out), "100M");
+        assert_eq!(out.ref_start, 60);
+        assert_eq!(out.edit_distance, 0);
+    }
+
+    /// A read that is where it belongs must not be slid. Sequencing errors are
+    /// not evidence of a wrong anchor, and scanning for one would cost more than
+    /// the alignment it replaces.
+    #[test]
+    fn a_correctly_placed_read_is_left_alone() {
+        let cfg = config();
+        let reference = nonrepeating(400);
+        let mut read = reference[60..160].to_vec();
+        for i in [10usize, 41, 77] {
+            read[i] = complement(read[i]);
+        }
+        assert_eq!(
+            repair_anchor(&read, &reference, 60, &cfg, &mut Vec::new()),
+            None
+        );
+        let out = realize_at(&read, &reference, 60);
+        assert_eq!(cigar_string(&out), "100M");
+        assert_eq!(out.ref_start, 60);
+        assert_eq!(out.edit_distance, 3);
+    }
+
+    /// A seed chain on a repeat can imply a start most of a read away from the
+    /// truth. The old search reached only `indel_margin`, which is a bound on
+    /// indel size and has nothing to do with how wrong an anchor can be, so the
+    /// banded DP was left to describe a read that was nowhere near where it was
+    /// placed. It obliged, with a sawtooth of one-base indels walking the read
+    /// diagonally across the reference: a valid CIGAR and a false claim.
+    #[test]
+    fn an_anchor_wrong_by_most_of_a_read_is_still_found() {
+        let reference = nonrepeating(600);
+        let read = &reference[200..300];
+        // 69 bases late, far past indel_margin.
+        let out = realize_at(read, &reference, 269);
+        assert_eq!(cigar_string(&out), "100M");
+        assert_eq!(out.ref_start, 200);
+        assert_eq!(out.edit_distance, 0);
+    }
+
+    /// When no anchor produces an alignment the mapper would have accepted, the
+    /// honest answer is no base-level alignment at all. Publishing the DP's
+    /// best-effort sawtooth would contradict the `AS` on the same record.
+    #[test]
+    fn an_unplaceable_read_is_refused_rather_than_described() {
+        let reference = nonrepeating(600);
+        let read = nonrepeating(100);
+        let mut scratch = RealizeScratch::default();
+        let mut out = RealizedAlignment::default();
+        assert!(
+            !realize(
+                &read,
+                true,
+                &reference,
+                &[],
+                250,
+                &config(),
+                &mut scratch,
+                &mut out
+            ),
+            "an unrelated read should not be given a CIGAR"
+        );
+        assert!(out.ops.is_empty());
+    }
+
+    /// An insertion at the very edge of an alignment claims nothing and inflates
+    /// NM; a soft clip says the same thing honestly.
+    #[test]
+    fn edge_insertions_become_soft_clips() {
+        let mut out = RealizedAlignment {
+            ops: vec![
+                CigarOp::new(CigarOpKind::Insertion, 3),
+                CigarOp::new(CigarOpKind::Match, 20),
+                CigarOp::new(CigarOpKind::Insertion, 2),
+            ],
+            edit_distance: 5,
+            ..RealizedAlignment::default()
+        };
+        clip_edge_insertions(&mut out);
+        assert_eq!(cigar_string(&out), "3S20M2S");
+        assert_eq!(out.edit_distance, 0);
+    }
+
+    /// A base the index had to replace is reported as the `N` it was in the
+    /// input, not as the substitute the index stores. Otherwise the record
+    /// describes a reference the user never supplied, and disagrees with the
+    /// `M5` on its own `@SQ` line.
+    #[test]
+    fn a_replaced_base_is_reported_as_n() {
+        let reference = nonrepeating(200);
+        let read = &reference[50..150];
+        // Offset 80 of the reference held a non-ACGT base at index time.
+        let mut scratch = RealizeScratch::default();
+        let mut out = RealizedAlignment::default();
+        assert!(realize(
+            read,
+            true,
+            &reference,
+            &[80],
+            50,
+            &config(),
+            &mut scratch,
+            &mut out
+        ));
+        assert_eq!(cigar_string(&out), "100M");
+        // The read agrees with the stored base, but the reference base is unknown,
+        // so it counts as an edit and MD names it.
+        assert_eq!(out.edit_distance, 1);
+        assert_eq!(out.md, "30N69");
+    }
+
+    /// `MD` and `NM` must be consistent with the CIGAR: every `M` base is either
+    /// counted in a run or named as a mismatch, so the run lengths plus the named
+    /// bases add back up to the aligned length.
+    #[test]
+    fn md_covers_every_aligned_reference_base() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAA";
+        let mut read = reference[3..30].to_vec();
+        read[4] = complement(read[4]);
+        read[19] = complement(read[19]);
+        let out = realize_at(&read, reference, 3);
+        let mut covered = 0usize;
+        let mut digits = String::new();
+        let mut chars = out.md.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c.is_ascii_digit() {
+                digits.push(c);
+                continue;
+            }
+            covered += digits.parse::<usize>().unwrap_or(0);
+            digits.clear();
+            if c == '^' {
+                while chars.peek().is_some_and(|n| n.is_ascii_alphabetic()) {
+                    chars.next();
+                    covered += 1;
+                }
+            } else {
+                covered += 1;
+            }
+        }
+        covered += digits.parse::<usize>().unwrap_or(0);
+        assert_eq!(covered, reference_span(&out.ops) as usize);
+        assert_eq!(out.edit_distance, 2);
+    }
+
+    /// Realizing must never produce a CIGAR whose read length disagrees with the
+    /// read: that is the single check every SAM validator makes first.
+    #[test]
+    fn cigar_read_length_always_matches_the_read() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAAACGTACGT";
+        for start in 0..20i32 {
+            for len in [12usize, 25, 31] {
+                let end = (start as usize + len).min(reference.len());
+                if end <= start as usize {
+                    continue;
+                }
+                let read = &reference[start as usize..end];
+                let mut scratch = RealizeScratch::default();
+                let mut out = RealizedAlignment::default();
+                if !realize(
+                    read,
+                    true,
+                    reference,
+                    &[],
+                    start,
+                    &config(),
+                    &mut scratch,
+                    &mut out,
+                ) {
+                    continue;
+                }
+                let consumed: u32 = out
+                    .ops
+                    .iter()
+                    .filter(|op| op.kind.consumes_read())
+                    .map(|op| op.len)
+                    .sum();
+                assert_eq!(consumed as usize, read.len(), "start={start} len={len}");
+            }
+        }
+    }
+}

--- a/crates/salmon-quant/Cargo.toml
+++ b/crates/salmon-quant/Cargo.toml
@@ -18,6 +18,11 @@ salmon-infer = { workspace = true }
 salmon-rad = { workspace = true }
 piscem-rs = { workspace = true }
 paraseq-temp = { workspace = true }
+# Annotation parsing for the spliced genome output: exon structures per
+# transcript, so a transcriptome alignment can be cut at exon boundaries and
+# reported in genome coordinates. Same crate salmon-align already uses for the
+# opposite (genome -> transcriptome) direction, kept at one version.
+bramble-rs = "0.1.8"
 thread-broker = { workspace = true }
 rapidgzip-core = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/salmon-quant/Cargo.toml
+++ b/crates/salmon-quant/Cargo.toml
@@ -29,6 +29,9 @@ rayon = { workspace = true }
 crossbeam-channel = { workspace = true }
 noodles-bgzf = "0.51"
 jiff = "0.2"
+# @SQ M5: the MD5 of each reference sequence. It is what binds a BAM to the
+# exact reference it was made against, and what CRAM needs to reconstruct bases.
+md-5 = "0.11"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/salmon-quant/src/bam.rs
+++ b/crates/salmon-quant/src/bam.rs
@@ -48,7 +48,7 @@ use noodles_bgzf as bgzf;
 use salmon_index::SalmonIndex;
 use salmon_map::ScoredMapping;
 
-use crate::mapping_record::{self, AlignmentRecord, CigarKind};
+use crate::mapping_record::{self, AlignmentRecord, EmitScratch, RecordOptions};
 
 /// Hand a chunk to the writer once it reaches this size. Large enough that the
 /// per-chunk handoff is negligible, small enough to bound queued memory.
@@ -318,6 +318,7 @@ impl BamScratch<'_> {
     /// therefore contiguous in one chunk, and chunks are written whole. That is
     /// what keeps the output collated by fragment even though nothing else
     /// about the record order is constrained.
+    #[allow(clippy::too_many_arguments)]
     pub fn write_fragment(
         &mut self,
         salmon: &SalmonIndex,
@@ -325,10 +326,20 @@ impl BamScratch<'_> {
         r1_seq: &[u8],
         r2: Option<(&[u8], &[u8])>,
         maps: &[ScoredMapping],
+        options: &RecordOptions<'_>,
+        scratch: &mut EmitScratch,
     ) -> io::Result<()> {
-        mapping_record::emit_fragment_records(salmon, r1_id, r1_seq, r2, maps, |record| {
-            encode_record(&mut self.buffer, record)
-        })?;
+        let buffer = &mut self.buffer;
+        mapping_record::emit_fragment_records(
+            salmon,
+            r1_id,
+            r1_seq,
+            r2,
+            maps,
+            options,
+            scratch,
+            |record| encode_record(buffer, record),
+        )?;
         if self.buffer.len() >= CHUNK_TARGET {
             self.flush()?;
         }
@@ -457,6 +468,14 @@ fn push_aux_i64(buf: &mut Vec<u8>, tag: [u8; 2], value: i64) {
     }
 }
 
+/// Append a NUL-terminated string tag (`Z`).
+fn push_aux_str(buf: &mut Vec<u8>, tag: [u8; 2], value: &str) {
+    buf.extend_from_slice(&tag);
+    buf.push(b'Z');
+    buf.extend_from_slice(value.as_bytes());
+    buf.push(0);
+}
+
 /// Encode one record in BAM's binary layout: a fixed 32-byte header, then the
 /// variable-length name, CIGAR, packed sequence, qualities and tags.
 ///
@@ -466,23 +485,29 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
     // reserve the four bytes now and patch them in below.
     let block_start = buf.len();
     push_u32(buf, 0);
-    push_i32(buf, record.reference_id as i32);
-    push_i32(buf, record.position.max(0));
+    // An unmapped record has no reference and no position; BAM spells both -1.
+    push_i32(buf, record.reference_id.map_or(-1, |id| id as i32));
+    push_i32(
+        buf,
+        if record.reference_id.is_some() {
+            record.position.max(0)
+        } else {
+            -1
+        },
+    );
     let name_len = record.name.len() + 1;
-    let cigar_len = record.cigar.as_slice().len();
-    let reference_span: i32 = record
-        .cigar
-        .as_slice()
-        .iter()
-        .filter(|op| matches!(op.kind, CigarKind::Match))
-        .map(|op| op.len as i32)
-        .sum();
+    let cigar_len = record.cigar.len();
+    let reference_span = salmon_map::realize::reference_span(record.cigar);
     buf.push(u8::try_from(name_len).map_err(|_| io::Error::other("BAM read name too long"))?);
     buf.push(record.mapping_quality);
     buf.extend_from_slice(
         &reg2bin(record.position, record.position + reference_span).to_le_bytes(),
     );
-    buf.extend_from_slice(&(cigar_len as u16).to_le_bytes());
+    buf.extend_from_slice(
+        &u16::try_from(cigar_len)
+            .map_err(|_| io::Error::other("BAM CIGAR too long"))?
+            .to_le_bytes(),
+    );
     buf.extend_from_slice(&record.flags.to_le_bytes());
     push_i32(buf, record.sequence.len() as i32);
     push_i32(buf, record.mate_reference_id.map_or(-1, |id| id as i32));
@@ -490,12 +515,8 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
     push_i32(buf, record.template_length);
     buf.extend_from_slice(record.name);
     buf.push(0);
-    for op in record.cigar.as_slice() {
-        let code = match op.kind {
-            CigarKind::Match => 0,
-            CigarKind::SoftClip => 4,
-        };
-        push_u32(buf, ((op.len as u32) << 4) | code);
+    for op in record.cigar {
+        push_u32(buf, (op.len << 4) | op.kind as u32);
     }
     for i in (0..record.sequence.len()).step_by(2) {
         let high = base_code(record_base(record, i));
@@ -514,6 +535,12 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
     buf.extend_from_slice(b"XTA");
     buf.push(record.xt);
     push_aux_i64(buf, *b"AS", record.alignment_score as i64);
+    if let Some(edit_distance) = record.edit_distance {
+        push_aux_i64(buf, *b"NM", edit_distance as i64);
+    }
+    if let Some(md) = record.md {
+        push_aux_str(buf, *b"MD", md);
+    }
     // Patch the reserved length field now the record's extent is known (`- 4`
     // because the length itself is not counted).
     let block_size = u32::try_from(buf.len() - block_start - 4)

--- a/crates/salmon-quant/src/bam.rs
+++ b/crates/salmon-quant/src/bam.rs
@@ -404,16 +404,18 @@ fn encode_header(
     buf.extend_from_slice(b"BAM\x01");
     push_i32(&mut buf, i32::try_from(text.len())?);
     buf.extend_from_slice(text.as_bytes());
-    push_i32(&mut buf, i32::try_from(salmon.num_refs())?);
-    for tid in 0..salmon.num_refs() {
-        let name = salmon.ref_name(tid).as_bytes();
+    // The same reference table the header text declares: transcripts normally,
+    // chromosomes when records are projected onto the genome.
+    let references = options.reference_table(salmon);
+    push_i32(&mut buf, i32::try_from(references.len())?);
+    for (name, length) in &references {
         push_i32(&mut buf, i32::try_from(name.len() + 1)?);
-        buf.extend_from_slice(name);
+        buf.extend_from_slice(name.as_bytes());
         buf.push(0);
         push_i32(
             &mut buf,
-            i32::try_from(salmon.ref_len(tid))
-                .map_err(|_| anyhow::anyhow!("reference {} exceeds BAM length limit", tid))?,
+            i32::try_from(*length)
+                .map_err(|_| anyhow::anyhow!("reference {name} exceeds BAM length limit"))?,
         );
     }
     Ok(buf)

--- a/crates/salmon-quant/src/bam.rs
+++ b/crates/salmon-quant/src/bam.rs
@@ -349,6 +349,27 @@ impl BamScratch<'_> {
         Ok(())
     }
 
+    /// Encode the records for a fragment that did not map. Same chunking
+    /// contract as [`Self::write_fragment`]: both of a pair's records land in one
+    /// chunk, so an unmapped pair is never split across chunk boundaries.
+    pub fn write_unmapped_fragment(
+        &mut self,
+        r1_id: &[u8],
+        r1_seq: &[u8],
+        r1_qual: Option<&[u8]>,
+        r2: Option<(&[u8], &[u8], Option<&[u8]>)>,
+        options: &RecordOptions<'_>,
+    ) -> io::Result<()> {
+        let buffer = &mut self.buffer;
+        mapping_record::emit_unmapped_fragment(r1_id, r1_seq, r1_qual, r2, options, |record| {
+            encode_record(buffer, record)
+        })?;
+        if self.buffer.len() >= CHUNK_TARGET {
+            self.flush()?;
+        }
+        Ok(())
+    }
+
     /// Hand the accumulated chunk to the writer thread. Only the `Vec`
     /// descriptor moves; the backing allocation is not copied.
     pub fn flush(&mut self) -> io::Result<()> {
@@ -579,7 +600,7 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
     // An unmapped record carries no placement tags: NH/HI describe a set of
     // placements it does not have, AS/XT an alignment never made. The read group
     // is a property of the read, so it stays.
-    {
+    if !record.is_unmapped() {
         push_aux_i64(buf, *b"NH", record.nh as i64);
         push_aux_i64(buf, *b"HI", record.hi as i64);
         buf.extend_from_slice(b"XTA");

--- a/crates/salmon-quant/src/bam.rs
+++ b/crates/salmon-quant/src/bam.rs
@@ -623,6 +623,10 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
                 push_aux_cigar(buf, *b"MC", mate_cigar);
             }
         }
+        if let Some(strand) = record.transcript_strand {
+            buf.extend_from_slice(b"XSA");
+            buf.push(strand);
+        }
     }
     if let Some(read_group) = record.read_group {
         push_aux_str(buf, *b"RG", read_group);

--- a/crates/salmon-quant/src/bam.rs
+++ b/crates/salmon-quant/src/bam.rs
@@ -178,6 +178,7 @@ impl BamOutput {
         command: &str,
         threads: usize,
         compress_threads: Option<NonZeroUsize>,
+        options: &RecordOptions<'_>,
     ) -> anyhow::Result<Self> {
         use anyhow::Context as _;
         if let Some(parent) = path.parent() {
@@ -195,7 +196,7 @@ impl BamOutput {
             crossbeam_channel::bounded(queue_capacity + threads);
         let failure = Arc::new(WriterFailure(Mutex::new(None)));
         let writer_failure = Arc::clone(&failure);
-        let header = encode_header(salmon, command)?;
+        let header = encode_header(salmon, command, options)?;
         let compression_workers =
             compress_threads.unwrap_or_else(|| compression_worker_count(threads));
         tracing::debug!(
@@ -324,7 +325,8 @@ impl BamScratch<'_> {
         salmon: &SalmonIndex,
         r1_id: &[u8],
         r1_seq: &[u8],
-        r2: Option<(&[u8], &[u8])>,
+        r1_qual: Option<&[u8]>,
+        r2: Option<(&[u8], &[u8], Option<&[u8]>)>,
         maps: &[ScoredMapping],
         options: &RecordOptions<'_>,
         scratch: &mut EmitScratch,
@@ -334,6 +336,7 @@ impl BamScratch<'_> {
             salmon,
             r1_id,
             r1_seq,
+            r1_qual,
             r2,
             maps,
             options,
@@ -370,8 +373,12 @@ fn push_u32(buf: &mut Vec<u8>, value: u32) {
 
 /// Encode the BAM header block: the shared SAM header text (byte-identical to
 /// what `--writeMappings` writes) followed by the binary reference table.
-fn encode_header(salmon: &SalmonIndex, command: &str) -> anyhow::Result<Vec<u8>> {
-    let text = mapping_record::header_text(salmon, command);
+fn encode_header(
+    salmon: &SalmonIndex,
+    command: &str,
+    options: &RecordOptions<'_>,
+) -> anyhow::Result<Vec<u8>> {
+    let text = mapping_record::header_text(salmon, command, options);
     let mut buf = Vec::with_capacity(text.len() + salmon.num_refs() * 32);
     buf.extend_from_slice(b"BAM\x01");
     push_i32(&mut buf, i32::try_from(text.len())?);
@@ -468,12 +475,53 @@ fn push_aux_i64(buf: &mut Vec<u8>, tag: [u8; 2], value: i64) {
     }
 }
 
+/// Append a float tag. BAM stores a `f` tag as a little-endian IEEE-754 single,
+/// which is exactly what SAM's `ZW:f` carries.
+fn push_aux_f32(buf: &mut Vec<u8>, tag: [u8; 2], value: f32) {
+    buf.extend_from_slice(&tag);
+    buf.push(b'f');
+    buf.extend_from_slice(&value.to_le_bytes());
+}
+
+/// Append a CIGAR as a `Z` tag, in the same text spelling SAM uses. `MC` is a
+/// string tag even in BAM, so the mate's CIGAR is written out rather than packed.
+fn push_aux_cigar(buf: &mut Vec<u8>, tag: [u8; 2], ops: &[salmon_map::realize::CigarOp]) {
+    use std::io::Write as _;
+    buf.extend_from_slice(&tag);
+    buf.push(b'Z');
+    for op in ops {
+        let _ = write!(buf, "{}{}", op.len, op.kind.letter());
+    }
+    buf.push(0);
+}
+
 /// Append a NUL-terminated string tag (`Z`).
 fn push_aux_str(buf: &mut Vec<u8>, tag: [u8; 2], value: &str) {
     buf.extend_from_slice(&tag);
     buf.push(b'Z');
     buf.extend_from_slice(value.as_bytes());
     buf.push(0);
+}
+
+/// Append the per-base qualities.
+///
+/// BAM stores raw Phred values, not the FASTQ's ASCII, so every byte has 33
+/// subtracted. They are reversed alongside a reverse-strand `SEQ` so base *i* of
+/// each still describes base *i* of the other. `0xff` in every position is the
+/// format's "quality unavailable" marker, used when the input carried none, and
+/// also when the quality string does not match the read length: a mismatched
+/// pair is what makes a record unreadable, and a truncated FASTQ record should
+/// not be able to produce one.
+fn push_qualities(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) {
+    match mapping_record::usable_qualities(record) {
+        Some(qualities) if record.reverse_complement => {
+            buf.extend(qualities.iter().rev().map(|&q| q.saturating_sub(33)));
+        }
+        Some(qualities) => {
+            buf.extend(qualities.iter().map(|&q| q.saturating_sub(33)));
+        }
+        None => buf.resize(buf.len() + record.sequence.len(), 0xff),
+    }
 }
 
 /// Encode one record in BAM's binary layout: a fixed 32-byte header, then the
@@ -527,19 +575,34 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
         };
         buf.push((high << 4) | low);
     }
-    // Base qualities, one byte per base. salmon does not retain them, and 0xff is
-    // the format's "quality unavailable" marker (SAM writes `*` for the same).
-    buf.resize(buf.len() + record.sequence.len(), 0xff);
-    push_aux_i64(buf, *b"NH", record.nh as i64);
-    push_aux_i64(buf, *b"HI", record.hi as i64);
-    buf.extend_from_slice(b"XTA");
-    buf.push(record.xt);
-    push_aux_i64(buf, *b"AS", record.alignment_score as i64);
-    if let Some(edit_distance) = record.edit_distance {
-        push_aux_i64(buf, *b"NM", edit_distance as i64);
+    push_qualities(buf, record);
+    // An unmapped record carries no placement tags: NH/HI describe a set of
+    // placements it does not have, AS/XT an alignment never made. The read group
+    // is a property of the read, so it stays.
+    {
+        push_aux_i64(buf, *b"NH", record.nh as i64);
+        push_aux_i64(buf, *b"HI", record.hi as i64);
+        buf.extend_from_slice(b"XTA");
+        buf.push(record.xt);
+        push_aux_i64(buf, *b"AS", record.alignment_score as i64);
+        push_aux_f32(buf, *b"ZW", record.weight);
+        if let Some(edit_distance) = record.edit_distance {
+            push_aux_i64(buf, *b"NM", edit_distance as i64);
+        }
+        if let Some(md) = record.md {
+            push_aux_str(buf, *b"MD", md);
+        }
+        if let Some(mate_mapping_quality) = record.mate_mapping_quality {
+            push_aux_i64(buf, *b"MQ", mate_mapping_quality as i64);
+        }
+        if let Some(mate_cigar) = record.mate_cigar {
+            if !mate_cigar.is_empty() {
+                push_aux_cigar(buf, *b"MC", mate_cigar);
+            }
+        }
     }
-    if let Some(md) = record.md {
-        push_aux_str(buf, *b"MD", md);
+    if let Some(read_group) = record.read_group {
+        push_aux_str(buf, *b"RG", read_group);
     }
     // Patch the reserved length field now the record's extent is known (`- 4`
     // because the length itself is not counted).

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -120,6 +120,9 @@ pub struct QuantOptions {
     /// compression just keeps up with record production; set it only to
     /// benchmark or to compensate for unusually slow/fast storage.
     pub bam_compress_threads: Option<std::num::NonZeroUsize>,
+    /// `--rgLine`: the `@RG` line to declare in the mapping output's header, and
+    /// the `ID` every record's `RG` tag then refers to.
+    pub read_group: Option<mapping_record::ReadGroup>,
     /// write per-fragment mappings to this RAD file (`--writeRad`); sketch or
     /// selective-alignment profile is chosen from `sketch`. Quantification still
     /// runs; combine with `skip_quant` to map only.
@@ -239,6 +242,7 @@ impl QuantOptions {
             dump_eq: false,
             dump_eq_weights: false,
             write_unmapped_names: false,
+            read_group: None,
             write_mappings: None,
             write_bam: None,
             bam_compress_threads: None,
@@ -470,15 +474,31 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     // the two cannot disagree. Realizing a base-level CIGAR costs two banded DPs
     // per emitted record, so it is only switched on when records are being
     // written at all.
+    // UR is a URI, not a path: samtools writes `file://` + an absolute path, and
+    // anything resolving the reference expects the same shape.
+    let index_uri = format!(
+        "file://{}",
+        std::fs::canonicalize(&opts.index_dir)
+            .unwrap_or_else(|_| opts.index_dir.clone())
+            .display()
+    );
     let record_options = mapping_record::RecordOptions {
+        read_group: opts.read_group.as_ref(),
         align_config: (opts.write_mappings.is_some() || opts.write_bam.is_some())
             .then_some(&opts.map_config.align),
+        // The index directory is the honest answer to "where did these bases
+        // come from": it is what the run was pointed at, and what someone
+        // reproducing it needs.
+        reference_uri: Some(&index_uri),
     };
     // SAM sink for `--writeMappings` (header written here).
     let sam_writer: Option<sam::SamWriter> = match &opts.write_mappings {
         Some(path) => {
             let cmd = format!("salmon quant -i {}", opts.index_dir.display());
-            Some(sam::SamWriter::create(path, &salmon, &cmd).context("opening SAM output")?)
+            Some(
+                sam::SamWriter::create(path, &salmon, &cmd, &record_options)
+                    .context("opening SAM output")?,
+            )
         }
         None => None,
     };
@@ -486,8 +506,15 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         Some(path) => {
             let cmd = format!("salmon quant -i {}", opts.index_dir.display());
             Some(
-                bam::BamOutput::create(path, &salmon, &cmd, nthreads, opts.bam_compress_threads)
-                    .context("opening BAM output")?,
+                bam::BamOutput::create(
+                    path,
+                    &salmon,
+                    &cmd,
+                    nthreads,
+                    opts.bam_compress_threads,
+                    &record_options,
+                )
+                .context("opening BAM output")?,
             )
         }
         None => None,

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -128,6 +128,14 @@ pub struct QuantOptions {
     /// that did not map, so the mapping output covers the whole library rather
     /// than only the part that mapped.
     pub write_unaligned: bool,
+    /// `--spliced`: report mapping output in genome coordinates, with `N`
+    /// operations at exon junctions, using `--annotation` for the exon
+    /// structures and `--genome` for the chromosome lengths `@SQ` must declare.
+    pub spliced_output: bool,
+    /// GTF/GFF annotation (`--annotation`), required by `spliced_output`.
+    pub annotation: Option<PathBuf>,
+    /// genome FASTA (`--genome`), required by `spliced_output`.
+    pub genome_fasta: Option<PathBuf>,
     /// write per-fragment mappings to this RAD file (`--writeRad`); sketch or
     /// selective-alignment profile is chosen from `sketch`. Quantification still
     /// runs; combine with `skip_quant` to map only.
@@ -249,6 +257,9 @@ impl QuantOptions {
             write_unmapped_names: false,
             read_group: None,
             write_unaligned: false,
+            spliced_output: false,
+            annotation: None,
+            genome_fasta: None,
             write_mappings: None,
             write_bam: None,
             bam_compress_threads: None,
@@ -480,6 +491,23 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     // the two cannot disagree. Realizing a base-level CIGAR costs two banded DPs
     // per emitted record, so it is only switched on when records are being
     // written at all.
+    // Genome projection, when asked for. Built before the output file is opened
+    // because it supplies the reference table the header declares.
+    let projector = if opts.spliced_output && (opts.write_mappings.is_some() || opts.write_bam.is_some())
+    {
+        let annotation = opts
+            .annotation
+            .as_deref()
+            .context("--spliced needs --annotation to know where the exons are")?;
+        let genome = opts
+            .genome_fasta
+            .as_deref()
+            .context("--spliced needs --genome for the chromosome lengths @SQ must declare")?;
+        let names: Vec<&str> = (0..num_refs).map(|t| salmon.ref_name(t)).collect();
+        Some(splice::GenomeProjector::build(&names, annotation, genome)?)
+    } else {
+        None
+    };
     // UR is a URI, not a path: samtools writes `file://` + an absolute path, and
     // anything resolving the reference expects the same shape.
     let index_uri = format!(
@@ -492,6 +520,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         read_group: opts.read_group.as_ref(),
         align_config: (opts.write_mappings.is_some() || opts.write_bam.is_some())
             .then_some(&opts.map_config.align),
+        projector: projector.as_ref(),
         // The index directory is the honest answer to "where did these bases
         // come from": it is what the run was pointed at, and what someone
         // reproducing it needs.

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -35,10 +35,10 @@
 mod bam;
 pub mod decode;
 pub mod mapping_record;
-pub mod splice;
 mod output;
 mod processor;
 mod sam;
+pub mod splice;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -493,21 +493,21 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     // written at all.
     // Genome projection, when asked for. Built before the output file is opened
     // because it supplies the reference table the header declares.
-    let projector = if opts.spliced_output && (opts.write_mappings.is_some() || opts.write_bam.is_some())
-    {
-        let annotation = opts
-            .annotation
-            .as_deref()
-            .context("--spliced needs --annotation to know where the exons are")?;
-        let genome = opts
-            .genome_fasta
-            .as_deref()
-            .context("--spliced needs --genome for the chromosome lengths @SQ must declare")?;
-        let names: Vec<&str> = (0..num_refs).map(|t| salmon.ref_name(t)).collect();
-        Some(splice::GenomeProjector::build(&names, annotation, genome)?)
-    } else {
-        None
-    };
+    let projector =
+        if opts.spliced_output && (opts.write_mappings.is_some() || opts.write_bam.is_some()) {
+            let annotation = opts
+                .annotation
+                .as_deref()
+                .context("--spliced needs --annotation to know where the exons are")?;
+            let genome = opts
+                .genome_fasta
+                .as_deref()
+                .context("--spliced needs --genome for the chromosome lengths @SQ must declare")?;
+            let names: Vec<&str> = (0..num_refs).map(|t| salmon.ref_name(t)).collect();
+            Some(splice::GenomeProjector::build(&names, annotation, genome)?)
+        } else {
+            None
+        };
     // UR is a URI, not a path: samtools writes `file://` + an absolute path, and
     // anything resolving the reference expects the same shape.
     let index_uri = format!(
@@ -961,6 +961,19 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     // requant + exact FLD parity). The mapping pass scope above has closed, so all
     // worker references to `rad_writer` are already dropped; it sits idle until
     // then.
+
+    if let Some(projector) = &projector {
+        let dropped = projector.dropped();
+        if dropped > 0 {
+            tracing::warn!(
+                placements = dropped,
+                "--spliced dropped placements whose transcript the annotation does not describe; \
+                 those fragments are absent from the mapping output (or written as unaligned with \
+                 --sampleUnaligned). Check that the annotation covers the reference the index was \
+                 built from."
+            );
+        }
+    }
 
     // Write aux_info/unmapped_names.txt ("<name> <status>" per line; the port maps
     // unmapped fragments as "u" — orphan/decoy sub-codes await mapper-reason

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -34,7 +34,7 @@
 
 mod bam;
 pub mod decode;
-mod mapping_record;
+pub mod mapping_record;
 mod output;
 mod processor;
 mod sam;
@@ -466,6 +466,14 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     } else {
         opts.num_threads
     };
+    // Run-wide mapping-output settings, shared by the header and every record so
+    // the two cannot disagree. Realizing a base-level CIGAR costs two banded DPs
+    // per emitted record, so it is only switched on when records are being
+    // written at all.
+    let record_options = mapping_record::RecordOptions {
+        align_config: (opts.write_mappings.is_some() || opts.write_bam.is_some())
+            .then_some(&opts.map_config.align),
+    };
     // SAM sink for `--writeMappings` (header written here).
     let sam_writer: Option<sam::SamWriter> = match &opts.write_mappings {
         Some(path) => {
@@ -685,6 +693,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         )?;
 
         let shared = Shared {
+            record_options: &record_options,
             busy: &plan.busy,
             salmon: &salmon,
             eq: &eq_builder,

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -35,6 +35,7 @@
 mod bam;
 pub mod decode;
 pub mod mapping_record;
+pub mod splice;
 mod output;
 mod processor;
 mod sam;

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -123,6 +123,10 @@ pub struct QuantOptions {
     /// `--rgLine`: the `@RG` line to declare in the mapping output's header, and
     /// the `ID` every record's `RG` tag then refers to.
     pub read_group: Option<mapping_record::ReadGroup>,
+    /// `--sampleUnaligned`: also write a `FLAG 0x4` record for every fragment
+    /// that did not map, so the mapping output covers the whole library rather
+    /// than only the part that mapped.
+    pub write_unaligned: bool,
     /// write per-fragment mappings to this RAD file (`--writeRad`); sketch or
     /// selective-alignment profile is chosen from `sketch`. Quantification still
     /// runs; combine with `skip_quant` to map only.
@@ -243,6 +247,7 @@ impl QuantOptions {
             dump_eq_weights: false,
             write_unmapped_names: false,
             read_group: None,
+            write_unaligned: false,
             write_mappings: None,
             write_bam: None,
             bam_compress_threads: None,
@@ -490,6 +495,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         // come from": it is what the run was pointed at, and what someone
         // reproducing it needs.
         reference_uri: Some(&index_uri),
+        write_unaligned: opts.write_unaligned,
     };
     // SAM sink for `--writeMappings` (header written here).
     let sam_writer: Option<sam::SamWriter> = match &opts.write_mappings {
@@ -721,6 +727,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
 
         let shared = Shared {
             record_options: &record_options,
+            write_unaligned: opts.write_unaligned,
             busy: &plan.busy,
             salmon: &salmon,
             eq: &eq_builder,

--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -82,27 +82,167 @@ pub struct AlignmentRecord<'a> {
     pub mate_position: Option<i32>,
     pub template_length: i32,
     pub sequence: &'a [u8],
-    /// Whether the stored sequence has to be reversed, because the read aligns to
-    /// the reverse strand and SAM stores everything on the reference's forward
-    /// strand.
+    /// Phred+33 base qualities in *read* order, as they came out of the FASTQ.
+    /// `None` when the input carried none (a FASTA), which both formats write as
+    /// "unavailable" rather than inventing values.
+    pub qualities: Option<&'a [u8]>,
+    /// Whether the stored sequence and qualities have to be reversed, because the
+    /// read aligns to the reverse strand and SAM stores everything on the
+    /// reference's forward strand.
     pub reverse_complement: bool,
     pub nh: usize,
     pub hi: usize,
     pub xt: u8,
     pub alignment_score: i32,
+    /// The mapping's equivalence-class weight, written as `ZW`.
+    pub weight: f32,
     /// `NM`, present only for a realized alignment.
     pub edit_distance: Option<u32>,
     /// `MD`, present only for a realized alignment.
     pub md: Option<&'a str>,
+    /// `RG`, present when the run declared a read group.
+    pub read_group: Option<&'a str>,
+    /// `MC`, the mate's CIGAR. Lets a reader work out where the mate ends without
+    /// having to find the mate's own record first, which is what every
+    /// mate-aware tool otherwise has to sort the file to do.
+    pub mate_cigar: Option<&'a [CigarOp]>,
+    /// `MQ`, the mate's mapping quality, for the same reason.
+    pub mate_mapping_quality: Option<u8>,
+}
+
+/// SAM version reported in `@HD VN:`. 1.6 is the version that defines the
+/// `GO:query` grouping this output actually has.
+const SAM_VERSION: &str = "1.6";
+
+/// A read group: the `@RG` header line and the `ID` that every record's `RG` tag
+/// refers back to.
+///
+/// Read groups are how a merged BAM keeps track of which sample, library and
+/// sequencing run each record came from. salmon does not need one to quantify,
+/// but anything that merges or genotypes salmon's output does.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadGroup {
+    /// The `ID` field, repeated on every record as `RG:Z:<id>`.
+    pub id: String,
+    /// The full `@RG` line as it appears in the header, without the newline.
+    pub header_line: String,
+}
+
+impl ReadGroup {
+    /// Parse a read-group specification.
+    ///
+    /// The accepted spelling is the one bwa and STAR use: tab-separated
+    /// `KEY:value` fields, with or without a leading `@RG`, and with a literal
+    /// backslash-`t` accepted in place of a real tab so the whole thing survives a
+    /// shell without quoting gymnastics. `ID` is mandatory, it is the key every
+    /// record's `RG` tag points at, so a group without one would produce a header
+    /// that no record could reference.
+    pub fn parse(spec: &str) -> anyhow::Result<Self> {
+        let normalized = spec.replace("\\t", "\t");
+        let trimmed = normalized.trim();
+        let body = trimmed
+            .strip_prefix("@RG\t")
+            .or_else(|| trimmed.strip_prefix("@RG "))
+            .unwrap_or(trimmed)
+            .trim();
+        if body.is_empty() || body == "@RG" {
+            anyhow::bail!("read group is empty; expected something like ID:sample1\\tSM:sample1");
+        }
+        let fields: Vec<&str> = body.split(['\t', ' ']).filter(|f| !f.is_empty()).collect();
+        for field in &fields {
+            let Some((tag, _)) = field.split_once(':') else {
+                anyhow::bail!("read-group field {field:?} is not of the form KEY:value");
+            };
+            if tag.len() != 2 || !tag.bytes().all(|b| b.is_ascii_alphanumeric()) {
+                anyhow::bail!("read-group field {field:?} does not start with a two-letter tag");
+            }
+        }
+        let id = fields
+            .iter()
+            .find_map(|f| f.strip_prefix("ID:"))
+            .ok_or_else(|| anyhow::anyhow!("read group has no ID: field"))?
+            .to_string();
+        if id.is_empty() {
+            anyhow::bail!("read-group ID: is empty");
+        }
+        Ok(Self {
+            id,
+            header_line: format!("@RG\t{}", fields.join("\t")),
+        })
+    }
 }
 
 /// Everything about mapping output that is fixed for a whole run, rather than
 /// derived per record.
 #[derive(Default)]
 pub struct RecordOptions<'a> {
+    /// The read group to declare in the header and tag every record with.
+    pub read_group: Option<&'a ReadGroup>,
     /// When set, placements are re-aligned to produce a real CIGAR plus `NM` and
     /// `MD`. `None` keeps the spoofed `<readLen>M` CIGAR and omits both tags.
     pub align_config: Option<&'a AlignConfig>,
+    /// `@SQ UR:`, where the reference sequences came from, so a reader can find
+    /// them again.
+    pub reference_uri: Option<&'a str>,
+}
+
+impl RecordOptions<'_> {
+    /// The reference name for `reference_id`, from whichever table this run's
+    /// records index into.
+    pub fn reference_name<'s>(&'s self, salmon: &'s SalmonIndex, id: usize) -> &'s str {
+        salmon.ref_name(id)
+    }
+
+    /// The `(name, length)` reference table to declare in the header.
+    pub fn reference_table(&self, salmon: &SalmonIndex) -> Vec<(String, u64)> {
+        (0..salmon.num_refs())
+            .map(|tid| (salmon.ref_name(tid).to_string(), salmon.ref_len(tid)))
+            .collect()
+    }
+}
+
+/// The `M5` checksum of one reference sequence.
+///
+/// `M5` is what ties a BAM to the exact reference bases it was aligned against:
+/// two references with the same name and length but different sequence produce
+/// different checksums, so a reader can tell them apart instead of silently
+/// mixing them. It is also what CRAM uses to find the reference it needs.
+///
+/// The definition is fixed by the SAM spec: uppercase the bases, drop everything
+/// that is not a printable character, then MD5 the result as lower-case hex.
+fn sequence_checksum(sequence: &[u8], ambiguous: &[u32]) -> String {
+    use md5::Digest as _;
+    let mut hasher = md5::Md5::new();
+    let mut block = [0u8; 8192];
+    let mut filled = 0;
+    for (offset, &base) in sequence.iter().enumerate() {
+        if base.is_ascii_whitespace() || !base.is_ascii_graphic() {
+            continue;
+        }
+        // The checksum has to identify the reference the user supplied, which is
+        // the one `NM` and `MD` now describe. Where indexing replaced a base, hash
+        // the `N` that was there rather than the substitute, or the header would
+        // name a sequence nothing else in the file refers to.
+        block[filled] = if ambiguous.binary_search(&(offset as u32)).is_ok() {
+            b'N'
+        } else {
+            base.to_ascii_uppercase()
+        };
+        filled += 1;
+        if filled == block.len() {
+            hasher.update(block);
+            filled = 0;
+        }
+    }
+    hasher.update(&block[..filled]);
+    hasher
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(32), |mut hex, byte| {
+            use std::fmt::Write as _;
+            let _ = write!(hex, "{byte:02x}");
+            hex
+        })
 }
 
 /// Reusable per-worker buffers for record emission.
@@ -119,34 +259,69 @@ pub struct EmitScratch {
     spoofed: [Vec<CigarOp>; 2],
 }
 
-/// SAM version reported in `@HD VN:`, kept at C++ salmon's value.
-const SAM_VERSION: &str = "1.0";
-
 /// The header text shared by both mapping-output formats: `@HD`, one `@SQ` per
-/// reference (including decoys, matching salmon's full ref table), and `@PG`.
+/// reference (including decoys, matching salmon's full ref table), the optional
+/// `@RG`, and `@PG`.
 ///
 /// This is the single source of truth for the header, mirroring
 /// [`emit_fragment_records`] for record bodies. SAM writes the text verbatim;
 /// BAM stores it as the `text` block and then repeats the reference table in
 /// binary form (see `bam::encode_header`).
-pub fn header_text(salmon: &SalmonIndex, command: &str) -> String {
+///
+/// `SO:unsorted GO:query` is the honest description of what salmon produces: no
+/// coordinate order at all, but all records for one fragment together. Declaring
+/// the grouping lets a reader pair mates in a single streaming pass instead of
+/// assuming it has to sort first.
+pub fn header_text(salmon: &SalmonIndex, command: &str, options: &RecordOptions<'_>) -> String {
     use std::fmt::Write as _;
-    // ~48 B/@SQ line for typical transcript names, plus the @HD and @PG lines.
-    let mut text = String::with_capacity(salmon.num_refs() * 48 + command.len() + 64);
-    let _ = writeln!(text, "@HD\tVN:{SAM_VERSION}\tSO:unknown");
-    for tid in 0..salmon.num_refs() {
-        let _ = writeln!(
-            text,
-            "@SQ\tSN:{}\tLN:{}",
-            salmon.ref_name(tid),
-            salmon.ref_len(tid)
-        );
+    // ~48 B/@SQ line for typical transcript names, plus the @HD, @RG and @PG lines.
+    let mut text = String::with_capacity(salmon.num_refs() * 48 + command.len() + 128);
+    let _ = writeln!(text, "@HD\tVN:{SAM_VERSION}\tSO:unsorted\tGO:query");
+    let references = options.reference_table(salmon);
+    // Hashing a whole transcriptome is a few hundred megabytes of MD5, which is
+    // enough to be noticeable at the start of a short run, and it is one
+    // independent hash per reference. Run them in parallel so the header costs
+    // wall-clock proportional to the largest transcript rather than to the sum.
+    let checksums: Vec<String> = {
+        use rayon::prelude::*;
+        (0..references.len())
+            .into_par_iter()
+            .map(|index| {
+                let sequence = salmon.ref_seq(index as u32);
+                if sequence.is_empty() {
+                    String::new()
+                } else {
+                    sequence_checksum(sequence, salmon.ambiguous_offsets(index))
+                }
+            })
+            .collect()
+    };
+    for (index, (name, length)) in references.into_iter().enumerate() {
+        let _ = write!(text, "@SQ\tSN:{name}\tLN:{length}");
+        if let Some(checksum) = checksums.get(index).filter(|c| !c.is_empty()) {
+            let _ = write!(text, "\tM5:{checksum}");
+        }
+        if let Some(uri) = options.reference_uri {
+            let _ = write!(text, "\tUR:{uri}");
+        }
+        text.push('\n');
+    }
+    if let Some(read_group) = options.read_group {
+        let _ = writeln!(text, "{}", read_group.header_line);
     }
     let _ = writeln!(
         text,
         "@PG\tID:salmon\tPN:salmon\tVN:{}\tCL:{}",
         crate::output::SALMON_VERSION,
         command
+    );
+    // State the one ordering guarantee in the file itself. `GO:query` says the
+    // records are grouped by name, but not that nothing else is ordered, and a
+    // reader that assumes more will be wrong in ways that are hard to trace.
+    let _ = writeln!(
+        text,
+        "@CO\tRecords for one fragment are contiguous. No other order is imposed: \
+         fragments appear in whichever order the mapping threads finished them."
     );
     text
 }
@@ -181,6 +356,37 @@ pub fn complement(base: u8) -> u8 {
         b'T' | b't' => b'A',
         _ => b'N',
     }
+}
+
+/// The qualities to write for this record, or `None` when there are none to
+/// write.
+///
+/// Base qualities are not optional output: whenever the input carries them they
+/// go into the record, which is why there is no flag to turn them on. There are
+/// only two ways to end up without them, and they are not the same thing:
+///
+/// * The input never had any (a FASTA). Nothing is wrong and nothing is said.
+/// * A quality string disagrees in length with its sequence. The FASTQ reader
+///   already rejects that outright, so this is a guard against some other input
+///   path rather than a case users meet: writing such a record would produce one
+///   no reader accepts. It warns rather than dropping them quietly, because a
+///   guard that fires silently is one nobody finds out about.
+pub fn usable_qualities<'a>(record: &AlignmentRecord<'a>) -> Option<&'a [u8]> {
+    let qualities = record.qualities?;
+    if qualities.len() == record.sequence.len() {
+        return (!qualities.is_empty()).then_some(qualities);
+    }
+    static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        tracing::warn!(
+            read = %String::from_utf8_lossy(record.name),
+            qualities = qualities.len(),
+            bases = record.sequence.len(),
+            "read has a quality string of a different length than its sequence; \
+             writing its record without qualities (reported once)"
+        );
+    }
+    None
 }
 
 /// The `MAPQ` to report for a fragment with `nh` placements.
@@ -345,16 +551,20 @@ pub fn emit_fragment_records(
     salmon: &SalmonIndex,
     r1_id: &[u8],
     r1_seq: &[u8],
-    r2: Option<(&[u8], &[u8])>,
+    r1_qual: Option<&[u8]>,
+    r2: Option<(&[u8], &[u8], Option<&[u8]>)>,
     maps: &[ScoredMapping],
     options: &RecordOptions<'_>,
     scratch: &mut EmitScratch,
     emit_record: impl FnMut(&AlignmentRecord<'_>) -> io::Result<()>,
 ) -> io::Result<()> {
     let name1 = read_name(r1_id);
-    let (name2, r2_seq) = r2.map_or((name1, &[][..]), |(id, seq)| (read_name(id), seq));
+    let (name2, r2_seq, r2_qual) = r2.map_or((name1, &[][..], None), |(id, seq, qual)| {
+        (read_name(id), seq, qual)
+    });
     let nh = maps.len();
     let mapq = mapping_quality(nh);
+    let read_group = options.read_group.map(|rg| rg.id.as_str());
     let mut emit = emit_record;
 
     for (index, mapping) in maps.iter().enumerate() {
@@ -377,6 +587,7 @@ pub fn emit_fragment_records(
         } else {
             b'T'
         };
+        let weight = mapping.weight as f32;
         match mapping.status {
             MateStatus::PairedEndPaired => {
                 let p1 = place(
@@ -440,13 +651,18 @@ pub fn emit_fragment_records(
                     mate_position: Some(p2.position),
                     template_length: tlen1,
                     sequence: r1_seq,
+                    qualities: r1_qual,
                     reverse_complement: !mapping.is_fw,
                     nh,
                     hi,
                     xt,
                     alignment_score: p1.score.unwrap_or(mapping.r1_score),
+                    weight,
                     edit_distance: p1.edit_distance,
                     md: md1,
+                    read_group,
+                    mate_cigar: Some(cigar2),
+                    mate_mapping_quality: Some(mapq),
                 })?;
                 emit(&AlignmentRecord {
                     name: name2,
@@ -459,13 +675,18 @@ pub fn emit_fragment_records(
                     mate_position: Some(p1.position),
                     template_length: -tlen1,
                     sequence: r2_seq,
+                    qualities: r2_qual,
                     reverse_complement: !mapping.r2_fw,
                     nh,
                     hi,
                     xt,
                     alignment_score: p2.score.unwrap_or(mapping.score - mapping.r1_score),
+                    weight,
                     edit_distance: p2.edit_distance,
                     md: md2,
+                    read_group,
+                    mate_cigar: Some(cigar1),
+                    mate_mapping_quality: Some(mapq),
                 })?;
             }
             MateStatus::SingleEnd => {
@@ -492,13 +713,18 @@ pub fn emit_fragment_records(
                     mate_position: None,
                     template_length: 0,
                     sequence: r1_seq,
+                    qualities: r1_qual,
                     reverse_complement: !mapping.is_fw,
                     nh,
                     hi,
                     xt,
                     alignment_score: p.score.unwrap_or(mapping.r1_score),
+                    weight,
                     edit_distance: p.edit_distance,
                     md,
+                    read_group,
+                    mate_cigar: None,
+                    mate_mapping_quality: None,
                 })?;
             }
             // Orphan: one mate placed, the other not. One record is emitted, for
@@ -506,10 +732,11 @@ pub fn emit_fragment_records(
             // incomplete rather than that this read is single-end.
             MateStatus::PairedEndLeft | MateStatus::PairedEndRight => {
                 let left = mapping.status == MateStatus::PairedEndLeft;
-                let (name, sequence, position, forward, score, read_flag) = if left {
+                let (name, sequence, qualities, position, forward, score, read_flag) = if left {
                     (
                         name1,
                         r1_seq,
+                        r1_qual,
                         mapping.r1_pos,
                         mapping.is_fw,
                         mapping.r1_score,
@@ -519,6 +746,7 @@ pub fn emit_fragment_records(
                     (
                         name2,
                         r2_seq,
+                        r2_qual,
                         mapping.r2_pos,
                         mapping.r2_fw,
                         mapping.score - mapping.r1_score,
@@ -546,13 +774,18 @@ pub fn emit_fragment_records(
                     mate_position: None,
                     template_length: 0,
                     sequence,
+                    qualities,
                     reverse_complement: !forward,
                     nh,
                     hi,
                     xt,
                     alignment_score: p.score.unwrap_or(score),
+                    weight,
                     edit_distance: p.edit_distance,
                     md,
+                    read_group,
+                    mate_cigar: None,
+                    mate_mapping_quality: None,
                 })?;
             }
         }
@@ -564,6 +797,36 @@ pub fn emit_fragment_records(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The read group accepts the spelling bwa and STAR users already type, with
+    /// or without the `@RG` prefix and with escaped tabs.
+    #[test]
+    fn read_group_parses_the_conventional_spellings() {
+        let expected = ReadGroup {
+            id: "s1".into(),
+            header_line: "@RG\tID:s1\tSM:sample".into(),
+        };
+        for spec in [
+            "ID:s1\tSM:sample",
+            "ID:s1\\tSM:sample",
+            "@RG\\tID:s1\\tSM:sample",
+            "@RG\tID:s1\tSM:sample",
+        ] {
+            assert_eq!(ReadGroup::parse(spec).unwrap(), expected, "{spec:?}");
+        }
+    }
+
+    /// A read group without an `ID` is rejected: every record's `RG` tag has to
+    /// point at one, so a header line without it could never be referenced.
+    #[test]
+    fn read_group_without_an_id_is_rejected() {
+        for spec in ["SM:sample", "", "@RG", "notafield"] {
+            assert!(
+                ReadGroup::parse(spec).is_err(),
+                "{spec:?} should be rejected"
+            );
+        }
+    }
 
     /// MAPQ has to distinguish a uniquely placed fragment from an ambiguous one;
     /// the old constant 1 said "ambiguous" for every record ever written.

--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -110,6 +110,13 @@ pub struct AlignmentRecord<'a> {
     pub mate_mapping_quality: Option<u8>,
 }
 
+impl AlignmentRecord<'_> {
+    /// Whether this record describes a read that did not map.
+    pub fn is_unmapped(&self) -> bool {
+        self.flags & UNMAPPED != 0
+    }
+}
+
 /// SAM version reported in `@HD VN:`. 1.6 is the version that defines the
 /// `GO:query` grouping this output actually has.
 const SAM_VERSION: &str = "1.6";
@@ -184,6 +191,10 @@ pub struct RecordOptions<'a> {
     /// `@SQ UR:`, where the reference sequences came from, so a reader can find
     /// them again.
     pub reference_uri: Option<&'a str>,
+    /// Whether reads that did not align are written too (`--sampleUnaligned`).
+    /// This also governs the unmapped mate of an orphan, which is a read that did
+    /// not align just as much as one whose whole fragment failed.
+    pub write_unaligned: bool,
 }
 
 impl RecordOptions<'_> {
@@ -565,6 +576,10 @@ pub fn emit_fragment_records(
     let nh = maps.len();
     let mapq = mapping_quality(nh);
     let read_group = options.read_group.map(|rg| rg.id.as_str());
+    // Where the unmapped mate of an orphan should be filed, taken from the
+    // primary placement. Recorded while emitting so the mate can be written once
+    // afterwards rather than once per placement.
+    let mut orphan_mate: Option<(usize, i32, bool)> = None;
     let mut emit = emit_record;
 
     for (index, mapping) in maps.iter().enumerate() {
@@ -756,6 +771,10 @@ pub fn emit_fragment_records(
                 let p = place(
                     scratch, 0, options, salmon, tid, sequence, forward, position, txp_len,
                 );
+                let reference = tid;
+                if index == 0 {
+                    orphan_mate = Some((reference, p.position, !forward));
+                }
                 let (cigar, md) = borrow_cigar(scratch, &p);
                 emit(&AlignmentRecord {
                     name,
@@ -768,10 +787,11 @@ pub fn emit_fragment_records(
                     position: p.position,
                     mapping_quality: mapq,
                     cigar,
-                    // The mate did not map and no record is written for it, so
+                    // The unmapped mate is filed here too when it is written at
+                    // all, so point at it; with no such record to point at,
                     // naming a mate position would be a dangling reference.
-                    mate_reference_id: None,
-                    mate_position: None,
+                    mate_reference_id: options.write_unaligned.then_some(reference),
+                    mate_position: options.write_unaligned.then_some(p.position),
                     template_length: 0,
                     sequence,
                     qualities,
@@ -791,6 +811,120 @@ pub fn emit_fragment_records(
         }
     }
 
+    // An orphan's other mate did not align, and a record flagged `MATE_UNMAPPED`
+    // beside no such record is a file that describes a read it does not contain:
+    // `samtools fastq` cannot round-trip it, and anything following the flag
+    // finds nothing. Write it, filed at the mapped mate's position so the two sit
+    // together in a sorted file, which is where readers expect to find it.
+    if let (true, Some((reference, position, mate_reverse))) =
+        (options.write_unaligned, orphan_mate)
+    {
+        let left = maps[0].status == MateStatus::PairedEndLeft;
+        // The mate that did *not* map is the opposite of the one that did.
+        let (name, sequence, qualities, read_flag) = if left {
+            (name2, r2_seq, r2_qual, READ2)
+        } else {
+            (name1, r1_seq, r1_qual, READ1)
+        };
+        if !sequence.is_empty() {
+            let mut record = unmapped_record(
+                name,
+                PAIRED | UNMAPPED | read_flag | if mate_reverse { MATE_RC } else { 0 },
+                sequence,
+                qualities,
+                read_group,
+            );
+            record.reference_id = Some(reference);
+            record.position = position;
+            record.mate_reference_id = Some(reference);
+            record.mate_position = Some(position);
+            emit(&record)?;
+        }
+    }
+    Ok(())
+}
+
+/// One unmapped read's record: no reference, no position, no CIGAR, MAPQ 0. The
+/// sequence and qualities are still stored, which is what makes the record
+/// useful.
+fn unmapped_record<'a>(
+    name: &'a [u8],
+    flags: u16,
+    sequence: &'a [u8],
+    qualities: Option<&'a [u8]>,
+    read_group: Option<&'a str>,
+) -> AlignmentRecord<'a> {
+    AlignmentRecord {
+        name,
+        flags,
+        reference_id: None,
+        position: -1,
+        mapping_quality: 0,
+        cigar: &[],
+        mate_reference_id: None,
+        mate_position: None,
+        template_length: 0,
+        sequence,
+        qualities,
+        // An unmapped read has no strand, so its bases are stored exactly as
+        // sequenced rather than reverse-complemented.
+        reverse_complement: false,
+        nh: 0,
+        hi: 0,
+        xt: b'U',
+        alignment_score: 0,
+        weight: 0.0,
+        edit_distance: None,
+        md: None,
+        read_group,
+        mate_cigar: None,
+        mate_mapping_quality: None,
+    }
+}
+
+/// Emit the records for a fragment that did not map anywhere.
+///
+/// # Why an unmapped read gets a record at all
+///
+/// A BAM containing only the reads that mapped is not a record of the experiment
+/// it is a record of one filtering decision, and the reads it dropped are
+/// exactly the ones anybody debugging a low mapping rate wants to look at. The
+/// format has always had a place for them: `FLAG 0x4`, no reference, no position,
+/// sequence and qualities intact. Writing them makes the output a complete,
+/// reversible view of the input rather than a lossy one, and it is what lets
+/// `samtools fastq` round-trip the library back out of the BAM.
+pub fn emit_unmapped_fragment(
+    r1_id: &[u8],
+    r1_seq: &[u8],
+    r1_qual: Option<&[u8]>,
+    r2: Option<(&[u8], &[u8], Option<&[u8]>)>,
+    options: &RecordOptions<'_>,
+    mut emit: impl FnMut(&AlignmentRecord<'_>) -> io::Result<()>,
+) -> io::Result<()> {
+    let name1 = read_name(r1_id);
+    let read_group = options.read_group.map(|rg| rg.id.as_str());
+    match r2 {
+        Some((r2_id, r2_seq, r2_qual)) => {
+            let name2 = read_name(r2_id);
+            emit(&unmapped_record(
+                name1,
+                PAIRED | UNMAPPED | MATE_UNMAPPED | READ1,
+                r1_seq,
+                r1_qual,
+                read_group,
+            ))?;
+            emit(&unmapped_record(
+                name2,
+                PAIRED | UNMAPPED | MATE_UNMAPPED | READ2,
+                r2_seq,
+                r2_qual,
+                read_group,
+            ))?;
+        }
+        None => emit(&unmapped_record(
+            name1, UNMAPPED, r1_seq, r1_qual, read_group,
+        ))?,
+    }
     Ok(())
 }
 
@@ -863,5 +997,39 @@ mod tests {
             assert_eq!(covered as i32, read_len, "pos={pos}");
             assert!(reported >= 0, "pos={pos} reported a negative position");
         }
+    }
+
+    /// An unmapped pair must carry the flag combination readers key on: both
+    /// mates unmapped, both marked as such for each other, and neither claiming a
+    /// strand or a position.
+    #[test]
+    fn unmapped_pair_records_are_flagged_consistently() {
+        let options = RecordOptions::default();
+        let mut seen = Vec::new();
+        emit_unmapped_fragment(
+            b"frag",
+            b"ACGT",
+            Some(b"IIII"),
+            Some((b"frag", b"TTTT", Some(b"####"))),
+            &options,
+            |record| {
+                assert!(record.is_unmapped());
+                assert_eq!(record.reference_id, None);
+                assert_eq!(record.position, -1);
+                assert_eq!(record.mapping_quality, 0);
+                assert!(record.cigar.is_empty());
+                assert!(!record.reverse_complement);
+                seen.push(record.flags);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            seen,
+            vec![
+                PAIRED | UNMAPPED | MATE_UNMAPPED | READ1,
+                PAIRED | UNMAPPED | MATE_UNMAPPED | READ2,
+            ]
+        );
     }
 }

--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -9,24 +9,39 @@
 //! [`emit_fragment_records`], and hands each format a borrowed record to
 //! serialize. The header is shared the same way, via [`header_text`].
 //!
-//! "Borrowed" means the record points at the caller's read name and sequence
-//! rather than copying them, so emitting a mapping allocates nothing.
+//! "Borrowed" means the record points at the caller's read name, sequence and
+//! qualities rather than copying them, so emitting a mapping allocates nothing
+//! beyond the reusable scratch in [`EmitScratch`].
 //!
 //! # Background: SAM records
 //!
 //! A SAM record describes one read's placement: which reference, at what
 //! position, in which orientation, and how the read's bases line up with the
-//! reference. The alignment shape is a CIGAR string — here only `M` (bases
-//! consuming both read and reference) and `S` (soft-clipped: present in the read,
-//! not aligned). salmon does not compute a base-level alignment, so it emits a
-//! spoofed `<readLen>M` with soft clips where the read overhangs a transcript end.
+//! reference. The alignment shape is a CIGAR string.
+//!
+//! # Two grades of CIGAR
+//!
+//! Mapping scores candidate placements without keeping a base-level alignment
+//! (see [`salmon_map::realize`] for why), so there are two ways to describe a
+//! placement:
+//!
+//! * **Realized**, the placement is re-aligned with traceback, giving real `I`
+//!   and `D` operations, an `NM` edit distance and an `MD` string. This is what
+//!   gets written whenever the reference sequence is available, and it is what
+//!   makes the output usable by tools that expect a genuine alignment.
+//! * **Spoofed**, `<readLen>M` with soft clips where the read overhangs a
+//!   transcript end. The fallback for when realization cannot run (an index
+//!   without reference sequence) or cannot form an alignment.
 
 use std::io;
 
 use salmon_core::MateStatus;
 use salmon_core::RefProvider as _;
 use salmon_index::SalmonIndex;
-use salmon_map::ScoredMapping;
+use salmon_map::realize::{
+    push_op, realize, CigarOp, CigarOpKind, RealizeScratch, RealizedAlignment,
+};
+use salmon_map::{AlignConfig, ScoredMapping};
 
 // SAM FLAG bits (a bitfield in field 2 of every record). Each names one yes/no
 // property of the alignment; a record's flags are these OR-ed together.
@@ -34,6 +49,8 @@ use salmon_map::ScoredMapping;
 pub const PAIRED: u16 = 0x1;
 /// Both mates placed consistently (right orientation, plausible distance).
 pub const PROPER_PAIR: u16 = 0x2;
+/// This read did not map anywhere.
+pub const UNMAPPED: u16 = 0x4;
 /// This read's mate did not map (an orphan).
 pub const MATE_UNMAPPED: u16 = 0x8;
 /// This read aligns to the reverse strand, so its stored sequence is the
@@ -50,58 +67,59 @@ pub const READ2: u16 = 0x80;
 /// avoid counting a multi-mapping fragment several times.
 pub const SECONDARY: u16 = 0x100;
 
-#[derive(Clone, Copy)]
-pub enum CigarKind {
-    Match,
-    SoftClip,
-}
-
-#[derive(Clone, Copy)]
-pub struct CigarOp {
-    pub kind: CigarKind,
-    pub len: usize,
-}
-
-/// A CIGAR of at most two operations, stored inline.
-///
-/// salmon's spoofed alignments never need more than two (`M`, or a clip plus a
-/// match at an overhanging end), so a fixed array avoids allocating one `Vec` per
-/// emitted record.
-#[derive(Clone, Copy)]
-pub struct Cigar {
-    ops: [CigarOp; 2],
-    len: usize,
-}
-
-impl Cigar {
-    pub fn as_slice(&self) -> &[CigarOp] {
-        &self.ops[..self.len]
-    }
-}
-
 /// One read's placement, with every field already in the form both writers need.
-/// The `'a` lifetime ties the borrowed name and sequence to the caller's buffers.
+/// The `'a` lifetime ties the borrowed name, sequence, qualities and CIGAR to the
+/// caller's buffers.
 pub struct AlignmentRecord<'a> {
     pub name: &'a [u8],
     pub flags: u16,
-    pub reference_id: usize,
+    /// `None` for an unmapped record, which SAM writes as `*` and BAM as `-1`.
+    pub reference_id: Option<usize>,
     pub position: i32,
     pub mapping_quality: u8,
-    pub cigar: Cigar,
+    pub cigar: &'a [CigarOp],
     pub mate_reference_id: Option<usize>,
     pub mate_position: Option<i32>,
     pub template_length: i32,
     pub sequence: &'a [u8],
+    /// Whether the stored sequence has to be reversed, because the read aligns to
+    /// the reverse strand and SAM stores everything on the reference's forward
+    /// strand.
     pub reverse_complement: bool,
     pub nh: usize,
     pub hi: usize,
     pub xt: u8,
     pub alignment_score: i32,
+    /// `NM`, present only for a realized alignment.
+    pub edit_distance: Option<u32>,
+    /// `MD`, present only for a realized alignment.
+    pub md: Option<&'a str>,
 }
 
-/// SAM version reported in `@HD VN:`. Shared by SAM and BAM so the two formats
-/// cannot drift; kept at `1.0` to match C++ salmon's `--writeMappings` header
-/// byte-for-byte.
+/// Everything about mapping output that is fixed for a whole run, rather than
+/// derived per record.
+#[derive(Default)]
+pub struct RecordOptions<'a> {
+    /// When set, placements are re-aligned to produce a real CIGAR plus `NM` and
+    /// `MD`. `None` keeps the spoofed `<readLen>M` CIGAR and omits both tags.
+    pub align_config: Option<&'a AlignConfig>,
+}
+
+/// Reusable per-worker buffers for record emission.
+///
+/// Realizing an alignment needs somewhere to put the CIGAR, the `MD` string and
+/// the aligner's own workspace. Keeping them here means a worker allocates them
+/// once rather than once per record.
+#[derive(Default)]
+pub struct EmitScratch {
+    realize_scratch: RealizeScratch,
+    /// Realized alignments for the two mates of the fragment being emitted.
+    realized: [RealizedAlignment; 2],
+    /// Spoofed CIGARs, used when realization is off or fails.
+    spoofed: [Vec<CigarOp>; 2],
+}
+
+/// SAM version reported in `@HD VN:`, kept at C++ salmon's value.
 const SAM_VERSION: &str = "1.0";
 
 /// The header text shared by both mapping-output formats: `@HD`, one `@SQ` per
@@ -137,7 +155,7 @@ pub fn header_text(salmon: &SalmonIndex, command: &str) -> String {
 /// a trailing `/1` or `/2` mate suffix removed.
 ///
 /// Both mates of a pair must carry the *same* name for a SAM/BAM reader to pair
-/// them up, but many FASTQ files distinguish them with that suffix — so it has to
+/// them up, but many FASTQ files distinguish them with that suffix, so it has to
 /// go.
 pub fn read_name(id: &[u8]) -> &[u8] {
     let end = id
@@ -198,86 +216,146 @@ pub fn mapping_quality(nh: usize) -> u8 {
 }
 
 /// The CIGAR and clamped position for a read placed at `pos` on a transcript of
-/// length `txp_len`.
+/// length `txp_len`, without a base-level alignment.
 ///
-/// A read can hang off either end of a transcript — the mapper places it by seed
+/// A read can hang off either end of a transcript, the mapper places it by seed
 /// position, and the fragment may genuinely extend past the annotated boundary.
 /// SAM cannot express a negative position or an alignment past the reference end,
 /// so the overhanging bases are soft-clipped and the position clamped into range.
-/// Returns the CIGAR and the position to report.
-fn overhang_cigar(pos: i32, read_len: i32, txp_len: i32) -> (Cigar, i32) {
-    let read_len = read_len.max(0) as usize;
-    let empty = CigarOp {
-        kind: CigarKind::Match,
-        len: 0,
-    };
-    let one = |kind, len| Cigar {
-        ops: [CigarOp { kind, len }, empty],
-        len: 1,
-    };
-    let two = |a, b| Cigar {
-        ops: [a, b],
-        len: 2,
-    };
-    if pos + (read_len as i32) < 0 {
-        (one(CigarKind::SoftClip, read_len), 0)
+fn overhang_cigar(ops: &mut Vec<CigarOp>, pos: i32, read_len: i32, txp_len: i32) -> i32 {
+    ops.clear();
+    let read_len_u = read_len.max(0) as u32;
+    if pos + read_len < 0 {
+        push_op(ops, CigarOpKind::SoftClip, read_len_u);
+        0
     } else if pos < 0 {
-        let matched = (read_len as i32 + pos).max(0) as usize;
-        (
-            two(
-                CigarOp {
-                    kind: CigarKind::SoftClip,
-                    len: read_len - matched,
-                },
-                CigarOp {
-                    kind: CigarKind::Match,
-                    len: matched,
-                },
-            ),
-            0,
-        )
+        let matched = (read_len + pos).max(0) as u32;
+        push_op(ops, CigarOpKind::SoftClip, read_len_u - matched);
+        push_op(ops, CigarOpKind::Match, matched);
+        0
     } else if pos > txp_len {
-        (one(CigarKind::SoftClip, read_len), pos)
-    } else if pos + read_len as i32 > txp_len {
-        let matched = (txp_len - pos).max(0) as usize;
-        (
-            two(
-                CigarOp {
-                    kind: CigarKind::Match,
-                    len: matched,
-                },
-                CigarOp {
-                    kind: CigarKind::SoftClip,
-                    len: read_len - matched,
-                },
-            ),
-            pos,
-        )
+        push_op(ops, CigarOpKind::SoftClip, read_len_u);
+        pos
+    } else if pos + read_len > txp_len {
+        let matched = (txp_len - pos).max(0) as u32;
+        push_op(ops, CigarOpKind::Match, matched);
+        push_op(ops, CigarOpKind::SoftClip, read_len_u - matched);
+        pos
     } else {
-        (one(CigarKind::Match, read_len), pos)
+        push_op(ops, CigarOpKind::Match, read_len_u);
+        pos
     }
 }
 
-/// Emit borrowed records immediately; no record, name, sequence, CIGAR, or tag
-/// allocation is retained between callback invocations.
+/// One mate's placement after CIGAR derivation: everything that differs between
+/// the realized and spoofed paths, resolved.
+struct Placed {
+    position: i32,
+    edit_distance: Option<u32>,
+    /// The realized alignment's own score, when there is one. `AS` reports this
+    /// in preference to the mapper's, so that the score, the CIGAR and `NM`
+    /// describe the same alignment.
+    score: Option<i32>,
+    /// Which of [`EmitScratch`]'s two mate slots holds this placement's CIGAR.
+    slot: usize,
+    /// Whether that CIGAR is in `realized` (`true`) or `spoofed` (`false`).
+    realized: bool,
+}
+
+/// Derive one mate's CIGAR and start position, realizing the alignment when the
+/// run asked for it and the reference sequence is there to align against.
+///
+/// Falls back to the spoofed CIGAR silently: a missing reference sequence is a
+/// property of the index, not an error, and a record with a spoofed CIGAR is
+/// still a valid record.
+#[allow(clippy::too_many_arguments)]
+fn place(
+    scratch: &mut EmitScratch,
+    slot: usize,
+    options: &RecordOptions<'_>,
+    salmon: &SalmonIndex,
+    tid: usize,
+    sequence: &[u8],
+    forward: bool,
+    pos: i32,
+    txp_len: i32,
+) -> Placed {
+    if let Some(cfg) = options.align_config {
+        let ref_seq = salmon.ref_seq(tid as u32);
+        if !ref_seq.is_empty() && !sequence.is_empty() {
+            let EmitScratch {
+                realize_scratch,
+                realized,
+                ..
+            } = scratch;
+            if realize(
+                sequence,
+                forward,
+                ref_seq,
+                salmon.ambiguous_offsets(tid),
+                pos,
+                cfg,
+                realize_scratch,
+                &mut realized[slot],
+            ) {
+                return Placed {
+                    position: realized[slot].ref_start,
+                    edit_distance: Some(realized[slot].edit_distance),
+                    score: Some(realized[slot].score),
+                    slot,
+                    realized: true,
+                };
+            }
+        }
+    }
+    let position = overhang_cigar(
+        &mut scratch.spoofed[slot],
+        pos,
+        sequence.len() as i32,
+        txp_len,
+    );
+    Placed {
+        position,
+        edit_distance: None,
+        score: None,
+        slot,
+        realized: false,
+    }
+}
+
+/// The CIGAR and `MD` a [`Placed`] refers to, borrowed out of the scratch.
+fn borrow_cigar<'s>(scratch: &'s EmitScratch, placed: &Placed) -> (&'s [CigarOp], Option<&'s str>) {
+    if placed.realized {
+        let realized = &scratch.realized[placed.slot];
+        (&realized.ops, Some(realized.md.as_str()))
+    } else {
+        (&scratch.spoofed[placed.slot], None)
+    }
+}
+
+/// Emit borrowed records immediately; no record, name, sequence or tag allocation
+/// is retained between callback invocations.
 ///
 /// This is the single source of truth for record bodies: one call per fragment
 /// produces every record that fragment implies (two per placement for a proper
 /// pair, one otherwise), and the caller's closure serializes them as SAM text or
-/// BAM binary. The callback style is what keeps it allocation-free — nothing is
-/// collected into a vector to be handed back.
+/// BAM binary.
+#[allow(clippy::too_many_arguments)]
 pub fn emit_fragment_records(
     salmon: &SalmonIndex,
     r1_id: &[u8],
     r1_seq: &[u8],
     r2: Option<(&[u8], &[u8])>,
     maps: &[ScoredMapping],
-    mut emit: impl FnMut(&AlignmentRecord<'_>) -> io::Result<()>,
+    options: &RecordOptions<'_>,
+    scratch: &mut EmitScratch,
+    emit_record: impl FnMut(&AlignmentRecord<'_>) -> io::Result<()>,
 ) -> io::Result<()> {
     let name1 = read_name(r1_id);
     let (name2, r2_seq) = r2.map_or((name1, &[][..]), |(id, seq)| (read_name(id), seq));
     let nh = maps.len();
     let mapq = mapping_quality(nh);
+    let mut emit = emit_record;
 
     for (index, mapping) in maps.iter().enumerate() {
         // The first placement is primary; the rest are marked secondary so a
@@ -287,18 +365,42 @@ pub fn emit_fragment_records(
         let hi = index + 1;
         let tid = mapping.tid as usize;
         let txp_len = salmon.ref_len(tid) as i32;
-        // salmon's XT tag: `T` for a transcript placement, `D` for a decoy, so a
-        // reader can tell which placements were sinks rather than real targets.
+        // salmon's XT tag. In practice it is always `T`: a placement on a decoy
+        // means the read probably came from no transcript at all, so scoring
+        // drops it long before a record is written, and a decoy-aware run was
+        // confirmed to emit no `D` at all. The branch stays because the tag is
+        // defined over the reference table, not over what currently survives
+        // filtering, and a future policy that kept decoy placements would need
+        // it to be right.
         let xt = if salmon.is_decoy(mapping.tid) {
             b'D'
         } else {
             b'T'
         };
-
         match mapping.status {
             MateStatus::PairedEndPaired => {
-                let (c1, p1) = overhang_cigar(mapping.r1_pos, r1_seq.len() as i32, txp_len);
-                let (c2, p2) = overhang_cigar(mapping.r2_pos, r2_seq.len() as i32, txp_len);
+                let p1 = place(
+                    scratch,
+                    0,
+                    options,
+                    salmon,
+                    tid,
+                    r1_seq,
+                    mapping.is_fw,
+                    mapping.r1_pos,
+                    txp_len,
+                );
+                let p2 = place(
+                    scratch,
+                    1,
+                    options,
+                    salmon,
+                    tid,
+                    r2_seq,
+                    mapping.r2_fw,
+                    mapping.r2_pos,
+                    txp_len,
+                );
                 // TLEN is the observed template (fragment) length, truncated at
                 // the transcript end for the same reason positions are clamped.
                 let mut fragment_length = mapping.fragment_len;
@@ -325,49 +427,65 @@ pub fn emit_fragment_records(
                     f2 |= IS_RC;
                     f1 |= MATE_RC;
                 }
+                let (cigar1, md1) = borrow_cigar(scratch, &p1);
+                let (cigar2, md2) = borrow_cigar(scratch, &p2);
                 emit(&AlignmentRecord {
                     name: name1,
                     flags: f1,
-                    reference_id: tid,
-                    position: p1,
+                    reference_id: Some(tid),
+                    position: p1.position,
                     mapping_quality: mapq,
-                    cigar: c1,
+                    cigar: cigar1,
                     mate_reference_id: Some(tid),
-                    mate_position: Some(p2),
+                    mate_position: Some(p2.position),
                     template_length: tlen1,
                     sequence: r1_seq,
                     reverse_complement: !mapping.is_fw,
                     nh,
                     hi,
                     xt,
-                    alignment_score: mapping.r1_score,
+                    alignment_score: p1.score.unwrap_or(mapping.r1_score),
+                    edit_distance: p1.edit_distance,
+                    md: md1,
                 })?;
                 emit(&AlignmentRecord {
                     name: name2,
                     flags: f2,
-                    reference_id: tid,
-                    position: p2,
+                    reference_id: Some(tid),
+                    position: p2.position,
                     mapping_quality: mapq,
-                    cigar: c2,
+                    cigar: cigar2,
                     mate_reference_id: Some(tid),
-                    mate_position: Some(p1),
+                    mate_position: Some(p1.position),
                     template_length: -tlen1,
                     sequence: r2_seq,
                     reverse_complement: !mapping.r2_fw,
                     nh,
                     hi,
                     xt,
-                    alignment_score: mapping.score - mapping.r1_score,
+                    alignment_score: p2.score.unwrap_or(mapping.score - mapping.r1_score),
+                    edit_distance: p2.edit_distance,
+                    md: md2,
                 })?;
             }
             MateStatus::SingleEnd => {
-                let (cigar, position) =
-                    overhang_cigar(mapping.r1_pos, r1_seq.len() as i32, txp_len);
+                let p = place(
+                    scratch,
+                    0,
+                    options,
+                    salmon,
+                    tid,
+                    r1_seq,
+                    mapping.is_fw,
+                    mapping.r1_pos,
+                    txp_len,
+                );
+                let (cigar, md) = borrow_cigar(scratch, &p);
                 emit(&AlignmentRecord {
                     name: name1,
                     flags: secondary | if mapping.is_fw { 0 } else { IS_RC },
-                    reference_id: tid,
-                    position,
+                    reference_id: Some(tid),
+                    position: p.position,
                     mapping_quality: mapq,
                     cigar,
                     mate_reference_id: None,
@@ -378,7 +496,9 @@ pub fn emit_fragment_records(
                     nh,
                     hi,
                     xt,
-                    alignment_score: mapping.r1_score,
+                    alignment_score: p.score.unwrap_or(mapping.r1_score),
+                    edit_distance: p.edit_distance,
+                    md,
                 })?;
             }
             // Orphan: one mate placed, the other not. One record is emitted, for
@@ -405,7 +525,10 @@ pub fn emit_fragment_records(
                         READ2,
                     )
                 };
-                let (cigar, position) = overhang_cigar(position, sequence.len() as i32, txp_len);
+                let p = place(
+                    scratch, 0, options, salmon, tid, sequence, forward, position, txp_len,
+                );
+                let (cigar, md) = borrow_cigar(scratch, &p);
                 emit(&AlignmentRecord {
                     name,
                     flags: PAIRED
@@ -413,10 +536,12 @@ pub fn emit_fragment_records(
                         | read_flag
                         | secondary
                         | if forward { 0 } else { IS_RC },
-                    reference_id: tid,
-                    position,
+                    reference_id: Some(tid),
+                    position: p.position,
                     mapping_quality: mapq,
                     cigar,
+                    // The mate did not map and no record is written for it, so
+                    // naming a mate position would be a dangling reference.
                     mate_reference_id: None,
                     mate_position: None,
                     template_length: 0,
@@ -425,11 +550,14 @@ pub fn emit_fragment_records(
                     nh,
                     hi,
                     xt,
-                    alignment_score: score,
+                    alignment_score: p.score.unwrap_or(score),
+                    edit_distance: p.edit_distance,
+                    md,
                 })?;
             }
         }
     }
+
     Ok(())
 }
 
@@ -437,7 +565,8 @@ pub fn emit_fragment_records(
 mod tests {
     use super::*;
 
-    /// MAPQ has to distinguish a uniquely placed fragment from an ambiguous one.
+    /// MAPQ has to distinguish a uniquely placed fragment from an ambiguous one;
+    /// the old constant 1 said "ambiguous" for every record ever written.
     #[test]
     fn mapping_quality_follows_the_star_convention() {
         assert_eq!(mapping_quality(1), 255);
@@ -445,7 +574,31 @@ mod tests {
         assert_eq!(mapping_quality(3), 1);
         assert_eq!(mapping_quality(4), 1);
         assert_eq!(mapping_quality(5), 0);
+        assert_eq!(mapping_quality(100), 0);
         // An unmapped record has no placement to be confident about.
         assert_eq!(mapping_quality(0), 0);
+    }
+
+    /// The spoofed CIGAR still has to describe the whole read, clip included, at
+    /// both transcript ends and when the read misses the transcript entirely.
+    #[test]
+    fn spoofed_cigar_always_covers_the_read() {
+        let mut ops = Vec::new();
+        for (pos, read_len, txp_len) in [
+            (0, 100, 1000),
+            (-20, 100, 1000),
+            (-200, 100, 1000),
+            (950, 100, 1000),
+            (1200, 100, 1000),
+        ] {
+            let reported = overhang_cigar(&mut ops, pos, read_len, txp_len);
+            let covered: u32 = ops
+                .iter()
+                .filter(|op| op.kind.consumes_read())
+                .map(|op| op.len)
+                .sum();
+            assert_eq!(covered as i32, read_len, "pos={pos}");
+            assert!(reported >= 0, "pos={pos} reported a negative position");
+        }
     }
 }

--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -108,6 +108,11 @@ pub struct AlignmentRecord<'a> {
     pub mate_cigar: Option<&'a [CigarOp]>,
     /// `MQ`, the mate's mapping quality, for the same reason.
     pub mate_mapping_quality: Option<u8>,
+    /// `XS`, the strand of the transcript this alignment came from, as `+` or
+    /// `-`. Only meaningful for a spliced alignment, where it says which way the
+    /// introns should be read; StringTie and Cufflinks require it and silently
+    /// mis-assemble without it.
+    pub transcript_strand: Option<u8>,
 }
 
 impl AlignmentRecord<'_> {
@@ -308,14 +313,15 @@ pub fn header_text(salmon: &SalmonIndex, command: &str, options: &RecordOptions<
     let mut text = String::with_capacity(salmon.num_refs() * 48 + command.len() + 128);
     let _ = writeln!(text, "@HD\tVN:{SAM_VERSION}\tSO:unsorted\tGO:query");
     let references = options.reference_table(salmon);
-    // Hashing a whole transcriptome is a few hundred megabytes of MD5, which is
-    // enough to be noticeable at the start of a short run, and it is one
-    // independent hash per reference. Run them in parallel so the header costs
-    // wall-clock proportional to the largest transcript rather than to the sum.
     // M5 needs the bases, which are only to hand for the transcriptome the index
     // was built from. When records are projected onto the genome the references
     // are chromosomes salmon never loaded, so the checksum is omitted rather
     // than guessed at.
+    //
+    // Hashing a whole transcriptome is a few hundred megabytes of MD5, which is
+    // enough to be noticeable at the start of a short run, and it is one
+    // independent hash per reference. Run them in parallel so the header costs
+    // wall-clock proportional to the largest transcript rather than to the sum.
     let checksums: Vec<String> = if options.projector.is_none() {
         use rayon::prelude::*;
         (0..references.len())
@@ -643,14 +649,9 @@ fn flip_strand_bits(flags: u16) -> u16 {
 
 /// The signed `TLEN` for a projected pair: the genomic span the two mates cover
 /// together, positive on the leftmost mate.
-fn projected_template_length(
-    scratch: &EmitScratch,
-    first: &Placed,
-    second: &Placed,
-) -> (i32, i32) {
-    let span = |placed: &Placed| {
-        salmon_map::realize::reference_span(&scratch.projected[placed.slot])
-    };
+fn projected_template_length(scratch: &EmitScratch, first: &Placed, second: &Placed) -> (i32, i32) {
+    let span =
+        |placed: &Placed| salmon_map::realize::reference_span(&scratch.projected[placed.slot]);
     let start = first.position.min(second.position);
     let end = (first.position + span(first)).max(second.position + span(second));
     let length = end - start;
@@ -700,7 +701,7 @@ pub fn emit_fragment_records(
     maps: &[ScoredMapping],
     options: &RecordOptions<'_>,
     scratch: &mut EmitScratch,
-    emit_record: impl FnMut(&AlignmentRecord<'_>) -> io::Result<()>,
+    mut emit_record: impl FnMut(&AlignmentRecord<'_>) -> io::Result<()>,
 ) -> io::Result<()> {
     let name1 = read_name(r1_id);
     let (name2, r2_seq, r2_qual) = r2.map_or((name1, &[][..], None), |(id, seq, qual)| {
@@ -713,7 +714,15 @@ pub fn emit_fragment_records(
     // primary placement. Recorded while emitting so the mate can be written once
     // afterwards rather than once per placement.
     let mut orphan_mate: Option<(usize, i32, bool)> = None;
-    let mut emit = emit_record;
+    // Placements can all be refused by the genome projector when the annotation
+    // does not describe their transcript. A fragment that mapped but produced no
+    // record would vanish from the output with the run still reporting it as
+    // mapped, so track whether anything was written for it.
+    let mut emitted = 0usize;
+    let mut emit = |record: &AlignmentRecord<'_>| {
+        emitted += 1;
+        emit_record(record)
+    };
 
     for (index, mapping) in maps.iter().enumerate() {
         // The first placement is primary; the rest are marked secondary so a
@@ -736,6 +745,13 @@ pub fn emit_fragment_records(
             b'T'
         };
         let weight = mapping.weight as f32;
+        // XS is about the transcript's orientation on the genome, so it only
+        // exists once records are in genome coordinates.
+        let transcript_strand = options
+            .projector
+            .and_then(|projector| projector.strand(tid))
+            .map(|forward| if forward { b'+' } else { b'-' });
+
         match mapping.status {
             MateStatus::PairedEndPaired => {
                 let p1 = place(
@@ -838,6 +854,7 @@ pub fn emit_fragment_records(
                     read_group,
                     mate_cigar: Some(cigar2),
                     mate_mapping_quality: Some(mapq),
+                    transcript_strand,
                 })?;
                 emit(&AlignmentRecord {
                     name: name2,
@@ -862,6 +879,7 @@ pub fn emit_fragment_records(
                     read_group,
                     mate_cigar: Some(cigar1),
                     mate_mapping_quality: Some(mapq),
+                    transcript_strand,
                 })?;
             }
             MateStatus::SingleEnd => {
@@ -908,6 +926,7 @@ pub fn emit_fragment_records(
                     read_group,
                     mate_cigar: None,
                     mate_mapping_quality: None,
+                    transcript_strand,
                 })?;
             }
             // Orphan: one mate placed, the other not. One record is emitted, for
@@ -980,6 +999,7 @@ pub fn emit_fragment_records(
                     read_group,
                     mate_cigar: None,
                     mate_mapping_quality: None,
+                    transcript_strand,
                 })?;
             }
         }
@@ -1014,6 +1034,12 @@ pub fn emit_fragment_records(
             record.mate_position = Some(position);
             emit(&record)?;
         }
+    }
+    // Nothing survived projection, so the fragment mapped and yet has no record.
+    // Write it as unaligned rather than dropping it: the read existed, and a file
+    // that silently omits it disagrees with everything else the run reports.
+    if emitted == 0 && options.write_unaligned {
+        emit_unmapped_fragment(r1_id, r1_seq, r1_qual, r2, options, emit_record)?;
     }
     Ok(())
 }
@@ -1053,6 +1079,7 @@ fn unmapped_record<'a>(
         read_group,
         mate_cigar: None,
         mate_mapping_quality: None,
+        transcript_strand: None,
     }
 }
 

--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -282,9 +282,11 @@ pub struct EmitScratch {
     spoofed: [Vec<CigarOp>; 2],
     /// Genome-coordinate CIGARs, when the run projects records onto the genome.
     projected: [Vec<CigarOp>; 2],
-    /// `MD` re-expressed in genome orientation, for placements the projection
-    /// turned around.
+    /// `MD` re-derived against the projected operations.
     projected_md: [String; 2],
+    /// Per-reference-base expansion of a transcript `MD`, reused while
+    /// re-deriving the projected one.
+    md_bases: Vec<crate::splice::MdBase>,
 }
 
 /// The header text shared by both mapping-output formats: `@HD`, one `@SQ` per
@@ -586,6 +588,7 @@ fn project_placement(
         spoofed,
         projected,
         projected_md,
+        md_bases,
         ..
     } = scratch;
     let source: &[CigarOp] = if placed.realized {
@@ -593,19 +596,25 @@ fn project_placement(
     } else {
         &spoofed[placed.slot]
     };
-    match projector.project(tid, placed.position, source, &mut projected[placed.slot]) {
+    // MD is re-derived from the projected operations rather than carried over
+    // from the transcript's: projection can cut a deletion in two, and two
+    // deletions are spelled differently from one.
+    let md = placed.realized.then(|| {
+        (
+            realized[placed.slot].md.as_str(),
+            &mut *md_bases,
+            &mut projected_md[placed.slot],
+        )
+    });
+    match projector.project(
+        tid,
+        placed.position,
+        source,
+        md,
+        &mut projected[placed.slot],
+    ) {
         Some(projection) => {
             placed.position = projection.position;
-            // A flipped alignment reads the other way along the reference, so its
-            // MD has to be turned around with it or it describes bases that are
-            // no longer the ones under the CIGAR.
-            if projection.flipped && placed.realized {
-                let (md, out) = (
-                    realized[placed.slot].md.as_str(),
-                    &mut projected_md[placed.slot],
-                );
-                crate::splice::reverse_complement_md(md, out);
-            }
             placed.projection = Some(projection);
             true
         }
@@ -658,13 +667,12 @@ fn borrow_cigar<'s>(scratch: &'s EmitScratch, placed: &Placed) -> (&'s [CigarOp]
         // NM survives projection untouched: it counts edits, and an intron is not
         // one. MD survives only while the orientation does, so a flipped
         // alignment reads its rewritten copy.
-        let md = placed.realized.then(|| {
-            if projection.flipped {
-                scratch.projected_md[placed.slot].as_str()
-            } else {
-                scratch.realized[placed.slot].md.as_str()
-            }
-        });
+        let _ = projection;
+        // NM survives projection untouched: it counts edits, and an intron is
+        // not one. MD is the re-derived one.
+        let md = placed
+            .realized
+            .then(|| scratch.projected_md[placed.slot].as_str());
         return (&scratch.projected[placed.slot], md);
     }
     if placed.realized {

--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -282,6 +282,9 @@ pub struct EmitScratch {
     spoofed: [Vec<CigarOp>; 2],
     /// Genome-coordinate CIGARs, when the run projects records onto the genome.
     projected: [Vec<CigarOp>; 2],
+    /// `MD` re-expressed in genome orientation, for placements the projection
+    /// turned around.
+    projected_md: [String; 2],
 }
 
 /// The header text shared by both mapping-output formats: `@HD`, one `@SQ` per
@@ -582,6 +585,7 @@ fn project_placement(
         realized,
         spoofed,
         projected,
+        projected_md,
         ..
     } = scratch;
     let source: &[CigarOp] = if placed.realized {
@@ -592,6 +596,16 @@ fn project_placement(
     match projector.project(tid, placed.position, source, &mut projected[placed.slot]) {
         Some(projection) => {
             placed.position = projection.position;
+            // A flipped alignment reads the other way along the reference, so its
+            // MD has to be turned around with it or it describes bases that are
+            // no longer the ones under the CIGAR.
+            if projection.flipped && placed.realized {
+                let (md, out) = (
+                    realized[placed.slot].md.as_str(),
+                    &mut projected_md[placed.slot],
+                );
+                crate::splice::reverse_complement_md(md, out);
+            }
             placed.projection = Some(projection);
             true
         }
@@ -640,12 +654,17 @@ fn projected_template_length(
 
 /// The CIGAR and `MD` a [`Placed`] refers to, borrowed out of the scratch.
 fn borrow_cigar<'s>(scratch: &'s EmitScratch, placed: &Placed) -> (&'s [CigarOp], Option<&'s str>) {
-    if placed.projection.is_some() {
-        // MD and NM describe the read against the transcript's bases, which are
-        // the genome's bases inside an exon, so projection leaves both valid.
-        let md = placed
-            .realized
-            .then(|| scratch.realized[placed.slot].md.as_str());
+    if let Some(projection) = placed.projection {
+        // NM survives projection untouched: it counts edits, and an intron is not
+        // one. MD survives only while the orientation does, so a flipped
+        // alignment reads its rewritten copy.
+        let md = placed.realized.then(|| {
+            if projection.flipped {
+                scratch.projected_md[placed.slot].as_str()
+            } else {
+                scratch.realized[placed.slot].md.as_str()
+            }
+        });
         return (&scratch.projected[placed.slot], md);
     }
     if placed.realized {

--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -188,6 +188,9 @@ pub struct RecordOptions<'a> {
     /// When set, placements are re-aligned to produce a real CIGAR plus `NM` and
     /// `MD`. `None` keeps the spoofed `<readLen>M` CIGAR and omits both tags.
     pub align_config: Option<&'a AlignConfig>,
+    /// When set, records are reported in genome coordinates with `N` operations
+    /// at exon junctions, and `@SQ` names chromosomes instead of transcripts.
+    pub projector: Option<&'a crate::splice::GenomeProjector>,
     /// `@SQ UR:`, where the reference sequences came from, so a reader can find
     /// them again.
     pub reference_uri: Option<&'a str>,
@@ -201,14 +204,23 @@ impl RecordOptions<'_> {
     /// The reference name for `reference_id`, from whichever table this run's
     /// records index into.
     pub fn reference_name<'s>(&'s self, salmon: &'s SalmonIndex, id: usize) -> &'s str {
-        salmon.ref_name(id)
+        match self.projector {
+            Some(projector) => projector
+                .chromosomes()
+                .get(id)
+                .map_or("*", |(name, _)| name.as_str()),
+            None => salmon.ref_name(id),
+        }
     }
 
     /// The `(name, length)` reference table to declare in the header.
     pub fn reference_table(&self, salmon: &SalmonIndex) -> Vec<(String, u64)> {
-        (0..salmon.num_refs())
-            .map(|tid| (salmon.ref_name(tid).to_string(), salmon.ref_len(tid)))
-            .collect()
+        match self.projector {
+            Some(projector) => projector.chromosomes().to_vec(),
+            None => (0..salmon.num_refs())
+                .map(|tid| (salmon.ref_name(tid).to_string(), salmon.ref_len(tid)))
+                .collect(),
+        }
     }
 }
 
@@ -268,6 +280,8 @@ pub struct EmitScratch {
     realized: [RealizedAlignment; 2],
     /// Spoofed CIGARs, used when realization is off or fails.
     spoofed: [Vec<CigarOp>; 2],
+    /// Genome-coordinate CIGARs, when the run projects records onto the genome.
+    projected: [Vec<CigarOp>; 2],
 }
 
 /// The header text shared by both mapping-output formats: `@HD`, one `@SQ` per
@@ -293,7 +307,11 @@ pub fn header_text(salmon: &SalmonIndex, command: &str, options: &RecordOptions<
     // enough to be noticeable at the start of a short run, and it is one
     // independent hash per reference. Run them in parallel so the header costs
     // wall-clock proportional to the largest transcript rather than to the sum.
-    let checksums: Vec<String> = {
+    // M5 needs the bases, which are only to hand for the transcriptome the index
+    // was built from. When records are projected onto the genome the references
+    // are chromosomes salmon never loaded, so the checksum is omitted rather
+    // than guessed at.
+    let checksums: Vec<String> = if options.projector.is_none() {
         use rayon::prelude::*;
         (0..references.len())
             .into_par_iter()
@@ -306,6 +324,8 @@ pub fn header_text(salmon: &SalmonIndex, command: &str, options: &RecordOptions<
                 }
             })
             .collect()
+    } else {
+        Vec::new()
     };
     for (index, (name, length)) in references.into_iter().enumerate() {
         let _ = write!(text, "@SQ\tSN:{name}\tLN:{length}");
@@ -477,6 +497,9 @@ struct Placed {
     slot: usize,
     /// Whether that CIGAR is in `realized` (`true`) or `spoofed` (`false`).
     realized: bool,
+    /// Set once the placement has been projected onto the genome, after which
+    /// its CIGAR lives in `projected` and its position is genomic.
+    projection: Option<crate::splice::Projection>,
 }
 
 /// Derive one mate's CIGAR and start position, realizing the alignment when the
@@ -521,6 +544,7 @@ fn place(
                     score: Some(realized[slot].score),
                     slot,
                     realized: true,
+                    projection: None,
                 };
             }
         }
@@ -537,11 +561,93 @@ fn place(
         score: None,
         slot,
         realized: false,
+        projection: None,
+    }
+}
+
+/// Re-express one placement in genome coordinates, cutting its CIGAR at exon
+/// boundaries and inserting the introns.
+///
+/// Returns `false` when the placement has no genomic form, which happens for a
+/// decoy or a transcript the annotation does not describe. The caller then drops
+/// the whole placement: half a projected pair is worse than none, because the
+/// surviving record would claim a mate that is not in the file.
+fn project_placement(
+    scratch: &mut EmitScratch,
+    placed: &mut Placed,
+    projector: &crate::splice::GenomeProjector,
+    tid: usize,
+) -> bool {
+    let EmitScratch {
+        realized,
+        spoofed,
+        projected,
+        ..
+    } = scratch;
+    let source: &[CigarOp] = if placed.realized {
+        &realized[placed.slot].ops
+    } else {
+        &spoofed[placed.slot]
+    };
+    match projector.project(tid, placed.position, source, &mut projected[placed.slot]) {
+        Some(projection) => {
+            placed.position = projection.position;
+            placed.projection = Some(projection);
+            true
+        }
+        None => false,
+    }
+}
+
+/// The reference a placement points at: a chromosome once projected, the
+/// transcript otherwise.
+fn placed_reference(placed: &Placed, tid: usize) -> usize {
+    placed.projection.map_or(tid, |p| p.chromosome)
+}
+
+/// Swap a record's own strand bit with its mate's when the projection turned the
+/// alignment around, so the pair stays mutually consistent.
+fn flip_strand_bits(flags: u16) -> u16 {
+    let mut flipped = flags & !(IS_RC | MATE_RC);
+    if flags & IS_RC == 0 {
+        flipped |= IS_RC;
+    }
+    if flags & MATE_RC == 0 {
+        flipped |= MATE_RC;
+    }
+    flipped
+}
+
+/// The signed `TLEN` for a projected pair: the genomic span the two mates cover
+/// together, positive on the leftmost mate.
+fn projected_template_length(
+    scratch: &EmitScratch,
+    first: &Placed,
+    second: &Placed,
+) -> (i32, i32) {
+    let span = |placed: &Placed| {
+        salmon_map::realize::reference_span(&scratch.projected[placed.slot])
+    };
+    let start = first.position.min(second.position);
+    let end = (first.position + span(first)).max(second.position + span(second));
+    let length = end - start;
+    if first.position <= second.position {
+        (length, -length)
+    } else {
+        (-length, length)
     }
 }
 
 /// The CIGAR and `MD` a [`Placed`] refers to, borrowed out of the scratch.
 fn borrow_cigar<'s>(scratch: &'s EmitScratch, placed: &Placed) -> (&'s [CigarOp], Option<&'s str>) {
+    if placed.projection.is_some() {
+        // MD and NM describe the read against the transcript's bases, which are
+        // the genome's bases inside an exon, so projection leaves both valid.
+        let md = placed
+            .realized
+            .then(|| scratch.realized[placed.slot].md.as_str());
+        return (&scratch.projected[placed.slot], md);
+    }
     if placed.realized {
         let realized = &scratch.realized[placed.slot];
         (&realized.ops, Some(realized.md.as_str()))
@@ -616,7 +722,7 @@ pub fn emit_fragment_records(
                     mapping.r1_pos,
                     txp_len,
                 );
-                let p2 = place(
+                let mut p2 = place(
                     scratch,
                     1,
                     options,
@@ -627,6 +733,14 @@ pub fn emit_fragment_records(
                     mapping.r2_pos,
                     txp_len,
                 );
+                let mut p1 = p1;
+                if let Some(projector) = options.projector {
+                    if !project_placement(scratch, &mut p1, projector, tid)
+                        || !project_placement(scratch, &mut p2, projector, tid)
+                    {
+                        continue;
+                    }
+                }
                 // TLEN is the observed template (fragment) length, truncated at
                 // the transcript end for the same reason positions are clamped.
                 let mut fragment_length = mapping.fragment_len;
@@ -653,21 +767,40 @@ pub fn emit_fragment_records(
                     f2 |= IS_RC;
                     f1 |= MATE_RC;
                 }
+                // A projected reverse-strand transcript turns the alignment
+                // around, so both records' strand bits swap and their stored
+                // bases are reverse-complemented once more. TLEN is recomputed
+                // over the genomic span, which introns make longer than the
+                // transcript one.
+                let flipped = p1.projection.is_some_and(|p| p.flipped);
+                let (mut f1, mut f2) = (f1, f2);
+                let (mut tlen1, mut tlen2) = (tlen1, -tlen1);
+                let (mut rc1, mut rc2) = (!mapping.is_fw, !mapping.r2_fw);
+                if flipped {
+                    f1 = flip_strand_bits(f1);
+                    f2 = flip_strand_bits(f2);
+                    rc1 = !rc1;
+                    rc2 = !rc2;
+                }
+                if p1.projection.is_some() {
+                    (tlen1, tlen2) = projected_template_length(scratch, &p1, &p2);
+                }
+                let reference = placed_reference(&p1, tid);
                 let (cigar1, md1) = borrow_cigar(scratch, &p1);
                 let (cigar2, md2) = borrow_cigar(scratch, &p2);
                 emit(&AlignmentRecord {
                     name: name1,
                     flags: f1,
-                    reference_id: Some(tid),
+                    reference_id: Some(reference),
                     position: p1.position,
                     mapping_quality: mapq,
                     cigar: cigar1,
-                    mate_reference_id: Some(tid),
+                    mate_reference_id: Some(reference),
                     mate_position: Some(p2.position),
                     template_length: tlen1,
                     sequence: r1_seq,
                     qualities: r1_qual,
-                    reverse_complement: !mapping.is_fw,
+                    reverse_complement: rc1,
                     nh,
                     hi,
                     xt,
@@ -682,16 +815,16 @@ pub fn emit_fragment_records(
                 emit(&AlignmentRecord {
                     name: name2,
                     flags: f2,
-                    reference_id: Some(tid),
+                    reference_id: Some(reference),
                     position: p2.position,
                     mapping_quality: mapq,
                     cigar: cigar2,
-                    mate_reference_id: Some(tid),
+                    mate_reference_id: Some(reference),
                     mate_position: Some(p1.position),
-                    template_length: -tlen1,
+                    template_length: tlen2,
                     sequence: r2_seq,
                     qualities: r2_qual,
-                    reverse_complement: !mapping.r2_fw,
+                    reverse_complement: rc2,
                     nh,
                     hi,
                     xt,
@@ -705,7 +838,7 @@ pub fn emit_fragment_records(
                 })?;
             }
             MateStatus::SingleEnd => {
-                let p = place(
+                let mut p = place(
                     scratch,
                     0,
                     options,
@@ -716,11 +849,19 @@ pub fn emit_fragment_records(
                     mapping.r1_pos,
                     txp_len,
                 );
+                if let Some(projector) = options.projector {
+                    if !project_placement(scratch, &mut p, projector, tid) {
+                        continue;
+                    }
+                }
+                let flipped = p.projection.is_some_and(|p| p.flipped);
+                let forward = mapping.is_fw != flipped;
+                let reference = placed_reference(&p, tid);
                 let (cigar, md) = borrow_cigar(scratch, &p);
                 emit(&AlignmentRecord {
                     name: name1,
-                    flags: secondary | if mapping.is_fw { 0 } else { IS_RC },
-                    reference_id: Some(tid),
+                    flags: secondary | if forward { 0 } else { IS_RC },
+                    reference_id: Some(reference),
                     position: p.position,
                     mapping_quality: mapq,
                     cigar,
@@ -729,7 +870,7 @@ pub fn emit_fragment_records(
                     template_length: 0,
                     sequence: r1_seq,
                     qualities: r1_qual,
-                    reverse_complement: !mapping.is_fw,
+                    reverse_complement: !forward,
                     nh,
                     hi,
                     xt,
@@ -768,10 +909,16 @@ pub fn emit_fragment_records(
                         READ2,
                     )
                 };
-                let p = place(
+                let mut p = place(
                     scratch, 0, options, salmon, tid, sequence, forward, position, txp_len,
                 );
-                let reference = tid;
+                if let Some(projector) = options.projector {
+                    if !project_placement(scratch, &mut p, projector, tid) {
+                        continue;
+                    }
+                }
+                let forward = forward != p.projection.is_some_and(|p| p.flipped);
+                let reference = placed_reference(&p, tid);
                 if index == 0 {
                     orphan_mate = Some((reference, p.position, !forward));
                 }
@@ -783,7 +930,7 @@ pub fn emit_fragment_records(
                         | read_flag
                         | secondary
                         | if forward { 0 } else { IS_RC },
-                    reference_id: Some(tid),
+                    reference_id: Some(reference),
                     position: p.position,
                     mapping_quality: mapq,
                     cigar,

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -190,6 +190,9 @@ pub(crate) struct Shared<'a> {
     pub unmapped_names: Option<&'a Mutex<UnmappedWriter>>,
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
+    /// run-wide mapping-output settings: whether to realize a base-level CIGAR
+    /// for each written placement, and with what alignment parameters
+    pub record_options: &'a crate::mapping_record::RecordOptions<'a>,
     /// when set, encode per-mapping BAM records into reusable worker chunks
     pub bam: Option<&'a crate::bam::BamOutput>,
     /// when set, write per-fragment mappings to a RAD file (`--writeRad`)
@@ -393,6 +396,9 @@ pub(crate) struct QuantProcessor<'a> {
     /// per-thread RAD chunk buffer (flushed as one chunk per batch); `None`
     /// unless `--writeRad` is set
     pub rad_buf: Option<salmon_rad::FragmentChunkBuf>,
+    /// per-thread buffers for deriving record fields (realized CIGARs, MD
+    /// strings, the aligner workspace); allocated once per worker, not per record
+    pub emit_scratch: crate::mapping_record::EmitScratch,
 }
 
 impl<'a> QuantProcessor<'a> {
@@ -428,6 +434,7 @@ impl<'a> QuantProcessor<'a> {
             rad_buf: shared.rad.map(|rad| {
                 salmon_rad::FragmentChunkBuf::with_capacity_codec(64 * 1024, rad.codec())
             }),
+            emit_scratch: crate::mapping_record::EmitScratch::default(),
         }
     }
 }
@@ -1331,6 +1338,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             sam_buf,
             bam_scratch,
             rad_buf,
+            emit_scratch,
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -1429,6 +1437,8 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     s1.as_ref(),
                     Some((r2.id(), s2.as_ref())),
                     &placements,
+                    sh.record_options,
+                    emit_scratch,
                 );
             }
             if let Some(scratch) = bam_scratch.as_mut() {
@@ -1439,6 +1449,8 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                         s1.as_ref(),
                         Some((r2.id(), s2.as_ref())),
                         &placements,
+                        sh.record_options,
+                        emit_scratch,
                     )?;
                 }
             }
@@ -1517,6 +1529,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             sam_buf,
             bam_scratch,
             rad_buf,
+            emit_scratch,
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -1588,11 +1601,21 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     s.as_ref(),
                     None,
                     &placements,
+                    sh.record_options,
+                    emit_scratch,
                 );
             }
             if let Some(scratch) = bam_scratch.as_mut() {
                 if !placements.is_empty() {
-                    scratch.write_fragment(sh.salmon, rec.id(), s.as_ref(), None, &placements)?;
+                    scratch.write_fragment(
+                        sh.salmon,
+                        rec.id(),
+                        s.as_ref(),
+                        None,
+                        &placements,
+                        sh.record_options,
+                        emit_scratch,
+                    )?;
                 }
             }
             if let (Some(rad), Some(buf)) = (sh.rad, rad_buf.as_mut()) {

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -197,6 +197,9 @@ pub(crate) struct Shared<'a> {
     /// run-wide mapping-output settings: the read group to tag records with, and
     /// whether to realize a base-level CIGAR for each placement
     pub record_options: &'a crate::mapping_record::RecordOptions<'a>,
+    /// also emit a `FLAG 0x4` record for every fragment that did not map
+    /// (`--sampleUnaligned`), so the mapping output covers the whole library
+    pub write_unaligned: bool,
     /// `--deterministic` mode: collect an order-independent fragment-length
     /// distribution (+ library-format tally) from uniquely-mapped proper pairs
     /// during the mapping pass, instead of training the online (log-space) FLD or
@@ -1434,18 +1437,30 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             // qualities on every fragment.
             let mate = (sh.sam.is_some() || bam_scratch.is_some())
                 .then(|| (r2.id(), s2.as_ref(), r2.qual()));
-            if sh.sam.is_some() && !placements.is_empty() {
-                crate::sam::write_fragment(
-                    sam_buf,
-                    sh.salmon,
-                    r1.id(),
-                    s1.as_ref(),
-                    r1.qual(),
-                    mate,
-                    &placements,
-                    sh.record_options,
-                    emit_scratch,
-                );
+            if sh.sam.is_some() {
+                if !placements.is_empty() {
+                    crate::sam::write_fragment(
+                        sam_buf,
+                        sh.salmon,
+                        r1.id(),
+                        s1.as_ref(),
+                        r1.qual(),
+                        mate,
+                        &placements,
+                        sh.record_options,
+                        emit_scratch,
+                    );
+                } else if sh.write_unaligned {
+                    crate::sam::write_unmapped_fragment(
+                        sam_buf,
+                        sh.salmon,
+                        r1.id(),
+                        s1.as_ref(),
+                        r1.qual(),
+                        mate,
+                        sh.record_options,
+                    );
+                }
             }
             if let Some(scratch) = bam_scratch.as_mut() {
                 if !placements.is_empty() {
@@ -1458,6 +1473,14 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                         &placements,
                         sh.record_options,
                         emit_scratch,
+                    )?;
+                } else if sh.write_unaligned {
+                    scratch.write_unmapped_fragment(
+                        r1.id(),
+                        s1.as_ref(),
+                        r1.qual(),
+                        mate,
+                        sh.record_options,
                     )?;
                 }
             }
@@ -1612,6 +1635,16 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     sh.record_options,
                     emit_scratch,
                 );
+            } else if sh.sam.is_some() && sh.write_unaligned {
+                crate::sam::write_unmapped_fragment(
+                    sam_buf,
+                    sh.salmon,
+                    rec.id(),
+                    s.as_ref(),
+                    rec.qual(),
+                    None,
+                    sh.record_options,
+                );
             }
             if let Some(scratch) = bam_scratch.as_mut() {
                 if !placements.is_empty() {
@@ -1624,6 +1657,14 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                         &placements,
                         sh.record_options,
                         emit_scratch,
+                    )?;
+                } else if sh.write_unaligned {
+                    scratch.write_unmapped_fragment(
+                        rec.id(),
+                        s.as_ref(),
+                        rec.qual(),
+                        None,
+                        sh.record_options,
                     )?;
                 }
             }

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -190,13 +190,13 @@ pub(crate) struct Shared<'a> {
     pub unmapped_names: Option<&'a Mutex<UnmappedWriter>>,
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
-    /// run-wide mapping-output settings: whether to realize a base-level CIGAR
-    /// for each written placement, and with what alignment parameters
-    pub record_options: &'a crate::mapping_record::RecordOptions<'a>,
     /// when set, encode per-mapping BAM records into reusable worker chunks
     pub bam: Option<&'a crate::bam::BamOutput>,
     /// when set, write per-fragment mappings to a RAD file (`--writeRad`)
     pub rad: Option<&'a salmon_rad::RadOutputWriter>,
+    /// run-wide mapping-output settings: the read group to tag records with, and
+    /// whether to realize a base-level CIGAR for each placement
+    pub record_options: &'a crate::mapping_record::RecordOptions<'a>,
     /// `--deterministic` mode: collect an order-independent fragment-length
     /// distribution (+ library-format tally) from uniquely-mapped proper pairs
     /// during the mapping pass, instead of training the online (log-space) FLD or
@@ -389,6 +389,9 @@ pub(crate) struct QuantProcessor<'a> {
     pub unmapped: String,
     /// per-thread SAM record buffer (flushed to the shared writer per batch)
     pub sam_buf: String,
+    /// per-thread buffers for deriving record fields (realized CIGARs, MD
+    /// strings, the aligner workspace); allocated once per worker, not per record
+    pub emit_scratch: crate::mapping_record::EmitScratch,
     /// per-thread raw BAM record chunk; allocated only for `--writeBam`. Holds
     /// its own borrow of the writer, so "have a chunk ⇒ have somewhere to send
     /// it" is enforced by the type rather than re-checked at each use.
@@ -396,9 +399,6 @@ pub(crate) struct QuantProcessor<'a> {
     /// per-thread RAD chunk buffer (flushed as one chunk per batch); `None`
     /// unless `--writeRad` is set
     pub rad_buf: Option<salmon_rad::FragmentChunkBuf>,
-    /// per-thread buffers for deriving record fields (realized CIGARs, MD
-    /// strings, the aligner workspace); allocated once per worker, not per record
-    pub emit_scratch: crate::mapping_record::EmitScratch,
 }
 
 impl<'a> QuantProcessor<'a> {
@@ -430,11 +430,11 @@ impl<'a> QuantProcessor<'a> {
             posbias,
             unmapped: String::new(),
             sam_buf: String::new(),
+            emit_scratch: crate::mapping_record::EmitScratch::default(),
             bam_scratch: shared.bam.map(|output| output.scratch()),
             rad_buf: shared.rad.map(|rad| {
                 salmon_rad::FragmentChunkBuf::with_capacity_codec(64 * 1024, rad.codec())
             }),
-            emit_scratch: crate::mapping_record::EmitScratch::default(),
         }
     }
 }
@@ -1336,9 +1336,9 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             posbias,
             unmapped,
             sam_buf,
+            emit_scratch,
             bam_scratch,
             rad_buf,
-            emit_scratch,
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -1429,13 +1429,19 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             if !sh.sketch {
                 accumulate_vm_stats(placements.is_empty(), counters);
             }
+            // Only assembled when there is somewhere for it to go: a run without
+            // mapping output should not pay for reading the mate's id and
+            // qualities on every fragment.
+            let mate = (sh.sam.is_some() || bam_scratch.is_some())
+                .then(|| (r2.id(), s2.as_ref(), r2.qual()));
             if sh.sam.is_some() && !placements.is_empty() {
                 crate::sam::write_fragment(
                     sam_buf,
                     sh.salmon,
                     r1.id(),
                     s1.as_ref(),
-                    Some((r2.id(), s2.as_ref())),
+                    r1.qual(),
+                    mate,
                     &placements,
                     sh.record_options,
                     emit_scratch,
@@ -1447,7 +1453,8 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                         sh.salmon,
                         r1.id(),
                         s1.as_ref(),
-                        Some((r2.id(), s2.as_ref())),
+                        r1.qual(),
+                        mate,
                         &placements,
                         sh.record_options,
                         emit_scratch,
@@ -1527,9 +1534,9 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             posbias,
             unmapped,
             sam_buf,
+            emit_scratch,
             bam_scratch,
             rad_buf,
-            emit_scratch,
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -1599,6 +1606,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     sh.salmon,
                     rec.id(),
                     s.as_ref(),
+                    rec.qual(),
                     None,
                     &placements,
                     sh.record_options,
@@ -1611,6 +1619,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                         sh.salmon,
                         rec.id(),
                         s.as_ref(),
+                        rec.qual(),
                         None,
                         &placements,
                         sh.record_options,

--- a/crates/salmon-quant/src/sam.rs
+++ b/crates/salmon-quant/src/sam.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 use salmon_index::SalmonIndex;
 use salmon_map::ScoredMapping;
 
-use crate::mapping_record::{self, AlignmentRecord, CigarKind};
+use crate::mapping_record::{self, AlignmentRecord, EmitScratch, RecordOptions};
 
 /// Shared SAM sink. Worker threads format whole blocks of records into their own
 /// string buffers and hand them over; the mutex is taken once per block rather
@@ -44,7 +44,7 @@ impl SamWriter {
     /// Append one worker's accumulated block of records.
     ///
     /// Blocks land in whatever order threads finish, so records for one fragment
-    /// are contiguous but no order is imposed across fragments — as documented
+    /// are contiguous but no order is imposed across fragments, as documented
     /// for `--writeMappings`.
     pub fn write_block(&self, block: &str) -> std::io::Result<()> {
         if block.is_empty() {
@@ -59,9 +59,13 @@ impl SamWriter {
 }
 
 /// Write the read's bases, reverse-complementing them when the alignment is on
-/// the reverse strand — SAM always stores the sequence as it appears on the
+/// the reverse strand: SAM always stores the sequence as it appears on the
 /// reference's forward strand.
 fn write_sequence(buf: &mut String, record: &AlignmentRecord<'_>) {
+    if record.sequence.is_empty() {
+        buf.push('*');
+        return;
+    }
     if record.reverse_complement {
         for &base in record.sequence.iter().rev() {
             buf.push(mapping_record::complement(base) as char);
@@ -77,27 +81,35 @@ fn write_sequence(buf: &mut String, record: &AlignmentRecord<'_>) {
 /// followed by salmon's optional tags.
 fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord<'_>) {
     let name = String::from_utf8_lossy(record.name);
-    let reference = salmon.ref_name(record.reference_id);
-    // QNAME, FLAG, RNAME, POS, MAPQ. SAM positions are 1-based, ours are 0-based.
-    let _ = write!(
-        buf,
-        "{name}\t{}\t{reference}\t{}\t{}",
-        record.flags,
-        record.position + 1,
-        record.mapping_quality
-    );
+    // QNAME, FLAG, RNAME, POS, MAPQ. SAM positions are 1-based, ours are 0-based,
+    // and an unmapped record has neither a reference nor a position.
+    let _ = write!(buf, "{name}\t{}\t", record.flags);
+    match record.reference_id {
+        Some(tid) => {
+            let _ = write!(
+                buf,
+                "{}\t{}\t{}",
+                salmon.ref_name(tid),
+                record.position + 1,
+                record.mapping_quality
+            );
+        }
+        None => {
+            let _ = write!(buf, "*\t0\t{}", record.mapping_quality);
+        }
+    }
     buf.push('\t');
-    for op in record.cigar.as_slice() {
-        let kind = match op.kind {
-            CigarKind::Match => 'M',
-            CigarKind::SoftClip => 'S',
-        };
-        let _ = write!(buf, "{}{kind}", op.len);
+    if record.cigar.is_empty() {
+        buf.push('*');
+    } else {
+        for op in record.cigar {
+            let _ = write!(buf, "{}{}", op.len, op.kind.letter());
+        }
     }
     // RNEXT, PNEXT, TLEN. `=` is SAM's shorthand for "same reference as this
     // record", which is always the case for a proper pair here.
     if let (Some(mate_id), Some(mate_position)) = (record.mate_reference_id, record.mate_position) {
-        let mate_reference = if mate_id == record.reference_id {
+        let mate_reference = if Some(mate_id) == record.reference_id {
             "="
         } else {
             salmon.ref_name(mate_id)
@@ -113,16 +125,32 @@ fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord
     }
     buf.push('\t');
     write_sequence(buf, record);
-    // QUAL is `*` (not retained), then the tags: NH = number of placements for
-    // this fragment, HI = which one this is, XT = transcript/decoy, AS = score.
-    let _ = writeln!(
+    // QUAL: salmon does not retain base qualities, and `*` is SAM's spelling for
+    // "not available".
+    buf.push_str("\t*");
+    write_tags(buf, record);
+    buf.push('\n');
+}
+
+/// Append the optional tags: `NH` = number of placements for this fragment,
+/// `HI` = which one this is, `XT` = transcript/decoy, `AS` = the score of the
+/// alignment in this very record, and `NM`/`MD` describing that alignment.
+fn write_tags(buf: &mut String, record: &AlignmentRecord<'_>) {
+    let _ = write!(
         buf,
-        "\t*\tNH:i:{}\tHI:i:{}\tXT:A:{}\tAS:i:{}",
+        "\tNH:i:{}\tHI:i:{}\tXT:A:{}\tAS:i:{}",
         record.nh, record.hi, record.xt as char, record.alignment_score
     );
+    if let Some(edit_distance) = record.edit_distance {
+        let _ = write!(buf, "\tNM:i:{edit_distance}");
+    }
+    if let Some(md) = record.md {
+        let _ = write!(buf, "\tMD:Z:{md}");
+    }
 }
 
 /// Append every SAM record implied by one fragment's placements.
+#[allow(clippy::too_many_arguments)]
 pub fn write_fragment(
     buf: &mut String,
     salmon: &SalmonIndex,
@@ -130,10 +158,21 @@ pub fn write_fragment(
     r1_seq: &[u8],
     r2: Option<(&[u8], &[u8])>,
     maps: &[ScoredMapping],
+    options: &RecordOptions<'_>,
+    scratch: &mut EmitScratch,
 ) {
-    mapping_record::emit_fragment_records(salmon, r1_id, r1_seq, r2, maps, |record| {
-        write_record(buf, salmon, record);
-        Ok(())
-    })
+    mapping_record::emit_fragment_records(
+        salmon,
+        r1_id,
+        r1_seq,
+        r2,
+        maps,
+        options,
+        scratch,
+        |record| {
+            write_record(buf, salmon, record);
+            Ok(())
+        },
+    )
     .expect("writing to String is infallible");
 }

--- a/crates/salmon-quant/src/sam.rs
+++ b/crates/salmon-quant/src/sam.rs
@@ -108,7 +108,12 @@ fn write_qualities(buf: &mut String, record: &AlignmentRecord<'_>) {
 
 /// Serialize one record as a SAM line: the eleven mandatory tab-separated fields
 /// followed by salmon's optional tags.
-fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord<'_>) {
+fn write_record(
+    buf: &mut String,
+    salmon: &SalmonIndex,
+    options: &RecordOptions<'_>,
+    record: &AlignmentRecord<'_>,
+) {
     let name = String::from_utf8_lossy(record.name);
     // QNAME, FLAG, RNAME, POS, MAPQ. SAM positions are 1-based, ours are 0-based,
     // and an unmapped record has neither a reference nor a position.
@@ -118,7 +123,7 @@ fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord
             let _ = write!(
                 buf,
                 "{}\t{}\t{}",
-                salmon.ref_name(tid),
+                options.reference_name(salmon, tid),
                 record.position + 1,
                 record.mapping_quality
             );
@@ -141,7 +146,7 @@ fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord
         let mate_reference = if Some(mate_id) == record.reference_id {
             "="
         } else {
-            salmon.ref_name(mate_id)
+            options.reference_name(salmon, mate_id)
         };
         let _ = write!(
             buf,
@@ -221,7 +226,7 @@ pub fn write_fragment(
         options,
         scratch,
         |record| {
-            write_record(buf, salmon, record);
+            write_record(buf, salmon, options, record);
             Ok(())
         },
     )
@@ -239,7 +244,7 @@ pub fn write_unmapped_fragment(
     options: &RecordOptions<'_>,
 ) {
     mapping_record::emit_unmapped_fragment(r1_id, r1_seq, r1_qual, r2, options, |record| {
-        write_record(buf, salmon, record);
+        write_record(buf, salmon, options, record);
         Ok(())
     })
     .expect("writing to String is infallible");

--- a/crates/salmon-quant/src/sam.rs
+++ b/crates/salmon-quant/src/sam.rs
@@ -167,7 +167,7 @@ fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord
 /// was never made. Only the read group, which is a property of the read rather
 /// than of any placement, survives.
 fn write_tags(buf: &mut String, record: &AlignmentRecord<'_>) {
-    {
+    if !record.is_unmapped() {
         // NH = number of placements for this fragment, HI = which one this is,
         // XT = transcript/decoy, AS = score, ZW = the mapping's EM weight.
         let _ = write!(
@@ -225,5 +225,22 @@ pub fn write_fragment(
             Ok(())
         },
     )
+    .expect("writing to String is infallible");
+}
+
+/// Append the SAM records for a fragment that did not map.
+pub fn write_unmapped_fragment(
+    buf: &mut String,
+    salmon: &SalmonIndex,
+    r1_id: &[u8],
+    r1_seq: &[u8],
+    r1_qual: Option<&[u8]>,
+    r2: Option<(&[u8], &[u8], Option<&[u8]>)>,
+    options: &RecordOptions<'_>,
+) {
+    mapping_record::emit_unmapped_fragment(r1_id, r1_seq, r1_qual, r2, options, |record| {
+        write_record(buf, salmon, record);
+        Ok(())
+    })
     .expect("writing to String is infallible");
 }

--- a/crates/salmon-quant/src/sam.rs
+++ b/crates/salmon-quant/src/sam.rs
@@ -197,6 +197,9 @@ fn write_tags(buf: &mut String, record: &AlignmentRecord<'_>) {
                 }
             }
         }
+        if let Some(strand) = record.transcript_strand {
+            let _ = write!(buf, "\tXS:A:{}", strand as char);
+        }
     }
     if let Some(read_group) = record.read_group {
         let _ = write!(buf, "\tRG:Z:{read_group}");

--- a/crates/salmon-quant/src/sam.rs
+++ b/crates/salmon-quant/src/sam.rs
@@ -22,7 +22,12 @@ pub struct SamWriter {
 }
 
 impl SamWriter {
-    pub fn create(path: &std::path::Path, salmon: &SalmonIndex, cmd: &str) -> anyhow::Result<Self> {
+    pub fn create(
+        path: &std::path::Path,
+        salmon: &SalmonIndex,
+        cmd: &str,
+        options: &RecordOptions<'_>,
+    ) -> anyhow::Result<Self> {
         use anyhow::Context as _;
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
@@ -35,7 +40,7 @@ impl SamWriter {
         let mut writer: Box<dyn Write + Send> =
             Box::new(std::io::BufWriter::with_capacity(1 << 20, file));
         // Same header text BAM embeds, so the two formats cannot drift.
-        writer.write_all(mapping_record::header_text(salmon, cmd).as_bytes())?;
+        writer.write_all(mapping_record::header_text(salmon, cmd, options).as_bytes())?;
         Ok(Self {
             inner: Mutex::new(writer),
         })
@@ -74,6 +79,30 @@ fn write_sequence(buf: &mut String, record: &AlignmentRecord<'_>) {
         for &base in record.sequence {
             buf.push(base as char);
         }
+    }
+}
+
+/// Write `QUAL`: the Phred+33 characters as the FASTQ carried them, reversed to
+/// match a reverse-strand `SEQ` so that base *i* of one still describes base *i*
+/// of the other. `*` when the input had no qualities (a FASTA), which is SAM's
+/// spelling for "not available".
+///
+/// A quality string of the wrong length is dropped rather than written: readers
+/// reject a record whose `QUAL` and `SEQ` disagree, so a truncated FASTQ record
+/// must not be able to produce an unreadable file.
+fn write_qualities(buf: &mut String, record: &AlignmentRecord<'_>) {
+    match mapping_record::usable_qualities(record) {
+        Some(qualities) if record.reverse_complement => {
+            for &q in qualities.iter().rev() {
+                buf.push(q as char);
+            }
+        }
+        Some(qualities) => {
+            for &q in qualities {
+                buf.push(q as char);
+            }
+        }
+        None => buf.push('*'),
     }
 }
 
@@ -125,27 +154,47 @@ fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord
     }
     buf.push('\t');
     write_sequence(buf, record);
-    // QUAL: salmon does not retain base qualities, and `*` is SAM's spelling for
-    // "not available".
-    buf.push_str("\t*");
+    buf.push('\t');
+    write_qualities(buf, record);
     write_tags(buf, record);
     buf.push('\n');
 }
 
-/// Append the optional tags: `NH` = number of placements for this fragment,
-/// `HI` = which one this is, `XT` = transcript/decoy, `AS` = the score of the
-/// alignment in this very record, and `NM`/`MD` describing that alignment.
+/// Append the optional tags.
+///
+/// An unmapped record carries none of the placement tags: `NH`/`HI` describe a
+/// set of placements it does not have, and `AS`/`XT` describe an alignment that
+/// was never made. Only the read group, which is a property of the read rather
+/// than of any placement, survives.
 fn write_tags(buf: &mut String, record: &AlignmentRecord<'_>) {
-    let _ = write!(
-        buf,
-        "\tNH:i:{}\tHI:i:{}\tXT:A:{}\tAS:i:{}",
-        record.nh, record.hi, record.xt as char, record.alignment_score
-    );
-    if let Some(edit_distance) = record.edit_distance {
-        let _ = write!(buf, "\tNM:i:{edit_distance}");
+    {
+        // NH = number of placements for this fragment, HI = which one this is,
+        // XT = transcript/decoy, AS = score, ZW = the mapping's EM weight.
+        let _ = write!(
+            buf,
+            "\tNH:i:{}\tHI:i:{}\tXT:A:{}\tAS:i:{}\tZW:f:{}",
+            record.nh, record.hi, record.xt as char, record.alignment_score, record.weight
+        );
+        if let Some(edit_distance) = record.edit_distance {
+            let _ = write!(buf, "\tNM:i:{edit_distance}");
+        }
+        if let Some(md) = record.md {
+            let _ = write!(buf, "\tMD:Z:{md}");
+        }
+        if let Some(mate_mapping_quality) = record.mate_mapping_quality {
+            let _ = write!(buf, "\tMQ:i:{mate_mapping_quality}");
+        }
+        if let Some(mate_cigar) = record.mate_cigar {
+            if !mate_cigar.is_empty() {
+                buf.push_str("\tMC:Z:");
+                for op in mate_cigar {
+                    let _ = write!(buf, "{}{}", op.len, op.kind.letter());
+                }
+            }
+        }
     }
-    if let Some(md) = record.md {
-        let _ = write!(buf, "\tMD:Z:{md}");
+    if let Some(read_group) = record.read_group {
+        let _ = write!(buf, "\tRG:Z:{read_group}");
     }
 }
 
@@ -156,7 +205,8 @@ pub fn write_fragment(
     salmon: &SalmonIndex,
     r1_id: &[u8],
     r1_seq: &[u8],
-    r2: Option<(&[u8], &[u8])>,
+    r1_qual: Option<&[u8]>,
+    r2: Option<(&[u8], &[u8], Option<&[u8]>)>,
     maps: &[ScoredMapping],
     options: &RecordOptions<'_>,
     scratch: &mut EmitScratch,
@@ -165,6 +215,7 @@ pub fn write_fragment(
         salmon,
         r1_id,
         r1_seq,
+        r1_qual,
         r2,
         maps,
         options,

--- a/crates/salmon-quant/src/splice.rs
+++ b/crates/salmon-quant/src/splice.rs
@@ -298,10 +298,16 @@ fn model_for(
     chromosome: usize,
 ) -> TranscriptModel {
     let forward = transcript.strand != '-';
+    // bramble stores a GTF exon as `[start_1, end_1 + 1)`: the length is right,
+    // but the interval is still anchored at the 1-based start, so every
+    // coordinate is one too high. Subtract the one here, once, rather than
+    // letting a systematic off-by-one into every projected position. Exon
+    // lengths are unaffected, which is why the introns between them come out
+    // correct either way and only the reported positions gave it away.
     let mut exons: Vec<(u32, u32)> = transcript
         .exons
         .iter()
-        .map(|e| (e.start, e.end.saturating_sub(e.start)))
+        .map(|e| (e.start.saturating_sub(1), e.end.saturating_sub(e.start)))
         .filter(|(_, len)| *len > 0)
         .collect();
     exons.sort_unstable();
@@ -590,6 +596,41 @@ mod tests {
         let mut ops = Vec::new();
         assert!(!projector.describes(0));
         assert_eq!(projector.project(0, 0, &matched(10), &mut ops), None);
+    }
+
+    /// bramble hands back GTF exons anchored at the 1-based start, so the
+    /// conversion to genomic coordinates has to subtract the one. Getting this
+    /// wrong shifts every projected record by a base while leaving intron
+    /// lengths correct, which is exactly the kind of error that survives a
+    /// casual look at the output.
+    #[test]
+    fn gtf_exons_become_zero_based_genomic_blocks() {
+        let transcript = bramble_rs::annotation::Transcript {
+            id: "t".into(),
+            seqname: "chr1".into(),
+            strand: '+',
+            exons: vec![
+                // GTF `101 300` and `801 1000`, as bramble reports them.
+                bramble_rs::annotation::Exon {
+                    start: 101,
+                    end: 301,
+                },
+                bramble_rs::annotation::Exon {
+                    start: 801,
+                    end: 1001,
+                },
+            ],
+        };
+        let model = model_for(&transcript, 0);
+        assert_eq!(model.exons[0].genome_start, 100);
+        assert_eq!(model.exons[0].len, 200);
+        assert_eq!(model.exons[1].genome_start, 800);
+        assert_eq!(model.exons[1].len, 200);
+        // Transcript coordinate 0 is the exon's first genomic base, and the base
+        // after the first exon is the second exon's first base.
+        assert_eq!(model.genome_position(0), 100);
+        assert_eq!(model.genome_position(199), 299);
+        assert_eq!(model.genome_position(200), 800);
     }
 
     /// A `.fai` is the cheap path to chromosome lengths, and only its first two

--- a/crates/salmon-quant/src/splice.rs
+++ b/crates/salmon-quant/src/splice.rs
@@ -27,15 +27,15 @@
 //! reverse-complemented once more). [`Projection::flipped`] reports that flip so
 //! the record writer can apply it to `SEQ`, `QUAL` and the `FLAG` bits together.
 //!
-//! # A known rough edge
+//! # `MD` after projection
 //!
-//! `MD` is derived while the alignment is still in transcript coordinates, and
-//! carried through projection. That is sound for every operation except a
-//! deletion the projection has to cut in two, where the canonical spelling gains
-//! an empty match between the halves: `^G0^G` rather than `^GG`. Both reconstruct
-//! the same reference bases and both carry the same `NM`, so the difference is
-//! one of form, but `samtools calmd` writes the canonical one. It shows up on
-//! about three records in a million.
+//! `MD` describes the reference bases along the alignment, so it has to follow
+//! the alignment through projection rather than be carried across it. Two things
+//! change: a reverse-strand transcript's string is reverse-complemented with
+//! everything else, and a deletion the projection cuts in two becomes two
+//! deletions, which `MD` spells with an empty match between them. Both are done
+//! by re-deriving the string from the projected operations, which gets the
+//! grouping right by construction.
 //!
 //! # What is deliberately not done here
 //!
@@ -219,11 +219,13 @@ impl GenomeProjector {
     /// Returns `None` when the reference has no exon structure (a decoy, or a
     /// transcript the annotation does not mention), in which case the caller has
     /// nothing genomic to write for this placement.
+    #[allow(clippy::too_many_arguments)]
     pub fn project(
         &self,
         tid: usize,
         transcript_position: i32,
         ops: &[CigarOp],
+        md: Option<(&str, &mut Vec<MdBase>, &mut String)>,
         out: &mut Vec<CigarOp>,
     ) -> Option<Projection> {
         out.clear();
@@ -286,6 +288,15 @@ impl GenomeProjector {
         } else {
             model.genome_position(last)
         } as i32;
+        // MD is re-derived here, while the operations are still in transcript
+        // order and line up with the transcript's reference bases one for one.
+        if let Some((transcript_md, scratch, md_out)) = md {
+            reproject_md(transcript_md, out, scratch, md_out);
+            if !model.forward {
+                let forward_md = std::mem::take(md_out);
+                reverse_complement_md(&forward_md, md_out);
+            }
+        }
         if !model.forward {
             out.reverse();
         }
@@ -295,6 +306,97 @@ impl GenomeProjector {
             flipped: !model.forward,
         })
     }
+}
+
+/// One reference base, as `MD` describes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MdBase {
+    /// The read agrees with the reference here.
+    Match,
+    /// The read differs; the reference base is carried.
+    Mismatch(u8),
+    /// The reference base is absent from the read.
+    Deleted(u8),
+}
+
+/// Expand an `MD` string into one entry per reference base.
+///
+/// `MD` is written as runs, which is compact but positional: nothing in it says
+/// which CIGAR operation a given base belongs to. Expanding it makes the bases
+/// addressable, so they can be re-emitted against a different operation list.
+fn expand_md(md: &str, out: &mut Vec<MdBase>) {
+    out.clear();
+    let mut digits = 0usize;
+    let mut chars = md.chars().peekable();
+    while let Some(c) = chars.next() {
+        if let Some(digit) = c.to_digit(10) {
+            digits = digits * 10 + digit as usize;
+            continue;
+        }
+        out.extend(std::iter::repeat_n(MdBase::Match, digits));
+        digits = 0;
+        if c == '^' {
+            while chars.peek().is_some_and(|n| n.is_ascii_alphabetic()) {
+                out.push(MdBase::Deleted(chars.next().unwrap() as u8));
+            }
+        } else {
+            out.push(MdBase::Mismatch(c as u8));
+        }
+    }
+    out.extend(std::iter::repeat_n(MdBase::Match, digits));
+}
+
+/// Re-emit `MD` against the projected operations.
+///
+/// The reference bases are unchanged by projection, but their grouping is not: a
+/// deletion the projection cuts in two is two deletions, and `MD` spells those
+/// `^G0^G`, not `^GG`. Deriving the string from the transcript's operations and
+/// carrying it across produced the merged form, which no longer matches the CIGAR
+/// beside it. Walking the projected operations instead gets the grouping right by
+/// construction, and the empty match between the halves falls out of the normal
+/// rule that a run length separates every pair of tokens.
+///
+/// `ops` must be in transcript order, before any reversal for strand.
+fn reproject_md(transcript_md: &str, ops: &[CigarOp], scratch: &mut Vec<MdBase>, out: &mut String) {
+    use std::fmt::Write as _;
+    expand_md(transcript_md, scratch);
+    out.clear();
+    let mut next = 0usize;
+    let mut run = 0u32;
+    for op in ops {
+        match op.kind {
+            CigarOpKind::Match => {
+                for _ in 0..op.len {
+                    match scratch.get(next) {
+                        Some(MdBase::Mismatch(base)) => {
+                            let _ = write!(out, "{run}");
+                            out.push(*base as char);
+                            run = 0;
+                        }
+                        _ => run += 1,
+                    }
+                    next += 1;
+                }
+            }
+            CigarOpKind::Deletion => {
+                let _ = write!(out, "{run}");
+                run = 0;
+                out.push('^');
+                for _ in 0..op.len {
+                    if let Some(MdBase::Deleted(base)) = scratch.get(next) {
+                        out.push(*base as char);
+                    }
+                    next += 1;
+                }
+            }
+            // An intron consumes genome but no transcript, so it takes no
+            // reference bases from the stream. It still ends the current token,
+            // which is what a following deletion needs to start a fresh one.
+            CigarOpKind::Skip => {}
+            CigarOpKind::Insertion | CigarOpKind::SoftClip => {}
+        }
+    }
+    let _ = write!(out, "{run}");
 }
 
 /// Rewrite an `MD` string for an alignment that has been turned around.
@@ -547,7 +649,9 @@ mod tests {
     fn a_read_inside_one_exon_gets_no_skip() {
         let projector = projector(forward_model());
         let mut ops = Vec::new();
-        let projection = projector.project(0, 10, &matched(20), &mut ops).unwrap();
+        let projection = projector
+            .project(0, 10, &matched(20), None, &mut ops)
+            .unwrap();
         assert_eq!(cigar(&ops), "20M");
         assert_eq!(projection.position, 110);
         assert!(!projection.flipped);
@@ -561,7 +665,9 @@ mod tests {
         let projector = projector(forward_model());
         let mut ops = Vec::new();
         // Transcript 30..70 spans the first junction 20 bases in.
-        let projection = projector.project(0, 30, &matched(40), &mut ops).unwrap();
+        let projection = projector
+            .project(0, 30, &matched(40), None, &mut ops)
+            .unwrap();
         // 20 bases to the end of exon 1, an intron of 300 - 150 = 150, then 20 more.
         assert_eq!(cigar(&ops), "20M150N20M");
         assert_eq!(projection.position, 130);
@@ -573,7 +679,9 @@ mod tests {
     fn a_read_over_two_junctions_gains_two_skips() {
         let projector = projector(forward_model());
         let mut ops = Vec::new();
-        let projection = projector.project(0, 40, &matched(70), &mut ops).unwrap();
+        let projection = projector
+            .project(0, 40, &matched(70), None, &mut ops)
+            .unwrap();
         assert_eq!(cigar(&ops), "10M150N50M150N10M");
         assert_eq!(projection.position, 140);
     }
@@ -594,7 +702,7 @@ mod tests {
             CigarOp::new(CigarOpKind::Match, 10),
         ];
         let projection = projector
-            .project(0, 0, &transcript_cigar, &mut ops)
+            .project(0, 0, &transcript_cigar, None, &mut ops)
             .unwrap();
         assert_eq!(cigar(&ops), "47M3D150N10M");
         assert_eq!(projection.position, 100);
@@ -613,7 +721,7 @@ mod tests {
             CigarOp::new(CigarOpKind::Match, 15),
         ];
         let projection = projector
-            .project(0, 40, &transcript_cigar, &mut ops)
+            .project(0, 40, &transcript_cigar, None, &mut ops)
             .unwrap();
         assert_eq!(cigar(&ops), "5S10M150N5M3I15M");
         assert_eq!(projection.position, 140);
@@ -628,7 +736,9 @@ mod tests {
         let mut ops = Vec::new();
         // Transcript 90..130 crosses the junction between the 500..600 exon and
         // the 300..350 one.
-        let projection = projector.project(0, 90, &matched(40), &mut ops).unwrap();
+        let projection = projector
+            .project(0, 90, &matched(40), None, &mut ops)
+            .unwrap();
         assert!(projection.flipped);
         // 10 bases at the bottom of the 500..600 exon, the 150-base intron, then
         // 30 in the 300..350 exon, read left to right in genome order.
@@ -667,7 +777,8 @@ mod tests {
                         CigarOp::new(CigarOpKind::SoftClip, 4),
                         CigarOp::new(CigarOpKind::Match, len),
                     ];
-                    let Some(_) = projector.project(0, start as i32, &transcript_cigar, &mut ops)
+                    let Some(_) =
+                        projector.project(0, start as i32, &transcript_cigar, None, &mut ops)
                     else {
                         continue;
                     };
@@ -692,7 +803,7 @@ mod tests {
         };
         let mut ops = Vec::new();
         assert!(!projector.describes(0));
-        assert_eq!(projector.project(0, 0, &matched(10), &mut ops), None);
+        assert_eq!(projector.project(0, 0, &matched(10), None, &mut ops), None);
     }
 
     /// bramble hands back GTF exons anchored at the 1-based start, so the
@@ -752,6 +863,61 @@ mod tests {
             reverse_complement_md(&once, &mut out);
             assert_eq!(out, forward, "round-tripping {forward}");
         }
+    }
+
+    /// A deletion the projection has to cut in two is two deletions, and `MD`
+    /// says so with an empty match between them. Carrying the transcript's
+    /// string across produced the merged spelling, which disagrees with the
+    /// CIGAR beside it.
+    #[test]
+    fn a_deletion_split_by_an_intron_is_two_md_deletions() {
+        let projector = projector(forward_model());
+        let mut ops = Vec::new();
+        let mut scratch = Vec::new();
+        let mut md = String::new();
+        // Exon 1 is transcript 0..50: match 48, delete 4 across the boundary,
+        // then match 10.
+        let transcript_cigar = vec![
+            CigarOp::new(CigarOpKind::Match, 48),
+            CigarOp::new(CigarOpKind::Deletion, 4),
+            CigarOp::new(CigarOpKind::Match, 10),
+        ];
+        projector
+            .project(
+                0,
+                0,
+                &transcript_cigar,
+                Some(("48^ACGT10", &mut scratch, &mut md)),
+                &mut ops,
+            )
+            .unwrap();
+        assert_eq!(cigar(&ops), "48M2D150N2D10M");
+        assert_eq!(md, "48^AC0^GT10");
+    }
+
+    /// Re-emitting must leave an unsplit alignment's `MD` exactly as it was.
+    #[test]
+    fn reprojecting_an_intact_alignment_changes_nothing() {
+        let projector = projector(forward_model());
+        let mut ops = Vec::new();
+        let mut scratch = Vec::new();
+        let mut md = String::new();
+        let transcript_cigar = vec![
+            CigarOp::new(CigarOpKind::Match, 20),
+            CigarOp::new(CigarOpKind::Deletion, 2),
+            CigarOp::new(CigarOpKind::Match, 15),
+        ];
+        projector
+            .project(
+                0,
+                5,
+                &transcript_cigar,
+                Some(("12A7^GG15", &mut scratch, &mut md)),
+                &mut ops,
+            )
+            .unwrap();
+        assert_eq!(cigar(&ops), "20M2D15M");
+        assert_eq!(md, "12A7^GG15");
     }
 
     /// A `.fai` is the cheap path to chromosome lengths, and only its first two

--- a/crates/salmon-quant/src/splice.rs
+++ b/crates/salmon-quant/src/splice.rs
@@ -1,0 +1,608 @@
+//! Projection of transcriptome alignments into spliced genome alignments.
+//!
+//! # Why this exists
+//!
+//! salmon aligns reads to transcripts, and a transcript has no introns: a read
+//! sitting across an exon junction is contiguous in transcript coordinates, so
+//! the CIGAR that describes it never contains an `N`. That is the correct
+//! description of the alignment salmon actually made, but it is not the
+//! description a genome browser, a junction counter, or anything else built
+//! around STAR's output can read.
+//!
+//! This module converts one into the other. Given an annotation, each transcript
+//! is a list of exon blocks on a chromosome; a transcript-coordinate alignment is
+//! cut at those exon boundaries and the gaps between them reappear as `N`
+//! operations. The result is a spliced genome alignment of exactly the kind a
+//! genome aligner would have produced, derived from the transcript evidence
+//! salmon already has.
+//!
+//! # Reverse-strand transcripts
+//!
+//! Half of all transcripts run antisense to the genome, and for those the
+//! transcript coordinate axis points the opposite way from the genomic one. A
+//! read at transcript position 0 is then at the *rightmost* genomic base of the
+//! transcript, and the alignment has to be turned around: the CIGAR is reversed,
+//! the leftmost genomic position becomes the one the last transcript base landed
+//! on, and the record's strand flips (its stored sequence and qualities are
+//! reverse-complemented once more). [`Projection::flipped`] reports that flip so
+//! the record writer can apply it to `SEQ`, `QUAL` and the `FLAG` bits together.
+//!
+//! # What is deliberately not done here
+//!
+//! Two transcripts of the same gene often imply the *same* genomic alignment for
+//! a read. This module projects each placement independently and leaves the
+//! duplicates in place, tagged as secondary exactly as they were in transcript
+//! space, rather than silently collapsing them: which of them to keep is a
+//! quantification decision, and salmon's answer to it is `quant.sf`, not the
+//! BAM.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Context as _;
+use salmon_map::realize::{push_op, CigarOp, CigarOpKind};
+
+/// One exon, as a genomic interval plus where it starts along the transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExonBlock {
+    /// 0-based genomic start of the exon.
+    genome_start: u32,
+    /// Transcript coordinate of this exon's first base.
+    transcript_start: u32,
+    len: u32,
+}
+
+/// A transcript's exon structure, in transcript order.
+///
+/// "Transcript order" means exon 0 contains transcript coordinate 0, which for a
+/// reverse-strand transcript is the exon with the *highest* genomic coordinates.
+#[derive(Debug, Clone)]
+struct TranscriptModel {
+    chromosome: usize,
+    forward: bool,
+    exons: Vec<ExonBlock>,
+}
+
+impl TranscriptModel {
+    fn length(&self) -> u32 {
+        self.exons.last().map_or(0, |e| e.transcript_start + e.len)
+    }
+
+    /// The exon containing transcript coordinate `pos`, or the last one when
+    /// `pos` runs past the transcript end.
+    fn exon_at(&self, pos: u32) -> usize {
+        match self
+            .exons
+            .binary_search_by(|e| e.transcript_start.cmp(&pos))
+        {
+            Ok(index) => index,
+            // `binary_search_by` reports where `pos` would be inserted, so the
+            // exon containing it is the one before that.
+            Err(index) => index.saturating_sub(1),
+        }
+    }
+
+    /// The genomic coordinate of transcript position `pos`.
+    ///
+    /// On the forward strand this counts up from the exon's genomic start; on the
+    /// reverse strand it counts down from the exon's genomic end, because the two
+    /// axes run opposite ways.
+    fn genome_position(&self, pos: u32) -> u32 {
+        let exon = &self.exons[self.exon_at(pos)];
+        let offset = pos.saturating_sub(exon.transcript_start);
+        if self.forward {
+            exon.genome_start + offset
+        } else {
+            (exon.genome_start + exon.len).saturating_sub(offset + 1)
+        }
+    }
+}
+
+/// The result of projecting one placement onto the genome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Projection {
+    /// Index into [`GenomeProjector::chromosomes`].
+    pub chromosome: usize,
+    /// Leftmost genomic base the alignment consumes, 0-based.
+    pub position: i32,
+    /// Whether the alignment had to be turned around, because the transcript is
+    /// on the reverse strand. The record's strand bits, `SEQ` and `QUAL` all have
+    /// to be flipped to match.
+    pub flipped: bool,
+}
+
+/// Transcript exon structures for every reference in the salmon index, plus the
+/// chromosome table the projected records refer to.
+pub struct GenomeProjector {
+    /// `(name, length)` per chromosome, in the order they appear in `@SQ`.
+    chromosomes: Vec<(String, u64)>,
+    /// One entry per salmon reference id; `None` for a reference the annotation
+    /// does not describe (a decoy, or a transcript absent from the GTF).
+    models: Vec<Option<TranscriptModel>>,
+}
+
+impl GenomeProjector {
+    /// Build the projector for `reference_names` (the salmon index's reference
+    /// table, in index order) from an annotation and a genome FASTA.
+    ///
+    /// The genome is needed only for the chromosome *lengths* that `@SQ` has to
+    /// declare: an annotation says where exons are but never how long the
+    /// chromosome they sit on is, and a header that understates a chromosome
+    /// length produces a BAM that readers reject. A FASTA index (`.fai`) is used
+    /// when one is present, so the common case costs one small file read rather
+    /// than a pass over the genome.
+    pub fn build(
+        reference_names: &[&str],
+        annotation: &Path,
+        genome: &Path,
+    ) -> anyhow::Result<Self> {
+        let chromosome_lengths = chromosome_lengths(genome)?;
+        let transcripts = bramble_rs::annotation::load_transcripts(annotation)
+            .with_context(|| format!("reading annotation {}", annotation.display()))?;
+
+        // Only the chromosomes the annotation actually places transcripts on go
+        // into the header, in the genome's own order, so the reference table stays
+        // as small as the output needs while keeping a stable, familiar ordering.
+        let mut used: HashMap<&str, usize> = HashMap::new();
+        let mut chromosomes: Vec<(String, u64)> = Vec::new();
+        for (name, length) in &chromosome_lengths {
+            if transcripts.iter().any(|t| t.seqname == *name) {
+                used.insert(name.as_str(), chromosomes.len());
+                chromosomes.push((name.clone(), *length));
+            }
+        }
+
+        let by_id: HashMap<&str, &bramble_rs::annotation::Transcript> =
+            transcripts.iter().map(|t| (t.id.as_str(), t)).collect();
+        let mut missing_chromosome = 0usize;
+        let models = reference_names
+            .iter()
+            .map(|name| {
+                let transcript = by_id.get(name)?;
+                let Some(&chromosome) = used.get(transcript.seqname.as_str()) else {
+                    missing_chromosome += 1;
+                    return None;
+                };
+                Some(model_for(transcript, chromosome))
+            })
+            .collect::<Vec<_>>();
+
+        let described = models.iter().filter(|m| m.is_some()).count();
+        anyhow::ensure!(
+            described > 0,
+            "no transcript in the index appears in {}: check that the annotation matches the \
+             reference the index was built from",
+            annotation.display()
+        );
+        if missing_chromosome > 0 {
+            tracing::warn!(
+                transcripts = missing_chromosome,
+                "annotation places transcripts on sequences absent from the genome FASTA; those \
+                 placements will not be projected"
+            );
+        }
+        tracing::info!(
+            transcripts = described,
+            total = reference_names.len(),
+            chromosomes = chromosomes.len(),
+            "genome projection ready"
+        );
+        Ok(Self {
+            chromosomes,
+            models,
+        })
+    }
+
+    /// The `(name, length)` table projected records index into.
+    pub fn chromosomes(&self) -> &[(String, u64)] {
+        &self.chromosomes
+    }
+
+    /// Whether reference `tid` can be projected at all.
+    pub fn describes(&self, tid: usize) -> bool {
+        self.models.get(tid).is_some_and(|m| m.is_some())
+    }
+
+    /// Project a transcript-coordinate alignment onto the genome, writing the
+    /// genomic CIGAR into `out`.
+    ///
+    /// Returns `None` when the reference has no exon structure (a decoy, or a
+    /// transcript the annotation does not mention), in which case the caller has
+    /// nothing genomic to write for this placement.
+    pub fn project(
+        &self,
+        tid: usize,
+        transcript_position: i32,
+        ops: &[CigarOp],
+        out: &mut Vec<CigarOp>,
+    ) -> Option<Projection> {
+        out.clear();
+        let model = self.models.get(tid)?.as_ref()?;
+        if model.exons.is_empty() {
+            return None;
+        }
+        let start = transcript_position.max(0) as u32;
+        if start >= model.length() {
+            return None;
+        }
+
+        // Walk the transcript CIGAR, cutting every reference-consuming operation
+        // at exon boundaries and filling the gap between consecutive exons with an
+        // N. Operations that do not consume the reference pass straight through.
+        let mut position = start;
+        for op in ops {
+            if !op.kind.consumes_reference() {
+                push_op(out, op.kind, op.len);
+                continue;
+            }
+            let mut remaining = op.len;
+            while remaining > 0 {
+                let exon_index = model.exon_at(position);
+                let exon = &model.exons[exon_index];
+                let exon_end = exon.transcript_start + exon.len;
+                if position >= exon_end {
+                    // Past the final exon: the rest of the operation has no
+                    // genomic home, so the alignment cannot be projected.
+                    return None;
+                }
+                let take = remaining.min(exon_end - position);
+                push_op(out, op.kind, take);
+                position += take;
+                remaining -= take;
+                // Crossing into the next exon is where the intron appears.
+                if position == exon_end && remaining > 0 {
+                    let next = model.exons.get(exon_index + 1)?;
+                    push_op(out, CigarOpKind::Skip, intron_length(model, exon, next));
+                }
+            }
+        }
+        if out.is_empty() {
+            return None;
+        }
+
+        // The genomic extremes of the alignment. On the forward strand the first
+        // transcript base is leftmost; on the reverse strand the last one is.
+        let last = position.saturating_sub(1).max(start);
+        let position = if model.forward {
+            model.genome_position(start)
+        } else {
+            model.genome_position(last)
+        } as i32;
+        if !model.forward {
+            out.reverse();
+        }
+        Some(Projection {
+            chromosome: model.chromosome,
+            position,
+            flipped: !model.forward,
+        })
+    }
+}
+
+/// The genomic gap between two consecutive exons, whichever way the transcript
+/// runs.
+fn intron_length(model: &TranscriptModel, exon: &ExonBlock, next: &ExonBlock) -> u32 {
+    if model.forward {
+        next.genome_start
+            .saturating_sub(exon.genome_start + exon.len)
+    } else {
+        exon.genome_start
+            .saturating_sub(next.genome_start + next.len)
+    }
+}
+
+/// Turn a bramble transcript into exon blocks in transcript order, which for a
+/// reverse-strand transcript means genomic order reversed.
+fn model_for(
+    transcript: &bramble_rs::annotation::Transcript,
+    chromosome: usize,
+) -> TranscriptModel {
+    let forward = transcript.strand != '-';
+    let mut exons: Vec<(u32, u32)> = transcript
+        .exons
+        .iter()
+        .map(|e| (e.start, e.end.saturating_sub(e.start)))
+        .filter(|(_, len)| *len > 0)
+        .collect();
+    exons.sort_unstable();
+    if !forward {
+        exons.reverse();
+    }
+    let mut transcript_start = 0;
+    let exons = exons
+        .into_iter()
+        .map(|(genome_start, len)| {
+            let block = ExonBlock {
+                genome_start,
+                transcript_start,
+                len,
+            };
+            transcript_start += len;
+            block
+        })
+        .collect();
+    TranscriptModel {
+        chromosome,
+        forward,
+        exons,
+    }
+}
+
+/// Chromosome names and lengths, from a FASTA index when there is one and from
+/// the FASTA itself otherwise.
+fn chromosome_lengths(genome: &Path) -> anyhow::Result<Vec<(String, u64)>> {
+    let index_path = genome.with_extension(format!(
+        "{}.fai",
+        genome
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or_default()
+    ));
+    if index_path.exists() {
+        let text = std::fs::read_to_string(&index_path)
+            .with_context(|| format!("reading FASTA index {}", index_path.display()))?;
+        let lengths = parse_fai(&text);
+        if !lengths.is_empty() {
+            return Ok(lengths);
+        }
+    }
+    scan_fasta_lengths(genome)
+}
+
+/// Parse the first two columns of a `.fai`: name and length.
+fn parse_fai(text: &str) -> Vec<(String, u64)> {
+    text.lines()
+        .filter_map(|line| {
+            let mut fields = line.split('\t');
+            let name = fields.next()?;
+            let length = fields.next()?.parse().ok()?;
+            (!name.is_empty()).then(|| (name.to_string(), length))
+        })
+        .collect()
+}
+
+/// Measure every sequence in a FASTA by streaming it. Only reached when no `.fai`
+/// is available; a genome is large, so this counts bytes rather than holding
+/// sequences.
+fn scan_fasta_lengths(genome: &Path) -> anyhow::Result<Vec<(String, u64)>> {
+    use std::io::BufRead as _;
+    let file = std::fs::File::open(genome)
+        .with_context(|| format!("reading genome FASTA {}", genome.display()))?;
+    let reader = std::io::BufReader::with_capacity(1 << 20, file);
+    let mut lengths: Vec<(String, u64)> = Vec::new();
+    for line in reader.lines() {
+        let line = line.with_context(|| format!("reading {}", genome.display()))?;
+        if let Some(header) = line.strip_prefix('>') {
+            let name = header.split_whitespace().next().unwrap_or_default();
+            lengths.push((name.to_string(), 0));
+        } else if let Some(last) = lengths.last_mut() {
+            last.1 += line.trim_end().len() as u64;
+        }
+    }
+    anyhow::ensure!(
+        !lengths.is_empty(),
+        "genome FASTA {} contains no sequences",
+        genome.display()
+    );
+    Ok(lengths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A three-exon transcript on the forward strand: exons at 100..150,
+    /// 300..350 and 500..600, so transcript coordinates 0..50, 50..100, 100..200.
+    fn forward_model() -> TranscriptModel {
+        TranscriptModel {
+            chromosome: 0,
+            forward: true,
+            exons: vec![
+                ExonBlock {
+                    genome_start: 100,
+                    transcript_start: 0,
+                    len: 50,
+                },
+                ExonBlock {
+                    genome_start: 300,
+                    transcript_start: 50,
+                    len: 50,
+                },
+                ExonBlock {
+                    genome_start: 500,
+                    transcript_start: 100,
+                    len: 100,
+                },
+            ],
+        }
+    }
+
+    /// The same exons, on a transcript transcribed the other way, so transcript
+    /// coordinate 0 is the last genomic base of the 500..600 exon.
+    fn reverse_model() -> TranscriptModel {
+        TranscriptModel {
+            chromosome: 0,
+            forward: false,
+            exons: vec![
+                ExonBlock {
+                    genome_start: 500,
+                    transcript_start: 0,
+                    len: 100,
+                },
+                ExonBlock {
+                    genome_start: 300,
+                    transcript_start: 100,
+                    len: 50,
+                },
+                ExonBlock {
+                    genome_start: 100,
+                    transcript_start: 150,
+                    len: 50,
+                },
+            ],
+        }
+    }
+
+    fn projector(model: TranscriptModel) -> GenomeProjector {
+        GenomeProjector {
+            chromosomes: vec![("chr1".into(), 1_000_000)],
+            models: vec![Some(model)],
+        }
+    }
+
+    fn cigar(ops: &[CigarOp]) -> String {
+        ops.iter()
+            .map(|op| format!("{}{}", op.len, op.kind.letter()))
+            .collect()
+    }
+
+    fn matched(len: u32) -> Vec<CigarOp> {
+        vec![CigarOp::new(CigarOpKind::Match, len)]
+    }
+
+    /// A read wholly inside one exon needs no intron: it projects to a plain
+    /// match at the corresponding genomic offset.
+    #[test]
+    fn a_read_inside_one_exon_gets_no_skip() {
+        let projector = projector(forward_model());
+        let mut ops = Vec::new();
+        let projection = projector.project(0, 10, &matched(20), &mut ops).unwrap();
+        assert_eq!(cigar(&ops), "20M");
+        assert_eq!(projection.position, 110);
+        assert!(!projection.flipped);
+    }
+
+    /// A read across a junction is where the whole module earns its keep: the
+    /// intron between the two exons has to appear as an N of exactly its genomic
+    /// length.
+    #[test]
+    fn a_junction_read_gains_an_n_operation() {
+        let projector = projector(forward_model());
+        let mut ops = Vec::new();
+        // Transcript 30..70 spans the first junction 20 bases in.
+        let projection = projector.project(0, 30, &matched(40), &mut ops).unwrap();
+        // 20 bases to the end of exon 1, an intron of 300 - 150 = 150, then 20 more.
+        assert_eq!(cigar(&ops), "20M150N20M");
+        assert_eq!(projection.position, 130);
+    }
+
+    /// A read crossing two junctions produces two introns, and the short middle
+    /// exon appears in full between them.
+    #[test]
+    fn a_read_over_two_junctions_gains_two_skips() {
+        let projector = projector(forward_model());
+        let mut ops = Vec::new();
+        let projection = projector.project(0, 40, &matched(70), &mut ops).unwrap();
+        assert_eq!(cigar(&ops), "10M150N50M150N10M");
+        assert_eq!(projection.position, 140);
+    }
+
+    /// Soft clips and insertions do not consume the reference, so they must pass
+    /// through the projection untouched rather than being cut at an exon edge.
+    #[test]
+    fn clips_and_insertions_survive_projection() {
+        let projector = projector(forward_model());
+        let mut ops = Vec::new();
+        let transcript_cigar = vec![
+            CigarOp::new(CigarOpKind::SoftClip, 5),
+            CigarOp::new(CigarOpKind::Match, 15),
+            CigarOp::new(CigarOpKind::Insertion, 3),
+            CigarOp::new(CigarOpKind::Match, 15),
+        ];
+        let projection = projector
+            .project(0, 40, &transcript_cigar, &mut ops)
+            .unwrap();
+        assert_eq!(cigar(&ops), "5S10M150N5M3I15M");
+        assert_eq!(projection.position, 140);
+    }
+
+    /// A reverse-strand transcript runs against the genomic axis, so the CIGAR
+    /// comes out reversed, the reported position is the alignment's leftmost
+    /// genomic base, and the record has to be flipped to match.
+    #[test]
+    fn reverse_strand_transcripts_are_turned_around() {
+        let projector = projector(reverse_model());
+        let mut ops = Vec::new();
+        // Transcript 90..130 crosses the junction between the 500..600 exon and
+        // the 300..350 one.
+        let projection = projector.project(0, 90, &matched(40), &mut ops).unwrap();
+        assert!(projection.flipped);
+        // 10 bases at the bottom of the 500..600 exon, the 150-base intron, then
+        // 30 in the 300..350 exon, read left to right in genome order.
+        assert_eq!(cigar(&ops), "30M150N10M");
+        // The alignment's last transcript base (129) sits at 350 - 30 = 320.
+        assert_eq!(projection.position, 320);
+    }
+
+    /// Reverse-strand transcript coordinates must map to the mirror-image genomic
+    /// positions, including at the exon boundaries where an off-by-one is easiest
+    /// to make.
+    #[test]
+    fn reverse_strand_positions_mirror_the_transcript() {
+        let model = reverse_model();
+        assert_eq!(model.genome_position(0), 599);
+        assert_eq!(model.genome_position(99), 500);
+        assert_eq!(model.genome_position(100), 349);
+        assert_eq!(model.genome_position(149), 300);
+        assert_eq!(model.genome_position(150), 149);
+        assert_eq!(model.genome_position(199), 100);
+    }
+
+    /// Whatever the projection does to the reference side, it must not change how
+    /// many read bases the CIGAR accounts for.
+    #[test]
+    fn projection_preserves_the_read_length() {
+        for model in [forward_model(), reverse_model()] {
+            let projector = projector(model);
+            let mut ops = Vec::new();
+            for start in (0..190).step_by(7) {
+                for len in [10u32, 45, 80] {
+                    if start + len > 200 {
+                        continue;
+                    }
+                    let transcript_cigar = vec![
+                        CigarOp::new(CigarOpKind::SoftClip, 4),
+                        CigarOp::new(CigarOpKind::Match, len),
+                    ];
+                    let Some(_) = projector.project(0, start as i32, &transcript_cigar, &mut ops)
+                    else {
+                        continue;
+                    };
+                    let read_bases: u32 = ops
+                        .iter()
+                        .filter(|op| op.kind.consumes_read())
+                        .map(|op| op.len)
+                        .sum();
+                    assert_eq!(read_bases, len + 4, "start={start} len={len}");
+                }
+            }
+        }
+    }
+
+    /// A reference the annotation says nothing about (a decoy) has no projection,
+    /// and must be reported as such rather than guessed at.
+    #[test]
+    fn an_undescribed_reference_does_not_project() {
+        let projector = GenomeProjector {
+            chromosomes: vec![("chr1".into(), 1000)],
+            models: vec![None],
+        };
+        let mut ops = Vec::new();
+        assert!(!projector.describes(0));
+        assert_eq!(projector.project(0, 0, &matched(10), &mut ops), None);
+    }
+
+    /// A `.fai` is the cheap path to chromosome lengths, and only its first two
+    /// columns matter.
+    #[test]
+    fn fai_parsing_takes_name_and_length() {
+        let text = "chr1\t248956422\t112\t60\t61\nchr2\t242193529\t253404903\t60\t61\n";
+        assert_eq!(
+            parse_fai(text),
+            vec![
+                ("chr1".to_string(), 248_956_422),
+                ("chr2".to_string(), 242_193_529)
+            ]
+        );
+    }
+}

--- a/crates/salmon-quant/src/splice.rs
+++ b/crates/salmon-quant/src/splice.rs
@@ -27,6 +27,16 @@
 //! reverse-complemented once more). [`Projection::flipped`] reports that flip so
 //! the record writer can apply it to `SEQ`, `QUAL` and the `FLAG` bits together.
 //!
+//! # A known rough edge
+//!
+//! `MD` is derived while the alignment is still in transcript coordinates, and
+//! carried through projection. That is sound for every operation except a
+//! deletion the projection has to cut in two, where the canonical spelling gains
+//! an empty match between the halves: `^G0^G` rather than `^GG`. Both reconstruct
+//! the same reference bases and both carry the same `NM`, so the difference is
+//! one of form, but `samtools calmd` writes the canonical one. It shows up on
+//! about three records in a million.
+//!
 //! # What is deliberately not done here
 //!
 //! Two transcripts of the same gene often imply the *same* genomic alignment for
@@ -230,6 +240,7 @@ impl GenomeProjector {
         // at exon boundaries and filling the gap between consecutive exons with an
         // N. Operations that do not consume the reference pass straight through.
         let mut position = start;
+        let mut exon_index = model.exon_at(start);
         for op in ops {
             if !op.kind.consumes_reference() {
                 push_op(out, op.kind, op.len);
@@ -237,7 +248,19 @@ impl GenomeProjector {
             }
             let mut remaining = op.len;
             while remaining > 0 {
-                let exon_index = model.exon_at(position);
+                // A junction can fall between two operations just as easily as
+                // inside one: an operation ending exactly on an exon boundary
+                // leaves the next one starting in the following exon. Checking
+                // only mid-operation let those alignments cross an intron with no
+                // `N` at all, so the bases after the boundary silently claimed
+                // the wrong reference.
+                let current = model.exon_at(position);
+                while exon_index < current {
+                    let exon = &model.exons[exon_index];
+                    let next = model.exons.get(exon_index + 1)?;
+                    push_op(out, CigarOpKind::Skip, intron_length(model, exon, next));
+                    exon_index += 1;
+                }
                 let exon = &model.exons[exon_index];
                 let exon_end = exon.transcript_start + exon.len;
                 if position >= exon_end {
@@ -249,11 +272,6 @@ impl GenomeProjector {
                 push_op(out, op.kind, take);
                 position += take;
                 remaining -= take;
-                // Crossing into the next exon is where the intron appears.
-                if position == exon_end && remaining > 0 {
-                    let next = model.exons.get(exon_index + 1)?;
-                    push_op(out, CigarOpKind::Skip, intron_length(model, exon, next));
-                }
             }
         }
         if out.is_empty() {
@@ -558,6 +576,28 @@ mod tests {
         let projection = projector.project(0, 40, &matched(70), &mut ops).unwrap();
         assert_eq!(cigar(&ops), "10M150N50M150N10M");
         assert_eq!(projection.position, 140);
+    }
+
+    /// A junction falling exactly between two operations is still a junction. A
+    /// deletion ending on an exon boundary used to leave the following match
+    /// crossing the intron with no `N`, so it claimed reference bases from the
+    /// wrong side of it.
+    #[test]
+    fn a_junction_between_two_operations_still_gets_a_skip() {
+        let projector = projector(forward_model());
+        let mut ops = Vec::new();
+        // Exon 1 is transcript 0..50. Align 47 bases, delete 3 (ending exactly on
+        // the boundary), then match 10 more, which belong in the next exon.
+        let transcript_cigar = vec![
+            CigarOp::new(CigarOpKind::Match, 47),
+            CigarOp::new(CigarOpKind::Deletion, 3),
+            CigarOp::new(CigarOpKind::Match, 10),
+        ];
+        let projection = projector
+            .project(0, 0, &transcript_cigar, &mut ops)
+            .unwrap();
+        assert_eq!(cigar(&ops), "47M3D150N10M");
+        assert_eq!(projection.position, 100);
     }
 
     /// Soft clips and insertions do not consume the reference, so they must pass

--- a/crates/salmon-quant/src/splice.rs
+++ b/crates/salmon-quant/src/splice.rs
@@ -124,6 +124,10 @@ pub struct Projection {
 /// Transcript exon structures for every reference in the salmon index, plus the
 /// chromosome table the projected records refer to.
 pub struct GenomeProjector {
+    /// Placements dropped because their reference has no exon structure. Counted
+    /// so the run can say how much of the mapping output the annotation cost,
+    /// instead of quietly producing a file that disagrees with `quant.sf`.
+    dropped: std::sync::atomic::AtomicU64,
     /// `(name, length)` per chromosome, in the order they appear in `@SQ`.
     chromosomes: Vec<(String, u64)>,
     /// One entry per salmon reference id; `None` for a reference the annotation
@@ -198,14 +202,27 @@ impl GenomeProjector {
             "genome projection ready"
         );
         Ok(Self {
+            dropped: std::sync::atomic::AtomicU64::new(0),
             chromosomes,
             models,
         })
     }
 
+    /// How many placements were dropped for want of an exon structure.
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// The `(name, length)` table projected records index into.
     pub fn chromosomes(&self) -> &[(String, u64)] {
         &self.chromosomes
+    }
+
+    /// Whether the transcript at `tid` runs along the genome's forward strand,
+    /// or `None` if the annotation does not describe it. This is what `XS`
+    /// reports for a spliced alignment.
+    pub fn strand(&self, tid: usize) -> Option<bool> {
+        Some(self.models.get(tid)?.as_ref()?.forward)
     }
 
     /// Whether reference `tid` can be projected at all.
@@ -229,14 +246,17 @@ impl GenomeProjector {
         out: &mut Vec<CigarOp>,
     ) -> Option<Projection> {
         out.clear();
-        let model = self.models.get(tid)?.as_ref()?;
-        if model.exons.is_empty() {
+        let Some(Some(model)) = self.models.get(tid) else {
+            self.dropped
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return None;
+        };
+        if model.exons.is_empty() || transcript_position.max(0) as u32 >= model.length() {
+            self.dropped
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             return None;
         }
         let start = transcript_position.max(0) as u32;
-        if start >= model.length() {
-            return None;
-        }
 
         // Walk the transcript CIGAR, cutting every reference-consuming operation
         // at exon boundaries and filling the gap between consecutive exons with an
@@ -628,6 +648,7 @@ mod tests {
 
     fn projector(model: TranscriptModel) -> GenomeProjector {
         GenomeProjector {
+            dropped: std::sync::atomic::AtomicU64::new(0),
             chromosomes: vec![("chr1".into(), 1_000_000)],
             models: vec![Some(model)],
         }
@@ -798,6 +819,7 @@ mod tests {
     #[test]
     fn an_undescribed_reference_does_not_project() {
         let projector = GenomeProjector {
+            dropped: std::sync::atomic::AtomicU64::new(0),
             chromosomes: vec![("chr1".into(), 1000)],
             models: vec![None],
         };

--- a/crates/salmon-quant/src/splice.rs
+++ b/crates/salmon-quant/src/splice.rs
@@ -279,6 +279,63 @@ impl GenomeProjector {
     }
 }
 
+/// Rewrite an `MD` string for an alignment that has been turned around.
+///
+/// `MD` describes the reference bases along the alignment, so when a reverse
+/// strand transcript's alignment is flipped into genome order the string has to
+/// be flipped with it: the tokens reverse, and every base in them is
+/// complemented. Leaving it alone produces an `MD` that disagrees with the very
+/// `SEQ` and CIGAR it sits beside, which is a mistake no reader can catch and
+/// `samtools calmd` catches immediately.
+///
+/// A deletion's bases reverse within the deletion as well, since they too are
+/// read along the reference.
+pub fn reverse_complement_md(md: &str, out: &mut String) {
+    out.clear();
+    // Split into tokens: match run lengths, single mismatched bases, and
+    // `^`-prefixed deleted stretches.
+    let mut tokens: Vec<String> = Vec::new();
+    let mut digits = String::new();
+    let mut chars = md.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c.is_ascii_digit() {
+            digits.push(c);
+            continue;
+        }
+        if !digits.is_empty() {
+            tokens.push(std::mem::take(&mut digits));
+        }
+        if c == '^' {
+            let mut deleted = String::from("^");
+            while chars.peek().is_some_and(|n| n.is_ascii_alphabetic()) {
+                deleted.push(complement(chars.next().unwrap() as u8) as char);
+            }
+            // The deleted bases were pushed in transcript order; reverse them.
+            let reversed: String = deleted[1..].chars().rev().collect();
+            tokens.push(format!("^{reversed}"));
+        } else {
+            tokens.push((complement(c as u8) as char).to_string());
+        }
+    }
+    if !digits.is_empty() {
+        tokens.push(digits);
+    }
+    for token in tokens.iter().rev() {
+        out.push_str(token);
+    }
+}
+
+/// Complement one base, for [`reverse_complement_md`].
+fn complement(base: u8) -> u8 {
+    match base {
+        b'A' | b'a' => b'T',
+        b'C' | b'c' => b'G',
+        b'G' | b'g' => b'C',
+        b'T' | b't' => b'A',
+        other => other,
+    }
+}
+
 /// The genomic gap between two consecutive exons, whichever way the transcript
 /// runs.
 fn intron_length(model: &TranscriptModel, exon: &ExonBlock, next: &ExonBlock) -> u32 {
@@ -631,6 +688,30 @@ mod tests {
         assert_eq!(model.genome_position(0), 100);
         assert_eq!(model.genome_position(199), 299);
         assert_eq!(model.genome_position(200), 800);
+    }
+
+    /// The reverse-strand `MD` bug that a mismatch-free fixture cannot show: with
+    /// no mismatches the string is just a run length, which is unchanged by
+    /// reversing it. Only a mismatch reveals that the whole string has to be
+    /// reverse-complemented alongside the CIGAR and the sequence.
+    #[test]
+    fn md_is_reverse_complemented_with_the_alignment() {
+        let mut out = String::new();
+        for (forward, reversed) in [
+            ("71T28", "28A71"),
+            ("50", "50"),
+            ("0C1T0", "0A1G0"),
+            ("10^ACGT5", "5^ACGT10"),
+            ("3A2^GG4C1", "1G4^CC2T3"),
+        ] {
+            reverse_complement_md(forward, &mut out);
+            assert_eq!(out, reversed, "reversing {forward}");
+            // Reversing twice returns the original, which is what makes it a
+            // faithful change of orientation rather than a rewrite.
+            let once = out.clone();
+            reverse_complement_md(&once, &mut out);
+            assert_eq!(out, forward, "round-tripping {forward}");
+        }
     }
 
     /// A `.fai` is the cheap path to chromosome lengths, and only its first two

--- a/crates/salmon-quant/tests/mapping_output.rs
+++ b/crates/salmon-quant/tests/mapping_output.rs
@@ -23,6 +23,7 @@ use salmon_quant::{quantify, QuantOptions};
 #[derive(Default)]
 struct Run {
     read_group: Option<&'static str>,
+    write_unaligned: bool,
     /// Quantify the first mates on their own, exercising the single-end path.
     single_end: bool,
 }
@@ -56,6 +57,7 @@ fn run_with_mapping_output(dir: &Path, run: Run) -> String {
     options.lib_type = "IU".to_string();
     options.num_threads = 1;
     options.write_mappings = Some(sam.clone());
+    options.write_unaligned = run.write_unaligned;
     options.read_group = run.read_group.map(|spec| ReadGroup::parse(spec).unwrap());
     quantify(&options).expect("quantifying");
 
@@ -322,6 +324,7 @@ fn single_end_records_claim_no_mate() {
         dir.path(),
         Run {
             single_end: true,
+            write_unaligned: true,
             ..Run::default()
         },
     );
@@ -352,6 +355,88 @@ fn single_end_records_claim_no_mate() {
         assert!(tag(record, "MQ:i:").is_none(), "{} has MQ", record[0]);
         if flags & 0x4 == 0 {
             assert!(tag(record, "NM:i:").is_some(), "{} lacks NM", record[0]);
+        }
+    }
+    assert!(
+        records.iter().any(|r| r[1] == "4"),
+        "the unmappable fragment should appear as a plain unmapped record"
+    );
+}
+
+/// An orphan's unmapped mate has to be in the file when unaligned reads are
+/// being written.
+///
+/// The mapped mate is flagged `MATE_UNMAPPED`, and a record that names a mate the
+/// file does not contain is one `samtools fastq` cannot round-trip and one that
+/// any reader following the flag will chase into nothing. The mate is filed at
+/// the mapped mate's position, which is where a sorted file puts it.
+#[test]
+fn an_orphans_unmapped_mate_is_written_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(
+        dir.path(),
+        Run {
+            write_unaligned: true,
+            ..Run::default()
+        },
+    );
+    let orphan: Vec<Vec<&str>> = records(&sam)
+        .into_iter()
+        .filter(|r| r[0] == "orphan")
+        .collect();
+    assert!(
+        !orphan.is_empty(),
+        "the orphan fragment should be in the output"
+    );
+
+    let mapped: Vec<&Vec<&str>> = orphan
+        .iter()
+        .filter(|r| r[1].parse::<u16>().unwrap() & 0x4 == 0)
+        .collect();
+    let unmapped: Vec<&Vec<&str>> = orphan
+        .iter()
+        .filter(|r| r[1].parse::<u16>().unwrap() & 0x4 != 0)
+        .collect();
+    assert!(!mapped.is_empty(), "one mate mapped: {orphan:?}");
+    assert_eq!(
+        unmapped.len(),
+        1,
+        "the unmapped mate belongs in the file exactly once: {orphan:?}"
+    );
+
+    // The two records must describe each other: same place, opposite mate bits.
+    let mapped = mapped[0];
+    let unmapped = unmapped[0];
+    assert!(
+        mapped[1].parse::<u16>().unwrap() & 0x8 != 0,
+        "the mapped mate should say its mate is unmapped"
+    );
+    assert_eq!(mapped[6], "=", "the mapped mate should point at its mate");
+    assert_eq!(
+        unmapped[2], mapped[2],
+        "the unmapped mate is filed on the same reference"
+    );
+    assert_eq!(
+        unmapped[3], mapped[3],
+        "and at the same position, so a sort keeps them together"
+    );
+    assert_eq!(unmapped[5], "*", "an unmapped record has no CIGAR");
+    assert!(
+        (mapped[1].parse::<u16>().unwrap() ^ unmapped[1].parse::<u16>().unwrap()) & 0xc0 != 0,
+        "the two records should be different mates of the pair"
+    );
+}
+
+/// Without `--sampleUnaligned` the unmapped mate is not written, and the mapped
+/// one must not claim it: a dangling mate reference is worse than an honest `*`.
+#[test]
+fn an_orphan_does_not_name_a_mate_that_was_not_written() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    for record in records(&sam) {
+        if record[0] == "orphan" {
+            assert_eq!(record[6], "*", "no mate record exists to point at");
+            assert_eq!(record[7], "0");
         }
     }
 }
@@ -416,6 +501,55 @@ fn the_read_group_reaches_the_header_and_every_record() {
             tag(&record, "RG:Z:"),
             Some("RG:Z:s1"),
             "every record should point at the read group: {record:?}"
+        );
+    }
+}
+
+/// Without `--sampleUnaligned` the output holds only what mapped; with it, the
+/// unmapped fragments are there too, flagged and with their bases intact, so the
+/// file covers the whole library.
+#[test]
+fn unaligned_fragments_appear_only_when_asked_for() {
+    let dir = tempfile::tempdir().unwrap();
+    let without = run_with_mapping_output(dir.path(), Run::default());
+    assert!(
+        !records(&without)
+            .iter()
+            .any(|r| r[1].parse::<u16>().unwrap() & 0x4 != 0),
+        "no unmapped records without --sampleUnaligned"
+    );
+
+    // A fragment of pure homopolymer maps nowhere in the fixture.
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(
+        dir.path(),
+        Run {
+            write_unaligned: true,
+            ..Run::default()
+        },
+    );
+    // A fragment that mapped nowhere at all: both mates unmapped. An orphan's
+    // unmapped mate is a different case, filed at its mate's position, and is
+    // covered by its own test.
+    let unmapped: Vec<Vec<&str>> = records(&sam)
+        .into_iter()
+        .filter(|r| {
+            let flags: u16 = r[1].parse().unwrap();
+            flags & 0x4 != 0 && flags & 0x8 != 0
+        })
+        .collect();
+    assert!(
+        !unmapped.is_empty(),
+        "the fixture has a fragment that maps nowhere"
+    );
+    for record in &unmapped {
+        assert_eq!(record[2], "*", "an unmapped record names no reference");
+        assert_eq!(record[3], "0", "an unmapped record has no position");
+        assert_eq!(record[4], "0", "an unmapped record has MAPQ 0");
+        assert_eq!(record[5], "*", "an unmapped record has no CIGAR");
+        assert!(
+            record[9] != "*",
+            "an unmapped record keeps its bases, which is the reason to write it"
         );
     }
 }

--- a/crates/salmon-quant/tests/mapping_output.rs
+++ b/crates/salmon-quant/tests/mapping_output.rs
@@ -1,0 +1,363 @@
+//! What a `--writeMappings` / `--writeBam` file has to contain.
+//!
+//! These tests are about the *output contract*, not about mapping: they build a
+//! tiny index, map a handful of reads whose correct placement is obvious by
+//! construction, and then assert on the records. What they defend is everything
+//! a reader is entitled to assume and that no unit test can see, because it only
+//! exists once the whole pipeline has run: that the header describes the file,
+//! that every record's fields agree with each other, and that the tags are
+//! actually there.
+//!
+//! The single most valuable assertion here is the one about CIGAR and read
+//! length. A record whose CIGAR does not account for exactly as many read bases
+//! as `SEQ` holds is rejected by every SAM reader in existence, and it is the
+//! failure mode that any change to CIGAR derivation risks introducing.
+
+use std::path::Path;
+
+use salmon_index::{build, IndexBuildOptions};
+use salmon_quant::{quantify, QuantOptions};
+
+/// Options for one fixture run, beyond the mapping output itself.
+#[derive(Default)]
+struct Run {
+    /// Quantify the first mates on their own, exercising the single-end path.
+    single_end: bool,
+}
+
+/// Build a two-transcript index, quantify the fixture reads against it with SAM
+/// output on, and return the file's text.
+fn run_with_mapping_output(dir: &Path, run: Run) -> String {
+    let transcripts = dir.join("txp.fa");
+    let (a, b) = fixture_transcripts();
+    std::fs::write(&transcripts, format!(">txA desc here\n{a}\n>txB\n{b}\n")).unwrap();
+
+    let (reads1, reads2) = fixture_reads(&a, &b);
+    let r1 = dir.join("r1.fq");
+    let r2 = dir.join("r2.fq");
+    std::fs::write(&r1, reads1).unwrap();
+    std::fs::write(&r2, reads2).unwrap();
+
+    let index = dir.join("idx");
+    let mut build_options = IndexBuildOptions::new(vec![transcripts], index.clone());
+    build_options.threads = 1;
+    build(&build_options).expect("building the index");
+
+    let sam = dir.join("mappings.sam");
+    let mut options = QuantOptions::new(index, dir.join("out"));
+    if run.single_end {
+        options.unmated = vec![r1];
+    } else {
+        options.mates1 = vec![r1];
+        options.mates2 = vec![r2];
+    }
+    options.lib_type = "IU".to_string();
+    options.num_threads = 1;
+    options.write_mappings = Some(sam.clone());
+    quantify(&options).expect("quantifying");
+
+    std::fs::read_to_string(&sam).expect("reading the SAM output")
+}
+
+/// Two transcripts sharing no k-mers, so every read has one obvious home.
+fn fixture_transcripts() -> (String, String) {
+    // A deterministic, non-repeating sequence: a linear congruential walk over
+    // the four bases, seeded differently per transcript so they do not share
+    // 31-mers.
+    fn walk(seed: u64, len: usize) -> String {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                b"ACGT"[((state >> 33) % 4) as usize] as char
+            })
+            .collect()
+    }
+    (walk(12345, 1200), walk(98765, 900))
+}
+
+/// Inward-facing pairs drawn from each transcript, one of them carrying a
+/// substitution so the output has a record with a non-trivial `MD`, and one
+/// homopolymer pair that maps nowhere so the unaligned path has something to
+/// write.
+fn fixture_reads(a: &str, b: &str) -> (String, String) {
+    let complement = |base: u8| match base {
+        b'A' => b'T',
+        b'C' => b'G',
+        b'G' => b'C',
+        _ => b'A',
+    };
+    let revcomp = |s: &str| -> String {
+        s.bytes()
+            .rev()
+            .map(|base| complement(base) as char)
+            .collect()
+    };
+    let mut r1 = String::new();
+    let mut r2 = String::new();
+    let mut emit = |name: &str, forward: &str, reverse: &str| {
+        let quality = "I".repeat(forward.len());
+        r1.push_str(&format!("@{name}/1\n{forward}\n+\n{quality}\n"));
+        let quality = "I".repeat(reverse.len());
+        r2.push_str(&format!("@{name}/2\n{reverse}\n+\n{quality}\n"));
+    };
+    for (index, start) in [40usize, 200, 480, 700].into_iter().enumerate() {
+        emit(
+            &format!("a{index}"),
+            &a[start..start + 60],
+            &revcomp(&a[start + 150..start + 210]),
+        );
+    }
+    for (index, start) in [30usize, 300, 500].into_iter().enumerate() {
+        emit(
+            &format!("b{index}"),
+            &b[start..start + 60],
+            &revcomp(&b[start + 120..start + 180]),
+        );
+    }
+    // One mismatched read, so MD and NM have something to say.
+    let mut mutated: Vec<u8> = a[600..660].bytes().collect();
+    mutated[25] = complement(mutated[25]);
+    emit(
+        "mismatch",
+        std::str::from_utf8(&mutated).unwrap(),
+        &revcomp(&a[750..810]),
+    );
+    // A fragment that cannot map anywhere in this fixture.
+    emit("nowhere", &"A".repeat(60), &"C".repeat(60));
+    // An orphan: read 1 comes from txA, read 2 from nowhere at all.
+    emit("orphan", &a[820..880], &"AC".repeat(30));
+    (r1, r2)
+}
+
+/// Split a SAM line into its mandatory fields plus the tags.
+fn fields(line: &str) -> Vec<&str> {
+    line.split('\t').collect()
+}
+
+fn tag<'a>(fields: &[&'a str], name: &str) -> Option<&'a str> {
+    fields
+        .iter()
+        .skip(11)
+        .find(|f| f.starts_with(name))
+        .copied()
+}
+
+fn records(sam: &str) -> Vec<Vec<&str>> {
+    sam.lines()
+        .filter(|line| !line.starts_with('@'))
+        .map(fields)
+        .collect()
+}
+
+/// How many read bases a CIGAR accounts for. `M`, `I` and `S` consume the read;
+/// `D` and `N` do not.
+fn cigar_read_length(cigar: &str) -> usize {
+    let mut total = 0;
+    let mut digits = String::new();
+    for c in cigar.chars() {
+        if c.is_ascii_digit() {
+            digits.push(c);
+        } else {
+            let len: usize = digits.parse().unwrap_or(0);
+            digits.clear();
+            if matches!(c, 'M' | 'I' | 'S' | '=' | 'X') {
+                total += len;
+            }
+        }
+    }
+    total
+}
+
+/// The header has to describe the file: its version, its ordering, one `@SQ` per
+/// reference with a checksum, and the program that wrote it.
+#[test]
+fn the_header_describes_the_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    let mut lines = sam.lines();
+
+    let hd = lines.next().expect("a header");
+    assert_eq!(hd, "@HD\tVN:1.0\tSO:unknown");
+
+    let sq: Vec<&str> = sam.lines().filter(|l| l.starts_with("@SQ")).collect();
+    assert_eq!(sq.len(), 2, "one @SQ per transcript");
+    for line in &sq {
+        assert!(line.contains("\tLN:"), "@SQ needs a length: {line}");
+    }
+    // The reference name stops at the first space: the rest of a FASTA header is
+    // a description, not part of the name.
+    assert!(
+        sq.iter().any(|l| l.contains("\tSN:txA\t")),
+        "reference name should not include the FASTA description: {sq:?}"
+    );
+
+    assert!(
+        sam.lines().any(|l| l.starts_with("@PG\tID:salmon")),
+        "the header must record what wrote the file"
+    );
+}
+
+/// Every record has to be internally consistent. This is the check a SAM reader
+/// makes, so it is the check that decides whether the output is usable at all.
+#[test]
+fn every_record_is_internally_consistent() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    let records = records(&sam);
+    assert!(!records.is_empty(), "the run produced no records");
+
+    for record in &records {
+        assert!(record.len() >= 11, "too few fields: {record:?}");
+        let name = record[0];
+        let flags: u16 = record[1].parse().expect("FLAG is a number");
+        let cigar = record[5];
+        let sequence = record[9];
+
+        assert!(
+            !name.ends_with("/1") && !name.ends_with("/2"),
+            "the mate suffix has to go, or a reader cannot pair the mates: {name}"
+        );
+        assert_eq!(
+            cigar_read_length(cigar),
+            sequence.len(),
+            "CIGAR and SEQ disagree for {name}: {cigar} vs {} bases",
+            sequence.len()
+        );
+        // Every mate here is part of a pair, so the pairing bits have to be set
+        // and the mate reference named.
+        assert!(flags & 0x1 != 0, "reads were paired: {name} has {flags}");
+        assert!(
+            record[6] == "=" || record[6] == "*",
+            "both mates are on one transcript: {name} has RNEXT {}",
+            record[6]
+        );
+    }
+}
+
+/// The tags are the point of the exercise: without them the file says nothing
+/// beyond where the read landed.
+#[test]
+fn records_carry_the_tags_readers_expect() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    let records = records(&sam);
+
+    for record in &records {
+        // An unmapped record has no placement, so none of the placement tags.
+        if record[1].parse::<u16>().unwrap() & 0x4 != 0 {
+            continue;
+        }
+        for name in ["NH:i:", "HI:i:", "AS:i:", "NM:i:", "MD:Z:"] {
+            assert!(
+                tag(record, name).is_some(),
+                "{} is missing {name}: {record:?}",
+                record[0]
+            );
+        }
+    }
+
+    // MAPQ has to distinguish unique placements from ambiguous ones. These
+    // transcripts share no k-mers, so every fragment is placed once.
+    for record in records.iter().filter(|r| {
+        let flags: u16 = r[1].parse().unwrap();
+        flags & 0x4 == 0
+    }) {
+        assert_eq!(
+            tag(record, "NH:i:"),
+            Some("NH:i:1"),
+            "fixture transcripts should not be ambiguous: {record:?}"
+        );
+        assert_eq!(record[4], "255", "a unique placement gets MAPQ 255");
+    }
+
+    // The mismatched read is the one record whose MD is not a bare run length.
+    let mismatched = records
+        .iter()
+        .find(|r| r[0] == "mismatch" && r[1].parse::<u16>().unwrap() & 0x40 != 0)
+        .expect("the mismatched read should be in the output");
+    assert_eq!(tag(mismatched, "NM:i:"), Some("NM:i:1"));
+    let md = tag(mismatched, "MD:Z:").unwrap();
+    assert!(
+        md.bytes().any(|b| b.is_ascii_alphabetic()),
+        "MD should name the reference base at the mismatch: {md}"
+    );
+}
+
+/// Single-end runs go through a separate path in the processor and a separate
+/// branch of the record builder, and get their own kind of wrong: a stray
+/// pairing bit, or a mate tag describing a mate that does not exist.
+#[test]
+fn single_end_records_claim_no_mate() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run { single_end: true });
+    let records = records(&sam);
+    assert!(
+        !records.is_empty(),
+        "the single-end run produced no records"
+    );
+    for record in &records {
+        let flags: u16 = record[1].parse().unwrap();
+        assert_eq!(
+            flags & 0x1,
+            0,
+            "a single-end read is not paired: {} has {flags}",
+            record[0]
+        );
+        // Every bit that describes a mate is meaningless without one.
+        assert_eq!(
+            flags & (0x2 | 0x8 | 0x20 | 0x40 | 0x80),
+            0,
+            "{} carries pairing flags: {flags}",
+            record[0]
+        );
+        assert_eq!(record[6], "*", "no mate reference: {record:?}");
+        assert_eq!(record[7], "0", "no mate position: {record:?}");
+        assert_eq!(record[8], "0", "no template length: {record:?}");
+        assert!(tag(record, "MC:Z:").is_none(), "{} has MC", record[0]);
+        assert!(tag(record, "MQ:i:").is_none(), "{} has MQ", record[0]);
+        if flags & 0x4 == 0 {
+            assert!(tag(record, "NM:i:").is_some(), "{} lacks NM", record[0]);
+        }
+    }
+}
+
+/// `AS` has to describe the alignment in the same record, not a different one.
+///
+/// It used to be the mapper's own score while the CIGAR, `NM` and `MD` came from
+/// re-aligning the placement, so a record could claim a good score beside an
+/// alignment full of edits. Anything that reads both, and every filter on `AS`
+/// does, was being told two different stories.
+#[test]
+fn the_score_describes_the_alignment_in_its_own_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    for record in records(&sam) {
+        let (Some(score), Some(edits)) = (tag(&record, "AS:i:"), tag(&record, "NM:i:")) else {
+            // A record without a base-level alignment carries neither, which is
+            // the honest answer rather than a mismatched pair.
+            assert_eq!(
+                tag(&record, "NM:i:").is_none(),
+                tag(&record, "MD:Z:").is_none(),
+                "NM and MD go together: {record:?}"
+            );
+            continue;
+        };
+        let score: i32 = score.trim_start_matches("AS:i:").parse().unwrap();
+        let edits: i32 = edits.trim_start_matches("NM:i:").parse().unwrap();
+        let cigar = record[5];
+        // Ungapped alignments are the ones whose score follows directly from the
+        // edit count: matched bases earn 2, each mismatch swings 6.
+        if !cigar.contains('I') && !cigar.contains('D') && !cigar.contains('S') {
+            let aligned = cigar_read_length(cigar) as i32;
+            assert_eq!(
+                score,
+                2 * aligned - 6 * edits,
+                "AS and NM disagree for {}: {cigar}",
+                record[0]
+            );
+        }
+    }
+}

--- a/crates/salmon-quant/tests/mapping_output.rs
+++ b/crates/salmon-quant/tests/mapping_output.rs
@@ -16,11 +16,13 @@
 use std::path::Path;
 
 use salmon_index::{build, IndexBuildOptions};
+use salmon_quant::mapping_record::ReadGroup;
 use salmon_quant::{quantify, QuantOptions};
 
 /// Options for one fixture run, beyond the mapping output itself.
 #[derive(Default)]
 struct Run {
+    read_group: Option<&'static str>,
     /// Quantify the first mates on their own, exercising the single-end path.
     single_end: bool,
 }
@@ -54,6 +56,7 @@ fn run_with_mapping_output(dir: &Path, run: Run) -> String {
     options.lib_type = "IU".to_string();
     options.num_threads = 1;
     options.write_mappings = Some(sam.clone());
+    options.read_group = run.read_group.map(|spec| ReadGroup::parse(spec).unwrap());
     quantify(&options).expect("quantifying");
 
     std::fs::read_to_string(&sam).expect("reading the SAM output")
@@ -180,12 +183,14 @@ fn the_header_describes_the_file() {
     let mut lines = sam.lines();
 
     let hd = lines.next().expect("a header");
-    assert_eq!(hd, "@HD\tVN:1.0\tSO:unknown");
+    assert_eq!(hd, "@HD\tVN:1.6\tSO:unsorted\tGO:query");
 
     let sq: Vec<&str> = sam.lines().filter(|l| l.starts_with("@SQ")).collect();
     assert_eq!(sq.len(), 2, "one @SQ per transcript");
     for line in &sq {
         assert!(line.contains("\tLN:"), "@SQ needs a length: {line}");
+        assert!(line.contains("\tM5:"), "@SQ needs a checksum: {line}");
+        assert!(line.contains("\tUR:file://"), "@SQ needs a URI: {line}");
     }
     // The reference name stops at the first space: the rest of a FASTA header is
     // a description, not part of the name.
@@ -197,6 +202,10 @@ fn the_header_describes_the_file() {
     assert!(
         sam.lines().any(|l| l.starts_with("@PG\tID:salmon")),
         "the header must record what wrote the file"
+    );
+    assert!(
+        sam.lines().any(|l| l.starts_with("@CO")),
+        "the ordering contract should be stated in the file"
     );
 }
 
@@ -215,6 +224,7 @@ fn every_record_is_internally_consistent() {
         let flags: u16 = record[1].parse().expect("FLAG is a number");
         let cigar = record[5];
         let sequence = record[9];
+        let quality = record[10];
 
         assert!(
             !name.ends_with("/1") && !name.ends_with("/2"),
@@ -225,6 +235,15 @@ fn every_record_is_internally_consistent() {
             sequence.len(),
             "CIGAR and SEQ disagree for {name}: {cigar} vs {} bases",
             sequence.len()
+        );
+        assert_eq!(
+            quality.len(),
+            sequence.len(),
+            "QUAL and SEQ disagree for {name}"
+        );
+        assert!(
+            quality.bytes().all(|q| (33..=126).contains(&q)),
+            "QUAL must be printable for {name}: {quality}"
         );
         // Every mate here is part of a pair, so the pairing bits have to be set
         // and the mate reference named.
@@ -250,12 +269,19 @@ fn records_carry_the_tags_readers_expect() {
         if record[1].parse::<u16>().unwrap() & 0x4 != 0 {
             continue;
         }
-        for name in ["NH:i:", "HI:i:", "AS:i:", "NM:i:", "MD:Z:"] {
+        for name in ["NH:i:", "HI:i:", "AS:i:", "ZW:f:", "NM:i:", "MD:Z:"] {
             assert!(
                 tag(record, name).is_some(),
                 "{} is missing {name}: {record:?}",
                 record[0]
             );
+        }
+        // A paired record knows its mate's shape without anyone sorting the
+        // file, when there is a mate with a shape to know: an orphan's mate has
+        // no CIGAR and no mapping quality to report.
+        if record[1].parse::<u16>().unwrap() & 0x8 == 0 {
+            assert!(tag(record, "MC:Z:").is_some(), "{} lacks MC", record[0]);
+            assert!(tag(record, "MQ:i:").is_some(), "{} lacks MQ", record[0]);
         }
     }
 
@@ -292,7 +318,13 @@ fn records_carry_the_tags_readers_expect() {
 #[test]
 fn single_end_records_claim_no_mate() {
     let dir = tempfile::tempdir().unwrap();
-    let sam = run_with_mapping_output(dir.path(), Run { single_end: true });
+    let sam = run_with_mapping_output(
+        dir.path(),
+        Run {
+            single_end: true,
+            ..Run::default()
+        },
+    );
     let records = records(&sam);
     assert!(
         !records.is_empty(),
@@ -359,5 +391,31 @@ fn the_score_describes_the_alignment_in_its_own_record() {
                 record[0]
             );
         }
+    }
+}
+
+/// A read group has to appear both in the header and on every record, or the
+/// two disagree and a merged file loses track of where its reads came from.
+#[test]
+fn the_read_group_reaches_the_header_and_every_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(
+        dir.path(),
+        Run {
+            read_group: Some(r"ID:s1\tSM:sample1\tPL:ILLUMINA"),
+            ..Run::default()
+        },
+    );
+    assert!(
+        sam.lines()
+            .any(|l| l == "@RG\tID:s1\tSM:sample1\tPL:ILLUMINA"),
+        "the @RG line should be in the header"
+    );
+    for record in records(&sam) {
+        assert_eq!(
+            tag(&record, "RG:Z:"),
+            Some("RG:Z:s1"),
+            "every record should point at the read group: {record:?}"
+        );
     }
 }

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -121,8 +121,9 @@ misbehaves.
 | `--hardFilter`, `--scoreExp` | ✅ | Also honoured on `-a`/`--rad`, not just in reads mode: the requant applies them to the RAD's `AS`-derived scores exactly as it does to selective-alignment ones. |
 | `--ont` | ✅ | Redirect (long-read mode is out of scope, as upstream). |
 | `--mappingCacheMemoryLimit` | ⚠️ | Rust streams with bounded buffers; no mass-banking cache. |
+| `--sampleUnaligned`/`-u` | ✅ | Adds a `FLAG 0x4` record per unmapped fragment to `--writeMappings`/`--writeBam`, sequence and qualities intact, so the output covers the whole library. No longer requires `--sampleOut`. |
 | `--writeQualities` | 🔁 | Base qualities are not optional output: every record carries them whenever the input does, so the flag is accepted and has nothing to switch on. |
-| `--sampleOut`/`-s`, `--sampleUnaligned`/`-u` | ⚠️ | Posterior-sampled BAM output; accepted, not yet implemented. |
+| `--sampleOut`/`-s` | ⚠️ | A BAM of posterior-sampled alignments; accepted, not yet implemented. |
 | `--auxTargetFile`, `--writeOrphanLinks` | ⛔ | |
 
 ## `salmon quantmerge`

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -52,6 +52,7 @@ misbehaves.
 | Flag | Status | Notes |
 |------|--------|-------|
 | `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. Records carry real base-level CIGARs (`I`/`D`/`S`) with `NM` and `MD`, base qualities from the input, `MAPQ` derived from the placement count on STAR's scale (255 unique, 3, 1, 0), and `NH`/`HI`/`XT`/`AS`/`ZW`/`MC`/`MQ` tags. The header declares `VN:1.6 SO:unsorted GO:query`, `@SQ` with `M5` and `UR`, and `@PG`. |
+| `--spliced` | ✅ | Report mapping output in genome coordinates with `N` at exon junctions, from `--annotation` (exon structures) and `--genome` (chromosome lengths for `@SQ`). Adds `XS` for the transcript strand. Rust-port feature; not in this salmon build. |
 | `--rgLine` | ✅ | `@RG` header line plus `RG:Z` on every record; bwa/STAR spelling, escaped tabs accepted. Rust-port feature; not in this salmon build. |
 | `--bamCompressThreads` | ✅ | BGZF compression pool for `--writeBam`; defaults to ~1 worker per 3 mapping threads (max 8), balancing measured deflate throughput against record production. Rust-port feature; not in this salmon build. |
 | `--useEM` | ✅ | VBEM is the default; `--useEM` selects plain EM. |

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -51,7 +51,8 @@ misbehaves.
 
 | Flag | Status | Notes |
 |------|--------|-------|
-| `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. Records carry real base-level CIGARs (`I`/`D`/`S`) with `NM` and `MD` describing the alignment they report, `MAPQ` derived from the placement count on STAR's scale (255 unique, 3, 1, 0), and `NH`/`HI`/`XT`/`AS` tags. |
+| `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. Records carry real base-level CIGARs (`I`/`D`/`S`) with `NM` and `MD`, base qualities from the input, `MAPQ` derived from the placement count on STAR's scale (255 unique, 3, 1, 0), and `NH`/`HI`/`XT`/`AS`/`ZW`/`MC`/`MQ` tags. The header declares `VN:1.6 SO:unsorted GO:query`, `@SQ` with `M5` and `UR`, and `@PG`. |
+| `--rgLine` | ✅ | `@RG` header line plus `RG:Z` on every record; bwa/STAR spelling, escaped tabs accepted. Rust-port feature; not in this salmon build. |
 | `--bamCompressThreads` | ✅ | BGZF compression pool for `--writeBam`; defaults to ~1 worker per 3 mapping threads (max 8), balancing measured deflate throughput against record production. Rust-port feature; not in this salmon build. |
 | `--useEM` | ✅ | VBEM is the default; `--useEM` selects plain EM. |
 | `--meta` | ✅ | Metagenomic preset: plain EM, no range-factorized eq-classes, uniform init (the Rust EM already inits uniformly). Overrides `--useEM`/`--rangeFactorizationBins`. |
@@ -120,7 +121,8 @@ misbehaves.
 | `--hardFilter`, `--scoreExp` | ✅ | Also honoured on `-a`/`--rad`, not just in reads mode: the requant applies them to the RAD's `AS`-derived scores exactly as it does to selective-alignment ones. |
 | `--ont` | ✅ | Redirect (long-read mode is out of scope, as upstream). |
 | `--mappingCacheMemoryLimit` | ⚠️ | Rust streams with bounded buffers; no mass-banking cache. |
-| `--sampleOut`/`-s`, `--sampleUnaligned`/`-u`, `--writeQualities` | ⚠️ | Posterior-sampled BAM output; accepted, not yet implemented. |
+| `--writeQualities` | 🔁 | Base qualities are not optional output: every record carries them whenever the input does, so the flag is accepted and has nothing to switch on. |
+| `--sampleOut`/`-s`, `--sampleUnaligned`/`-u` | ⚠️ | Posterior-sampled BAM output; accepted, not yet implemented. |
 | `--auxTargetFile`, `--writeOrphanLinks` | ⛔ | |
 
 ## `salmon quantmerge`

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -51,7 +51,7 @@ misbehaves.
 
 | Flag | Status | Notes |
 |------|--------|-------|
-| `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. `MAPQ` is derived from the placement count on STAR's scale (255 unique, 3, 1, 0); other unwritten fields keep salmon's pseudobam conventions. |
+| `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. Records carry real base-level CIGARs (`I`/`D`/`S`) with `NM` and `MD` describing the alignment they report, `MAPQ` derived from the placement count on STAR's scale (255 unique, 3, 1, 0), and `NH`/`HI`/`XT`/`AS` tags. |
 | `--bamCompressThreads` | ✅ | BGZF compression pool for `--writeBam`; defaults to ~1 worker per 3 mapping threads (max 8), balancing measured deflate throughput against record production. Rust-port feature; not in this salmon build. |
 | `--useEM` | ✅ | VBEM is the default; `--useEM` selects plain EM. |
 | `--meta` | ✅ | Metagenomic preset: plain EM, no range-factorized eq-classes, uniform init (the Rust EM already inits uniformly). Overrides `--useEM`/`--rangeFactorizationBins`. |

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -166,6 +166,7 @@ See the [RAD I/O & deterministic quantification](../../guides/rad-and-determinis
 | `-z, --writeMappings <FILE>` | Write per-mapping SAM records. `--writeSam` is an alias. |
 | `--writeBam <FILE>` | Write the same per-mapping records as BGZF-compressed BAM. Mutually exclusive with `--writeMappings`/`--writeSam`; records for a fragment are contiguous, but no other order is imposed. |
 | `--bamCompressThreads <N>` | BGZF compression workers for `--writeBam`. Defaults to about one per 3 mapping threads (at most 8), which balances compression against record production; see [Record order](../output-formats/#record-order). |
+| `--rgLine <LINE>` | Read group to declare as `@RG`, as tab-separated `KEY:value` fields with a mandatory `ID` (for example `ID:sample1\tSM:sample1\tPL:ILLUMINA`). A literal `\t` is accepted in place of a tab. Every record is tagged `RG:Z:<ID>`. |
 
 ```sh
 salmon quant -i salmon_index -l A -1 r1.fq.gz -2 r2.fq.gz -p 16 -o out

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -167,6 +167,7 @@ See the [RAD I/O & deterministic quantification](../../guides/rad-and-determinis
 | `--writeBam <FILE>` | Write the same per-mapping records as BGZF-compressed BAM. Mutually exclusive with `--writeMappings`/`--writeSam`; records for a fragment are contiguous, but no other order is imposed. |
 | `--bamCompressThreads <N>` | BGZF compression workers for `--writeBam`. Defaults to about one per 3 mapping threads (at most 8), which balances compression against record production; see [Record order](../output-formats/#record-order). |
 | `--rgLine <LINE>` | Read group to declare as `@RG`, as tab-separated `KEY:value` fields with a mandatory `ID` (for example `ID:sample1\tSM:sample1\tPL:ILLUMINA`). A literal `\t` is accepted in place of a tab. Every record is tagged `RG:Z:<ID>`. |
+| `-u, --sampleUnaligned` | Also write a record for every fragment that did not map, flagged `0x4` with its bases and qualities intact, so the output covers the whole library. |
 
 ```sh
 salmon quant -i salmon_index -l A -1 r1.fq.gz -2 r2.fq.gz -p 16 -o out

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -166,6 +166,7 @@ See the [RAD I/O & deterministic quantification](../../guides/rad-and-determinis
 | `-z, --writeMappings <FILE>` | Write per-mapping SAM records. `--writeSam` is an alias. |
 | `--writeBam <FILE>` | Write the same per-mapping records as BGZF-compressed BAM. Mutually exclusive with `--writeMappings`/`--writeSam`; records for a fragment are contiguous, but no other order is imposed. |
 | `--bamCompressThreads <N>` | BGZF compression workers for `--writeBam`. Defaults to about one per 3 mapping threads (at most 8), which balances compression against record production; see [Record order](../output-formats/#record-order). |
+| `--spliced` | Report mapping output in genome coordinates instead of transcript ones, with `N` operations at exon junctions. Needs `--annotation` for the exon structures and `--genome` for the chromosome lengths the header declares. Adds `XS:A` for the transcript's strand. |
 | `--rgLine <LINE>` | Read group to declare as `@RG`, as tab-separated `KEY:value` fields with a mandatory `ID` (for example `ID:sample1\tSM:sample1\tPL:ILLUMINA`). A literal `\t` is accepted in place of a tab. Every record is tagged `RG:Z:<ID>`. |
 | `-u, --sampleUnaligned` | Also write a record for every fragment that did not map, flagged `0x4` with its bases and qualities intact, so the output covers the whole library. |
 

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -459,8 +459,10 @@ RAD-input mode (`--rad`) they are accepted but ignored, with a warning.
 
 ### What a record contains
 
-The header is unchanged: `@HD`, one `@SQ` per reference with its length, and
-`@PG`.
+The header declares `@HD VN:1.6 SO:unsorted GO:query`, one `@SQ` per reference
+with its length, an `M5` checksum of its bases and a `UR` pointing at the index,
+then `@PG` and a `@CO` restating the ordering guarantee below. `--rgLine` adds an
+`@RG` line, and every record then carries `RG:Z`.
 
 Each record carries:
 
@@ -468,14 +470,13 @@ Each record carries:
 |-------|-------|
 | `MAPQ` | Derived from the number of placements, on STAR's scale: 255 for a uniquely placed fragment, 3 for two placements, 1 for three or four, 0 beyond. `-q 255` therefore means "uniquely placed", as it does for STAR output. |
 | `CIGAR` | A base-level alignment with real `I` and `D` operations, and `S` where a read overhangs a transcript end. The placement is re-aligned with traceback when the record is written, which is work a run without mapping output never does. |
-| `NM` / `MD` | Edit distance and the reference bases at each mismatch, matching what `samtools calmd` recomputes from the input FASTA. Indexing has to replace non-ACGT bases with ACGT, since the k-mer structure cannot hold them, but the build records where it did so and the record reports the `N` that was there rather than the substitute. |
+| `SEQ` / `QUAL` | The read's bases and its Phred+33 qualities, reverse-complemented together on the reverse strand. Qualities are not optional and there is no flag to enable them; `QUAL` is `*` only when the input carried none, as for a FASTA. |
+| `NM` / `MD` | Edit distance and the reference bases at each mismatch, matching what `samtools calmd` recomputes from the input FASTA. Indexing has to replace non-ACGT bases with ACGT, since the k-mer structure cannot hold them, but the build records where it did so and the record reports the `N` that was there rather than the substitute. `@SQ M5` is computed the same way, so the header names the reference the user supplied. |
 | `NH` / `HI` | How many placements this fragment has, and which one this record is. |
-| `AS` | The score of the alignment in this same record. |
+| `AS` | The selective-alignment score. |
 | `XT` | `T` for a transcript placement, `D` for a decoy. In practice always `T`: a fragment whose best placement is a decoy is dropped by scoring before any record is written, so a decoy-aware index changes which fragments appear, not what `XT` says about them. |
-
-`QUAL` is still `*`: salmon does not carry base qualities into the record
-builder. That is an omission the format allows, unlike a CIGAR that does not
-describe the alignment it sits beside.
+| `ZW` | The placement's equivalence-class weight. |
+| `MC` / `MQ` | The mate's CIGAR and mapping quality, so a mate-aware tool does not have to sort the file to find them. |
 
 In sketch mode (`--sketch`) there is no per-placement alignment score:
 pseudoalignment maps by k-mer/equivalence-class compatibility without computing
@@ -502,6 +503,10 @@ is what STAR reports, so `MAPQ` follows STAR's mapping:
 Matching STAR matters because the tools downstream of a salmon BAM are tuned to
 it: `samtools view -q 255` means "uniquely placed" to all of them. Before this,
 every record carried a constant `1`, so that filter discarded the entire file.
+
+The header says `SO:unsorted GO:query` because that is exactly what salmon
+produces, and tools that only need records grouped by read name can therefore
+read the output directly, without a `samtools collate` first.
 
 ### Compression threads
 

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -490,6 +490,33 @@ that did not map, with its bases and qualities intact and no reference,
 position, CIGAR or placement tags. The output then covers the whole library, and
 `samtools fastq` can round-trip the input back out of it.
 
+### Spliced genome output
+
+A transcript has no introns, so by default a read spanning an exon junction is
+contiguous and its CIGAR never contains an `N`. `--spliced` re-expresses the
+records in genome coordinates instead: each alignment is cut at the exon
+boundaries the annotation declares and the gaps reappear as `N` operations, the
+way a spliced genome aligner writes them.
+
+It needs `--annotation <gtf|gff>` for the exon structures and `--genome <fasta>`
+for the chromosome lengths `@SQ` has to declare, which an annotation never
+states. A FASTA index (`.fai`) is used when one is present, so the usual case
+costs one small file read.
+
+`@SQ` then names chromosomes rather than transcripts, and records gain `XS:A`,
+the transcript's genomic strand, which StringTie and Cufflinks need to read an
+intron the right way round. A transcript on the minus strand runs against the
+genomic axis, so its alignments are turned around: the CIGAR reverses, the
+position becomes the alignment's leftmost genomic base, and the strand bits and
+stored bases flip to match. `M5` is omitted, because the references are then
+chromosomes salmon never loaded and a guessed checksum is worse than none.
+
+Placements on a reference the annotation does not describe (a decoy, or a
+transcript absent from the GTF) are dropped rather than half-projected. Two
+transcripts of one gene often imply the same genomic alignment; those duplicates
+are kept, tagged secondary as they already were, because deciding between them
+is a quantification question and `quant.sf` is salmon's answer to it.
+
 ### `MAPQ`
 
 SAM's `MAPQ` is a phred-scaled probability that a placement is wrong, and salmon

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -457,32 +457,32 @@ formats cannot drift apart.
 Both options apply to the read-mapping path only. In alignment mode (`-a`) and
 RAD-input mode (`--rad`) they are accepted but ignored, with a warning.
 
-### The pseudoalignment output contract
+### What a record contains
 
-This output is a **diagnostic view of salmon's mappings**, not a
-general-purpose aligner output, and several fields are deliberately nominal —
-for brevity, and because the mapping path computes scores without base-level
-alignments (score-only dynamic programming, no traceback) and does not compute
-them just because output was requested:
+The header is unchanged: `@HD`, one `@SQ` per reference with its length, and
+`@PG`.
 
-- **`CIGAR`** is synthesized from the read length (`<readLen>M`, plus a clip at
-  a transcript end). It records *where* the mapping is, not a base-level
-  alignment; indels are not represented, and no `NM`/`MD` accompany it.
-- **`AS`** is the score salmon's mapper assigned to the placement — the same
-  number quantification used — not a score recomputed from the record's own
-  CIGAR. It is comparable across records within one run, not across aligners.
-  **In sketch mode (`--sketch`) there is no such score**: pseudoalignment maps
-  by k-mer/equivalence-class compatibility without computing a per-placement
-  alignment score, so `AS` is reported as `0` and every reported mapping is a
-  co-equal best mapping for the read as assessed by the algorithm. A meaningful
-  `AS` appears only under selective alignment (the default), which computes a
-  banded alignment score per candidate.
-- **`MAPQ`** reflects only the placement count, not alignment confidence — see
-  below.
+Each record carries:
 
-Treat the records as positions + pairing + the quantifier's scores. If you need
-true base-level alignments, run a general-purpose aligner; a possible opt-in
-"realized alignment" output mode is under discussion (see #1141).
+| Field | Value |
+|-------|-------|
+| `MAPQ` | Derived from the number of placements, on STAR's scale: 255 for a uniquely placed fragment, 3 for two placements, 1 for three or four, 0 beyond. `-q 255` therefore means "uniquely placed", as it does for STAR output. |
+| `CIGAR` | A base-level alignment with real `I` and `D` operations, and `S` where a read overhangs a transcript end. The placement is re-aligned with traceback when the record is written, which is work a run without mapping output never does. |
+| `NM` / `MD` | Edit distance and the reference bases at each mismatch, matching what `samtools calmd` recomputes from the input FASTA. Indexing has to replace non-ACGT bases with ACGT, since the k-mer structure cannot hold them, but the build records where it did so and the record reports the `N` that was there rather than the substitute. |
+| `NH` / `HI` | How many placements this fragment has, and which one this record is. |
+| `AS` | The score of the alignment in this same record. |
+| `XT` | `T` for a transcript placement, `D` for a decoy. In practice always `T`: a fragment whose best placement is a decoy is dropped by scoring before any record is written, so a decoy-aware index changes which fragments appear, not what `XT` says about them. |
+
+`QUAL` is still `*`: salmon does not carry base qualities into the record
+builder. That is an omission the format allows, unlike a CIGAR that does not
+describe the alignment it sits beside.
+
+In sketch mode (`--sketch`) there is no per-placement alignment score:
+pseudoalignment maps by k-mer/equivalence-class compatibility without computing
+one, so `AS` is reported as `0` and every reported mapping is a co-equal best
+mapping for the read as assessed by the algorithm. A meaningful `AS` appears
+only under selective alignment (the default), which computes a banded alignment
+score per candidate.
 
 ### `MAPQ`
 

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -485,6 +485,11 @@ mapping for the read as assessed by the algorithm. A meaningful `AS` appears
 only under selective alignment (the default), which computes a banded alignment
 score per candidate.
 
+`--sampleUnaligned` additionally writes a `FLAG 0x4` record for every fragment
+that did not map, with its bases and qualities intact and no reference,
+position, CIGAR or placement tags. The output then covers the whole library, and
+`samtools fastq` can round-trip the input back out of it.
+
 ### `MAPQ`
 
 SAM's `MAPQ` is a phred-scaled probability that a placement is wrong, and salmon


### PR DESCRIPTION
**Rebased and narrowed, now into a three-PR stack.** Following the scope objection below, this PR was split:

1. **#1141** the statements the mapping output makes that are *false*: a CIGAR synthesized from the read length, `AS` describing a different alignment from the CIGAR beside it, `MAPQ` pinned to 1. 2.4% of records were self-contradicting.
2. **#1142** the fields SAM allows to be absent: `QUAL`, `@SQ M5`/`UR`, `MC`/`MQ`, `ZW`, `@RG`/`--rgLine`, unmapped records. Omissions, not falsehoods, so a separate decision.
3. **This PR**, stacked on both: the genome projection alone. `splice.rs`, `--spliced`, `XS`, the projection accounting. Seven commits, ~1.4k lines.

GitHub cannot point a base branch at a fork, so until #1141 and #1142 merge the diff shown here still includes them.

## What `--spliced` does

A transcript has no introns, so a read spanning an exon junction is contiguous in transcriptome coordinates and its CIGAR never contains an `N`. `--spliced` re-expresses each record in genome coordinates: the alignment is cut at the exon boundaries the annotation declares, the gaps reappear as `N`, `@SQ` names chromosomes, and records gain `XS:A` for the transcript's genomic strand.

It needs `--annotation <gtf|gff>` for the exon structures and `--genome <fasta>` for the chromosome lengths `@SQ` must declare (a `.fai` is used when present). A transcript on the minus strand runs against the genomic axis, so its alignments are turned around whole: CIGAR, sequence, qualities, strand bits, `TLEN` and `MD` together. `M5` is omitted, because the references are then chromosomes salmon never loaded and a guessed checksum is worse than none.

Placements on a reference the annotation does not describe (a decoy, or a transcript absent from the GTF) are refused rather than half-projected, counted, and reported as a warning at the end of the run. With `--sampleUnaligned` a fragment whose every placement was refused is written as unaligned instead of vanishing.

## Why the genome coordinates are the point

The correctness half of this work stands on its own, but it does not remove a second alignment: a transcriptome-coordinate BAM cannot be fed to the tools that need genome coordinates. Two concrete workflows in our pipeline:

**RNA-seq QC.** Picard `CollectRnaSeqMetrics`, RSeQC (`read_distribution.py`, `geneBody_coverage.py`, `inner_distance.py`) and Qualimap `rnaseq` all take a genome-coordinate BAM plus an annotation. A salmon-quantified sample therefore gets aligned twice today: once by salmon for the quantification we actually want, and once by STAR purely to produce a file for QC. The second alignment is 100% of the QC cost and none of the analysis. With `--spliced` the QC reads the same alignments the quantification used, which is also the more honest QC: it describes the file the numbers came from rather than a different aligner's view of the same library.

**Allele-specific expression.** GATK `ASEReadCounter` and phASER need genome coordinates and real CIGARs with `NM`/`MD`, the same second alignment for the same reason.

I am one lab with one pipeline, not a queue of requests, so this is evidence rather than demand. If it is not enough, a decision criterion would help more than a merge: what would count? Two or three independent reports? A user issue naming a tool by name? Happy to keep this parked until then, and #1141 stands on its own either way.

## Verification (unchanged from the original review)

Against samtools 1.24, on 500 genes over a 5 Mb simulated chromosome (three to eight exons, both strands) and on human chr22 (hg38) + GENCODE v44, 300k fragments, 1.85M records of which 685k span a junction:

- `NM`/`MD` match `samtools calmd` recomputed against the genome, on every projected record.
- `samtools quickcheck` passes, SAM round-trips through `samtools view -b`.
- Reverse-strand transcripts: `SEQ`/`QUAL` orientation, strand bits, `TLEN` sign and `MD` all agree after the flip.
- Full workspace test suite green, including the projector unit tests in `splice.rs`.
