### PR TITLE
Update README with corrected quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,15 @@ docker run --rm combinelab/salmon:latest salmon --version
 ## Quick start
 
 ```sh
+# 0) Unpack the sample data
+tar xzf sample_data.tgz
+
 # 1) build a reusable index from a transcriptome
-salmon index -t transcripts.fa -i salmon_index -p 16
+salmon index -t transcripts.fasta -i salmon_index -p 16
 
 # 2) quantify (-l A auto-detects the library type)
 salmon quant -i salmon_index -l A \
-  -1 reads_1.fastq.gz -2 reads_2.fastq.gz -p 16 -o sample_quant
+  -1 reads_1.fastq -2 reads_2.fastq -p 4 -o sample_quant
 ```
 
 Results land in `sample_quant/quant.sf` (drop-in for tximport / tximeta /

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ docker run --rm combinelab/salmon:latest salmon --version
 ## Quick start
 
 ```sh
-# 0) Unpack the sample data
+# 0) Unpack the sample data and go to it
 tar xzf sample_data.tgz
+cd sample_data
 
 # 1) build a reusable index from a transcriptome
 salmon index -t transcripts.fasta -i salmon_index -p 16


### PR DESCRIPTION
I added a step 0 to the quick start instructions to extract the sample data.

The prior text did not have the full name of the transcripts file and the fastq files in the sample data are not compressed.

I corrected all three file names, and the examples now seem to run without error.