### PR TITLE
perf(index): map refseq.bin instead of reading it into a Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ name = "salmon-core"
 version = "2.5.1"
 dependencies = [
  "flate2",
+ "memmap2",
  "niffler",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ rand_pcg = "0.10"
 rand_distr = "0.6"
 # hashing
 xxhash-rust = { version = "0.8", features = ["xxh3", "xxh64"] }
+# memory-mapped reads of the index's reference-base blob; already in the tree
+# via sshash-lib, which maps the sshash index the same way.
+memmap2 = "0.9"
 # compression
 flate2 = "1"
 zstd = "0.13"

--- a/crates/salmon-core/Cargo.toml
+++ b/crates/salmon-core/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 description = "Shared core types for the Rust port of salmon (transcripts, library formats, log-space math)."
 
 [dependencies]
+memmap2 = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 # the unmatched-transcript list under aux_info/ is JSON, like the other

--- a/crates/salmon-core/src/lib.rs
+++ b/crates/salmon-core/src/lib.rs
@@ -62,6 +62,87 @@ pub use libtype::{LibraryFormat, ReadOrientation, ReadStrandedness, ReadType};
 pub use mate::MateStatus;
 pub use transcript::Transcript;
 
+/// A read-only byte blob that is either owned on the heap or mapped from a file.
+///
+/// The reference bases are the largest thing salmon loads: a human
+/// transcriptome is a few hundred MB, and an index with a genome decoy is
+/// several GB. Reading that into a `Vec` costs the whole file in resident
+/// memory and a full read before the first fragment is processed, even though
+/// the bases are only ever read, never written, and bias correction touches a
+/// small fraction of them. Mapping the file instead makes the load a syscall,
+/// leaves paging to the kernel, and lets several salmon processes on one
+/// machine share the pages.
+///
+/// `Owned` remains for everything built in memory (test fixtures, references
+/// reconstructed from an annotation), so nothing that does not read an index
+/// file has to care.
+#[derive(Debug, Clone)]
+pub enum Bases {
+    /// Bases held in the heap.
+    Owned(Vec<u8>),
+    /// Bases mapped from a file. `Arc` so cloning a [`RefSeqs`] does not
+    /// re-map; the mapping is read-only and freely shared between threads.
+    Mapped(std::sync::Arc<memmap2::Mmap>),
+}
+
+impl Default for Bases {
+    fn default() -> Self {
+        Bases::Owned(Vec::new())
+    }
+}
+
+impl std::ops::Deref for Bases {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        match self {
+            Bases::Owned(v) => v,
+            Bases::Mapped(m) => m,
+        }
+    }
+}
+
+impl AsRef<[u8]> for Bases {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+impl PartialEq for Bases {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl Eq for Bases {}
+
+impl From<Vec<u8>> for Bases {
+    fn from(v: Vec<u8>) -> Self {
+        Bases::Owned(v)
+    }
+}
+
+/// Map a file read-only for the lifetime of the returned handle.
+///
+/// # Correctness
+///
+/// A memory mapping aliases the file: if the bytes change underneath us the
+/// mapped slice changes too, which Rust's aliasing rules do not allow. The
+/// invariant this relies on is that an index directory is immutable while a run
+/// reads it, which salmon already depends on elsewhere -- `sshash-lib` maps the
+/// sshash index itself the same way. Rebuilding an index into a directory that
+/// a running salmon has open was never supported.
+#[allow(unsafe_code)]
+pub fn map_file(path: &std::path::Path) -> Result<std::sync::Arc<memmap2::Mmap>> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| SalmonError::Other(format!("opening {}: {e}", path.display())))?;
+    // SAFETY: see the note above -- the index directory is immutable for the
+    // duration of the run.
+    let map = unsafe { memmap2::Mmap::map(&file) }
+        .map_err(|e| SalmonError::Other(format!("mapping {}: {e}", path.display())))?;
+    Ok(std::sync::Arc::new(map))
+}
+
 /// A set of reference sequences held as one contiguous buffer plus endpoint
 /// offsets, handing out `&[u8]` views.
 ///
@@ -76,10 +157,10 @@ pub use transcript::Transcript;
 /// scattered, and — where the source is already concatenated — avoids copying
 /// the bases at all. On a human transcriptome (~250k references) the header
 /// overhead alone is ~6 MB before a single base is stored.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub struct RefSeqs {
     /// Every reference's bases, back to back.
-    seqs: Vec<u8>,
+    seqs: Bases,
     /// `n + 1` endpoints delimiting each reference inside `seqs`; reference `i`
     /// occupies `offsets[i]..offsets[i + 1]`.
     offsets: Vec<u64>,
@@ -97,6 +178,24 @@ impl RefSeqs {
     /// past the end of `seqs` — any of which would otherwise surface later as a
     /// panicking slice or, worse, as a silently wrong reference.
     pub fn from_concatenated(seqs: Vec<u8>, offsets: Vec<u64>) -> Result<Self> {
+        Self::from_bases(Bases::Owned(seqs), offsets)
+    }
+
+    /// Wrap a mapped index file and its offset table.
+    ///
+    /// The zero-copy path for `refseq.bin`: nothing is read up front and the
+    /// bases never occupy anonymous memory. See [`map_file`] for the invariant
+    /// this depends on.
+    ///
+    /// # Errors
+    ///
+    /// The same offset-table validation as [`Self::from_concatenated`].
+    pub fn from_mapped(seqs: std::sync::Arc<memmap2::Mmap>, offsets: Vec<u64>) -> Result<Self> {
+        Self::from_bases(Bases::Mapped(seqs), offsets)
+    }
+
+    /// Shared validation for both constructors above.
+    fn from_bases(seqs: Bases, offsets: Vec<u64>) -> Result<Self> {
         let bad = |m: String| SalmonError::Other(m);
         if offsets.is_empty() {
             return Err(bad(
@@ -141,7 +240,10 @@ impl RefSeqs {
             buf.extend_from_slice(s.as_ref());
             offsets.push(buf.len() as u64);
         }
-        Self { seqs: buf, offsets }
+        Self {
+            seqs: Bases::Owned(buf),
+            offsets,
+        }
     }
 
     /// Number of references.
@@ -180,6 +282,14 @@ impl RefSeqs {
         &self.offsets
     }
 }
+
+impl PartialEq for RefSeqs {
+    fn eq(&self, other: &Self) -> bool {
+        self.offsets == other.offsets && self.seqs == other.seqs
+    }
+}
+
+impl Eq for RefSeqs {}
 
 impl std::ops::Index<usize> for RefSeqs {
     type Output = [u8];

--- a/crates/salmon-index/src/lib.rs
+++ b/crates/salmon-index/src/lib.rs
@@ -1088,7 +1088,7 @@ pub struct SalmonIndex {
     /// without sequence-dependent bias correction): the raw nucleotides are only
     /// needed for selective-alignment extension and seq/GC bias, so skipping the
     /// read avoids holding a multi-GB decoy genome resident.
-    refseq: Vec<u8>,
+    refseq: salmon_core::Bases,
     /// offsets into `refseq` (`num_refs + 1` entries); empty iff `!refseq_loaded`
     ref_offsets: Vec<u64>,
     /// whether the reference sequence bytes were loaded
@@ -1102,8 +1102,8 @@ pub struct SalmonIndex {
 /// the index already stores, so the user need not re-supply a transcript FASTA.
 pub fn load_ref_seqs(dir: impl AsRef<Path>) -> Result<RefSeqs> {
     let dir = dir.as_ref();
-    let refseq =
-        std::fs::read(dir.join(REFSEQ_FILE)).with_context(|| format!("reading {REFSEQ_FILE}"))?;
+    let refseq = salmon_core::map_file(&dir.join(REFSEQ_FILE))
+        .with_context(|| format!("mapping {REFSEQ_FILE}"))?;
     let offsets: Vec<u64> = serde_json::from_slice(
         &std::fs::read(dir.join(REFSEQ_OFFSETS_FILE))
             .with_context(|| format!("reading {REFSEQ_OFFSETS_FILE}"))?,
@@ -1113,7 +1113,7 @@ pub fn load_ref_seqs(dir: impl AsRef<Path>) -> Result<RefSeqs> {
     // no copy of the bases, and no per-transcript allocation. `from_concatenated`
     // validates the table against the blob, turning a corrupt index into an error
     // here rather than a panicking slice at the first bias lookup.
-    RefSeqs::from_concatenated(refseq, offsets)
+    RefSeqs::from_mapped(refseq, offsets)
         .with_context(|| format!("reference sequences in {}", dir.display()))
 }
 
@@ -1177,15 +1177,17 @@ impl SalmonIndex {
         let inner = ReferenceIndex::load(&index_prefix, info.has_ec_table, false)
             .with_context(|| format!("loading piscem index at {}", index_prefix.display()))?;
         let (refseq, ref_offsets) = if load_refseq {
-            let refseq = std::fs::read(dir.join(REFSEQ_FILE))
-                .with_context(|| format!("reading {REFSEQ_FILE}"))?;
+            let refseq = salmon_core::Bases::Mapped(
+                salmon_core::map_file(&dir.join(REFSEQ_FILE))
+                    .with_context(|| format!("mapping {REFSEQ_FILE}"))?,
+            );
             let ref_offsets: Vec<u64> = serde_json::from_slice(
                 &std::fs::read(dir.join(REFSEQ_OFFSETS_FILE))
                     .with_context(|| format!("reading {REFSEQ_OFFSETS_FILE}"))?,
             )?;
             (refseq, ref_offsets)
         } else {
-            (Vec::new(), Vec::new())
+            (salmon_core::Bases::default(), Vec::new())
         };
         Ok(Self {
             inner,


### PR DESCRIPTION
The reference bases are the largest thing a run loads: a few hundred MB for a human transcriptome, several GB once a genome decoy is in the index. Both `load_ref_seqs` and `SalmonIndex::load_with_opts` pulled the whole `refseq.bin` into a `Vec<u8>` before the first fragment was processed, even though the bases are only ever read and bias correction touches a fraction of them.

`salmon_core::Bases` is now either `Owned(Vec<u8>)` (everything built in memory: annotation-reconstructed references, test fixtures) or `Mapped(Arc<Mmap>)`, deref'ing to `&[u8]` either way, so no accessor signature changes. `RefSeqs::from_mapped` runs the same offset-table validation as `from_concatenated`.

### Measured

Synthetic 509 MB / 250k-reference store, page cache warm, release build:

| mode | before | after | peak RSS before | peak RSS after |
|---|---|---|---|---|
| load only | 39.4 ms | **2.1 ms** | 496 MB | **10 MB** |
| load + read every 10th reference | 44.2 ms | **18.2 ms** | 496 MB | 420 MB |
| load + read every base | 47.3 ms | **34.4 ms** | 496 MB | 496 MB |

Checksums over the bases are identical in every mode. Even the read-everything case is faster, because the copy into anonymous memory is skipped. The mapped pages are also clean and reclaimable, unlike the anonymous buffer they replace, so several salmon processes on one machine share them instead of each paying the full resident cost.

### Safety

The mapping relies on the index directory being immutable for the duration of a run. salmon already depends on that: `sshash-lib` maps the sshash index the same way, and rebuilding an index under a running salmon was never supported. The `unsafe` block carries that note; it is the only one in `salmon-core`, and `memmap2` is already in the tree transitively via `sshash-lib`.

### Not included

`refseq_offsets.json` is still parsed as JSON. Converting it to a binary or zero-copy table needs an index-format bump and is a much smaller cost, so it is left for a separate change.

`cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
