### PR TITLE
perf(deps): hash with foldhash instead of ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,10 +2744,10 @@ dependencies = [
 name = "salmon-index"
 version = "2.5.1"
 dependencies = [
- "ahash",
  "anyhow",
  "cf1-rs",
  "ensure_simd",
+ "foldhash 0.2.0",
  "needletail",
  "piscem-rs",
  "salmon-core",
@@ -2776,7 +2776,7 @@ dependencies = [
 name = "salmon-map"
 version = "2.5.1"
 dependencies = [
- "ahash",
+ "foldhash 0.2.0",
  "hashbrown 0.15.5",
  "ksw2rs",
  "piscem-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,12 @@ crossbeam-channel = "0.5"
 # concurrent map for equivalence classes
 scc = "3"
 dashmap = "6"
-# fast (non-DoS-resistant) hasher for hot per-read integer-keyed maps
-ahash = "0.8"
+# fast (non-DoS-resistant) hasher for hot per-read integer-keyed maps.
+# foldhash's fixed-size integer path is a few multiply/rotate steps with no
+# per-byte loop, which is the shape of the (u32, bool) and u32 keys the mapper
+# builds per read. `gxhash` is faster still but needs AES-NI, which the portable
+# `target-cpu` floor in .cargo/config.toml rules out.
+foldhash = "0.2"
 # raw hash table, for caches that must probe with a borrowed key (no key
 # allocation on a lookup that hits)
 hashbrown = "0.15"

--- a/crates/salmon-index/Cargo.toml
+++ b/crates/salmon-index/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 needletail = "0.7"
 sha2 = { workspace = true }
-ahash = { workspace = true }
+foldhash = { workspace = true }
 # cf1-rs -> simd-minimizers -> packed-seq -> ensure_simd guards against building
 # its `wide`/portable-simd minimizer code without an AVX2 (x86) / NEON target,
 # which would otherwise force a compile-time `target-feature=+avx2` on the whole

--- a/crates/salmon-index/src/lib.rs
+++ b/crates/salmon-index/src/lib.rs
@@ -300,7 +300,7 @@ pub struct IndexInfo {
 /// supplied, independently of how salmon later transforms it.
 fn compute_ref_hashes(
     transcripts: &[PathBuf],
-    decoy_names: &ahash::AHashSet<Vec<u8>>,
+    decoy_names: &foldhash::HashSet<Vec<u8>>,
     gencode: bool,
 ) -> Result<RefHashes> {
     use sha2::{Digest, Sha256, Sha512};
@@ -451,7 +451,7 @@ fn preprocess_fasta(
     inputs: &[PathBuf],
     out_path: &Path,
     keep_duplicates: bool,
-    decoy_names: &ahash::AHashSet<Vec<u8>>,
+    decoy_names: &foldhash::HashSet<Vec<u8>>,
     gencode: bool,
     clip_polya: bool,
     k: usize,
@@ -481,7 +481,7 @@ fn preprocess_fasta(
     // sequences (keyed on the exact original bytes, matching salmon's pre-process
     // XXH64 over the unmodified sequence). Populated in both modes so duplicates
     // are detected for `duplicate_clusters.tsv` even under --keepDuplicates.
-    let mut seen: ahash::AHashMap<Vec<u8>, Vec<u8>> = ahash::AHashMap::new();
+    let mut seen: foldhash::HashMap<Vec<u8>, Vec<u8>> = foldhash::HashMap::default();
     for path in inputs {
         let mut reader = needletail::parse_fastx_file(path)
             .with_context(|| format!("opening {}", path.display()))?;
@@ -621,10 +621,10 @@ fn preprocess_fasta(
 ///
 /// A set (rather than a list) because membership is tested once per FASTA record
 /// and the decoy list can hold thousands of contig names.
-fn read_decoy_names(path: &Path) -> Result<ahash::AHashSet<Vec<u8>>> {
+fn read_decoy_names(path: &Path) -> Result<foldhash::HashSet<Vec<u8>>> {
     let bytes =
         std::fs::read(path).with_context(|| format!("reading decoys file {}", path.display()))?;
-    let mut set = ahash::AHashSet::new();
+    let mut set = foldhash::HashSet::default();
     for line in bytes.split(|&b| b == b'\n') {
         // trim trailing CR and surrounding whitespace
         //
@@ -722,7 +722,7 @@ pub fn build(opts: &IndexBuildOptions) -> Result<IndexInfo> {
     // Decoy names (genome/contamination sequences indexed but never quantified).
     let decoy_names = match &opts.decoys {
         Some(p) => read_decoy_names(p)?,
-        None => ahash::AHashSet::new(),
+        None => foldhash::HashSet::default(),
     };
 
     // Preprocess the references into the cleaned FASTA that feeds both the cDBG

--- a/crates/salmon-map/Cargo.toml
+++ b/crates/salmon-map/Cargo.toml
@@ -12,7 +12,7 @@ description = "Selective-alignment mapping for the salmon Rust port: MEM collect
 salmon-core = { workspace = true }
 piscem-rs = { workspace = true }
 sshash-lib = "0.6"
-ahash = { workspace = true }
+foldhash = { workspace = true }
 hashbrown = { workspace = true }
 # ksw2 (the alignment backend): a native-Rust ksw_extz2_sse port with runtime
 # SIMD dispatch (AVX2/SSE4.1/NEON + scalar fallback) — one portable binary.

--- a/crates/salmon-map/src/align.rs
+++ b/crates/salmon-map/src/align.rs
@@ -311,7 +311,7 @@ struct GapEntry {
 /// score is not a trade worth making here.)
 struct GapCache {
     table: hashbrown::HashTable<GapEntry>,
-    hasher: ahash::RandomState,
+    hasher: foldhash::fast::FixedState,
 }
 
 impl Default for GapCache {
@@ -321,12 +321,7 @@ impl Default for GapCache {
             // Fixed seeds: the lookup is byte-exact so the seed cannot affect
             // results, but pinning it keeps bucket layout (and therefore
             // profiling runs) reproducible.
-            hasher: ahash::RandomState::with_seeds(
-                0x51_7c_c1_b7,
-                0x27_22_0a_95,
-                0x9e_37_79_b9,
-                0x85_eb_ca_6b,
-            ),
+            hasher: foldhash::fast::FixedState::with_seed(0x517c_c1b7_2722_0a95),
         }
     }
 }
@@ -336,7 +331,7 @@ impl Default for GapCache {
 /// A free function rather than a method so the rehash-on-growth closure can call
 /// it while the table itself is mutably borrowed.
 #[inline]
-fn gap_hash(hasher: &ahash::RandomState, kind: GapKind, q: &[u8], t: &[u8]) -> u64 {
+fn gap_hash(hasher: &foldhash::fast::FixedState, kind: GapKind, q: &[u8], t: &[u8]) -> u64 {
     use std::hash::{BuildHasher, Hash, Hasher};
     let mut h = hasher.build_hasher();
     (kind as u8).hash(&mut h);

--- a/crates/salmon-map/src/collect.rs
+++ b/crates/salmon-map/src/collect.rs
@@ -32,7 +32,7 @@
 //! anchors increase colinearly with the reference coordinate. The resulting
 //! chains are stamped with `is_fw = false` so a later stage can map them back.
 
-use ahash::AHashMap;
+use foldhash::HashMap;
 
 use piscem_rs::index::contig_table::EntryEncoding;
 use piscem_rs::index::reference_index::ReferenceIndex;
@@ -96,8 +96,8 @@ pub fn project_raw_hits(
     read_len: i32,
     k: i32,
     max_hit_occ: usize,
-) -> AHashMap<(u32, bool), Vec<Mem>> {
-    let mut groups: AHashMap<(u32, bool), Vec<Mem>> = AHashMap::new();
+) -> HashMap<(u32, bool), Vec<Mem>> {
+    let mut groups: HashMap<(u32, bool), Vec<Mem>> = HashMap::default();
     for (read_pos, phit) in raw_hits {
         if phit.num_hits() > max_hit_occ {
             continue;

--- a/crates/salmon-map/src/pair.rs
+++ b/crates/salmon-map/src/pair.rs
@@ -22,7 +22,7 @@
 //! References that yield no concordant pair fall back to orphan mappings when
 //! orphans are allowed. Mirrors pufferfish/salmon's `joinReadsAndFilter`.
 
-use ahash::AHashSet;
+use foldhash::HashSet;
 
 use salmon_core::{LibraryFormat, MateStatus, ReadOrientation, ReadStrandedness, ReadType};
 
@@ -171,9 +171,9 @@ thread_local! {
     /// Reused per-thread `paired` set for [`join_reads_and_filter`] (the tids that
     /// formed a concordant pair). Cleared per call; reused so pairing allocates no
     /// per-read hash set. Grouping uses an in-place sort (no map), so the two
-    /// per-read `AHashMap<u32, Vec<usize>>` of the old `group_by_tid` are gone.
-    static PAIRED_TIDS: std::cell::RefCell<AHashSet<u32>> =
-        std::cell::RefCell::new(AHashSet::new());
+    /// per-read `HashMap<u32, Vec<usize>>` of the old `group_by_tid` are gone.
+    static PAIRED_TIDS: std::cell::RefCell<HashSet<u32>> =
+        std::cell::RefCell::new(HashSet::default());
 
     /// Set by [`join_reads_and_filter`] when it rejects an otherwise-valid
     /// (opposite-strand, in-range fragment length) concordant pair *solely*
@@ -409,7 +409,7 @@ pub fn join_reads_and_filter(
 /// has several chains to one reference (repeat copies). `cands` is tid-sorted.
 fn emit_best_orphans(
     cands: &[MappingCandidate],
-    paired: &AHashSet<u32>,
+    paired: &HashSet<u32>,
     cutoff: i32,
     status: MateStatus,
     joints: &mut Vec<JointMapping>,

--- a/crates/salmon-map/src/score.rs
+++ b/crates/salmon-map/src/score.rs
@@ -207,8 +207,8 @@ pub struct DedupScratch {
 /// Fixed seeds: the survivors' order does not affect results, but a stable
 /// hasher keeps a given input hashing the same way from run to run, which makes
 /// this path reproducible if that ever starts to matter.
-fn dedup_hasher() -> ahash::RandomState {
-    ahash::RandomState::with_seeds(0x5119_1B3D, 0xA5F1_2C07, 0x2D4E_9A11, 0x7C3B_60E5)
+fn dedup_hasher() -> foldhash::fast::FixedState {
+    foldhash::fast::FixedState::with_seed(0x5119_1b3d_a5f1_2c07)
 }
 
 /// Deduplicate in place by scanning the already-kept prefix. No allocation and
@@ -235,6 +235,7 @@ fn dedup_by_scan(raw: &mut Vec<RawMapping>) {
 /// Deduplicate through a reused hash table, for fragments with enough mappings
 /// that scanning the kept prefix costs more than hashing each key.
 fn dedup_by_table(raw: &mut Vec<RawMapping>, scratch: &mut DedupScratch) {
+    use std::hash::BuildHasher;
     let state = dedup_hasher();
     let hash_of = |tid: u32| state.hash_one(tid);
     let table = &mut scratch.table;


### PR DESCRIPTION
Every hashed key on the mapping hot path is small and fixed-size: `(u32, bool)` in `collect::group_by_tid`, `u32` in the paired-tid scratch set and in the dedup table, a `(kind, &[u8], &[u8])` triple in the gap cache. foldhash's fixed-size path is a few multiply/rotate steps with no per-byte streaming loop, which is exactly that shape.

### Measured

A/B of the three map shapes in isolation, identical key stream per hasher, divan medians (200 samples; 100 for the cache):

| shape | ahash | foldhash | rapidhash |
|---|---|---|---|
| `best_per_tid` (`u32` -> mapping) | 387.7 µs | **354.6 µs** (-8.5%) | 378.2 µs |
| `group_by_tid` (`(u32,bool)` -> mems) | 1.150 ms | **1.094 ms** (-4.9%) | 1.121 ms |
| gap-cache key (byte-slice pair) | 123.9 µs | 114.1 µs (-7.9%) | **112.8 µs** |

`examples/bench_align`, which drives the real gap cache, best of three runs per case, ns per alignment on the default anchored path:

| case | before | after |
|---|---|---|
| 51 bp, 0 mm | 21.7 | 20.8 |
| 51 bp, 2 mm | 21.2 | 20.7 |
| 100 bp, 0 mm | 38.5 | 37.3 |
| 100 bp, 2 mm | 37.8 | 35.6 |
| 150 bp, 0 mm | 51.0 | 46.9 |
| 150 bp, 2 mm | 46.3 | 41.6 |

All twelve alignment checksums are unchanged.

### Notes

- The seeded hashers stay seeded: `ahash::RandomState::with_seeds` becomes `foldhash::fast::FixedState::with_seed`, so the gap cache and the dedup table keep the reproducible bucket layout their comments promise.
- rapidhash was measured alongside and only edges foldhash out on the byte-key cache while losing on both integer shapes, so it is not worth a second hashing crate in the tree.
- gxhash is faster still but requires AES-NI, which the portable `target-cpu` floor in `.cargo/config.toml` rules out.
- These maps are a slice of total quant time, not all of it. This is a few percent on the paths that use them, not an end-to-end figure; I have no real dataset here to quote a wall-clock delta on.

`cargo test --workspace`, `cargo clippy --workspace --all-targets` and `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
