### PR TITLE
fix(quant): make each --writeMappings/--writeBam record describe the alignment it reports

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -532,9 +532,10 @@ struct QuantArgs {
     /// Write the names of unmapped fragments to aux_info/unmapped_names.txt.
     #[arg(long = "writeUnmappedNames")]
     write_unmapped_names: bool,
-    /// Write per-mapping SAM records to this file (spoofed CIGAR, like salmon's
-    /// standard `--writeMappings`). `--writeSam` is an accepted alias, naming
-    /// the format explicitly to pair with `--writeBam`.
+    /// Write per-mapping SAM records to this file. Records carry a base-level
+    /// CIGAR with NM and MD, describing the alignment the record reports.
+    /// `--writeSam` is an accepted alias, naming the format explicitly to pair
+    /// with `--writeBam`.
     #[arg(
         short = 'z',
         long = "writeMappings",
@@ -542,7 +543,8 @@ struct QuantArgs {
         conflicts_with = "write_bam"
     )]
     write_mappings: Option<PathBuf>,
-    /// Write per-mapping BAM records to this file. Mutually exclusive with
+    /// Write per-mapping BAM records to this file: the same records as
+    /// --writeMappings, BGZF-compressed. Mutually exclusive with
     /// --writeMappings/--writeSam.
     #[arg(long = "writeBam", conflicts_with = "write_mappings")]
     write_bam: Option<PathBuf>,
@@ -3545,6 +3547,16 @@ mod tests {
         assert_eq!(q.dump_eq_weights, defaults.dump_eq_weights);
         assert_eq!(q.no_length_correction, defaults.no_length_correction);
         assert_eq!(q.no_frag_length_dist, defaults.no_frag_length_dist);
+    }
+
+    /// `--sampleUnaligned` keeps its salmon short form, since it is the flag
+    /// users already have in their scripts.
+    #[test]
+    fn sample_unaligned_has_both_spellings() {
+        for flag in ["--sampleUnaligned", "-u"] {
+            assert!(quant_args(&[flag]).unwrap().sample_unaligned, "{flag}");
+        }
+        assert!(!quant_args(&[]).unwrap().sample_unaligned);
     }
 
     /// `--writeSam` is a spelling of `--writeMappings`, giving SAM output a

--- a/crates/salmon-index/src/lib.rs
+++ b/crates/salmon-index/src/lib.rs
@@ -65,6 +65,18 @@ const INFO_FILE: &str = "info.json";
 const REFSEQ_FILE: &str = "refseq.bin";
 /// Per-reference offsets into `REFSEQ_FILE` (`num_refs + 1` entries).
 const REFSEQ_OFFSETS_FILE: &str = "refseq_offsets.json";
+/// Reference offsets whose base was not ACGT in the input and was replaced to
+/// make the sequence k-mer-able. Pairs of `(tid, offset)`, little-endian `u32`,
+/// sorted, behind a `u64` count.
+///
+/// The index has to align against a cleaned sequence, but a record describing
+/// that alignment should not claim the reference had a base it never had. Keeping
+/// the positions costs one entry per ambiguous base (four across the whole
+/// GENCODE v44 human transcriptome) and lets `NM`, `MD` and the `@SQ M5` speak
+/// about the reference the user actually supplied.
+///
+/// Absent in indexes built before this existed, which load as "none recorded".
+const AMBIGUOUS_FILE: &str = "ambiguous.bin";
 
 /// On-disk salmon index *format* version written into `info.json` by this build.
 /// Distinct from `salmon_version` (the software release string): this is bumped
@@ -387,6 +399,10 @@ struct RefHashes {
 struct PreprocessResult {
     /// non-ACGT bases replaced with pseudo-random ACGT
     replaced: u64,
+    /// per written reference, the offsets whose base was replaced. Keyed by name
+    /// rather than by position because the index assigns its own reference order
+    /// later, and matching on names cannot drift from it.
+    ambiguous: Vec<(Vec<u8>, Vec<u32>)>,
     /// `(retained_name, duplicate_name)` pairs in discovery order. Without
     /// `--keepDuplicates` the duplicate was *not* written to the cleaned FASTA (so
     /// it is absent from the index); with `--keepDuplicates` every transcript is
@@ -462,6 +478,7 @@ fn preprocess_fasta(
             .with_context(|| format!("creating {}", out_path.display()))?,
     );
     let mut replaced = 0u64;
+    let mut ambiguous: Vec<(Vec<u8>, Vec<u32>)> = Vec::new();
     let mut polya_clipped = 0u64;
     let mut polya_dropped: Vec<Vec<u8>> = Vec::new();
     let mut short_decoys_dropped: Vec<Vec<u8>> = Vec::new();
@@ -537,9 +554,13 @@ fn preprocess_fasta(
             // assembly gaps. The refseq store keeps the raw bytes and the aligner
             // encodes N as a mismatch (dna5 code 4), so a read aligning over a decoy
             // N-run simply scores it as a mismatch.
+            // Offsets replaced in this record, kept so a later alignment can say
+            // the reference base was unknown rather than report the substitute.
+            let mut replaced_here: Vec<u32> = Vec::new();
             if !is_decoy {
-                for b in seq.iter_mut() {
+                for (offset, b) in seq.iter_mut().enumerate() {
                     if !matches!(*b, b'A' | b'C' | b'G' | b'T' | b'a' | b'c' | b'g' | b't') {
+                        replaced_here.push(offset as u32);
                         // A linear congruential generator: multiply, add, and take
                         // high bits. `wrapping_*` means overflow wraps around
                         // rather than panicking, which is the intended arithmetic.
@@ -592,6 +613,13 @@ fn preprocess_fasta(
                 continue;
             }
 
+            // Clipping can cut the tail off, taking replaced offsets with it, and
+            // only a record that is actually written has a reference to belong to.
+            replaced_here.retain(|&o| (o as usize) < seq.len());
+            if !replaced_here.is_empty() {
+                ambiguous.push((name.to_vec(), replaced_here));
+            }
+
             // Write the record in canonical two-line form (header, then the whole
             // sequence unwrapped), which is what the downstream builder expects.
             out.write_all(b">")?;
@@ -604,6 +632,7 @@ fn preprocess_fasta(
     out.flush()?;
     Ok(PreprocessResult {
         replaced,
+        ambiguous,
         duplicate_clusters,
         polya_clipped,
         polya_dropped,
@@ -950,6 +979,8 @@ pub fn build(opts: &IndexBuildOptions) -> Result<IndexInfo> {
 
     // Persist the (cleaned) reference sequences (piscem does not retain them) so
     // the selective-alignment step fetches windows matching the indexed k-mers.
+    write_ambiguous_positions(&opts.output_dir, &pre.ambiguous, &idx)
+        .context("writing the ambiguous-base position table")?;
     write_refseq_store(&opts.output_dir, std::slice::from_ref(&cleaned), &idx)
         .context("writing reference sequence store")?;
 
@@ -1021,6 +1052,67 @@ fn processed_name(id: &[u8], gencode: bool) -> &[u8] {
 ///
 /// Order matters: the sequences are written in the *index's* id order, not the
 /// FASTA's, because that is how every later lookup indexes them.
+/// Read the ambiguous-base table, or empty when the index predates it.
+///
+/// A missing file is not an error: an index built before this was recorded
+/// simply cannot say, and the output then matches what it always produced.
+fn read_ambiguous_positions(dir: &Path) -> Result<(Vec<u32>, Vec<u32>)> {
+    let path = dir.join(AMBIGUOUS_FILE);
+    let Ok(bytes) = std::fs::read(&path) else {
+        return Ok((Vec::new(), Vec::new()));
+    };
+    if bytes.len() < 8 {
+        anyhow::bail!("{AMBIGUOUS_FILE} is truncated");
+    }
+    let count = u64::from_le_bytes(bytes[..8].try_into().expect("8 bytes")) as usize;
+    if bytes.len() != 8 + count * 8 {
+        anyhow::bail!(
+            "{AMBIGUOUS_FILE} declares {count} entries but is {} bytes",
+            bytes.len()
+        );
+    }
+    let mut tids = Vec::with_capacity(count);
+    let mut offsets = Vec::with_capacity(count);
+    for entry in bytes[8..].chunks_exact(8) {
+        tids.push(u32::from_le_bytes(entry[..4].try_into().expect("4 bytes")));
+        offsets.push(u32::from_le_bytes(entry[4..].try_into().expect("4 bytes")));
+    }
+    Ok((tids, offsets))
+}
+
+/// Record which reference offsets held a base the index had to replace.
+///
+/// Names are resolved to reference ids here rather than during preprocessing,
+/// because the index assigns its own order and a table keyed by position would
+/// drift from it silently. A name the index does not carry is one whose record
+/// was dropped later, and is simply not recorded.
+fn write_ambiguous_positions(
+    dir: &Path,
+    ambiguous: &[(Vec<u8>, Vec<u32>)],
+    idx: &ReferenceIndex,
+) -> Result<()> {
+    use std::collections::HashMap;
+    let by_name: HashMap<&[u8], u32> = (0..idx.num_refs())
+        .map(|tid| (idx.ref_name(tid).as_bytes(), tid as u32))
+        .collect();
+    let mut pairs: Vec<(u32, u32)> = Vec::new();
+    for (name, offsets) in ambiguous {
+        if let Some(&tid) = by_name.get(name.as_slice()) {
+            pairs.extend(offsets.iter().map(|&offset| (tid, offset)));
+        }
+    }
+    pairs.sort_unstable();
+    let mut buf = Vec::with_capacity(8 + pairs.len() * 8);
+    buf.extend_from_slice(&(pairs.len() as u64).to_le_bytes());
+    for (tid, offset) in &pairs {
+        buf.extend_from_slice(&tid.to_le_bytes());
+        buf.extend_from_slice(&offset.to_le_bytes());
+    }
+    std::fs::write(dir.join(AMBIGUOUS_FILE), &buf)
+        .with_context(|| format!("writing {AMBIGUOUS_FILE}"))?;
+    Ok(())
+}
+
 fn write_refseq_store(dir: &Path, transcripts: &[PathBuf], idx: &ReferenceIndex) -> Result<()> {
     use std::collections::HashMap;
 
@@ -1088,6 +1180,15 @@ pub struct SalmonIndex {
     ref_offsets: Vec<u64>,
     /// whether the reference sequence bytes were loaded
     refseq_loaded: bool,
+    /// Reference ids of the bases the build had to replace, ascending, parallel
+    /// to [`Self::ambiguous_off`]. Held as two arrays rather than pairs so one
+    /// reference's offsets can be handed out as a slice.
+    ///
+    /// Empty for an index built before these were recorded, which reads as "none
+    /// known" rather than "none exist": the output is then what it always was.
+    ambiguous_tid: Vec<u32>,
+    /// Offsets within the corresponding reference.
+    ambiguous_off: Vec<u32>,
 }
 
 /// Load just the per-reference forward sequences from an index directory, in
@@ -1182,16 +1283,35 @@ impl SalmonIndex {
         } else {
             (Vec::new(), Vec::new())
         };
+        // Cheap enough to read unconditionally: it is empty for almost every
+        // index, and a caller that skipped the sequences still gets a consistent
+        // answer from `ambiguous_offsets`.
+        let (ambiguous_tid, ambiguous_off) = read_ambiguous_positions(dir)?;
         Ok(Self {
             inner,
             info,
             refseq,
             ref_offsets,
             refseq_loaded: load_refseq,
+            ambiguous_tid,
+            ambiguous_off,
         })
     }
 
     /// Whether the reference sequence bytes were loaded (see [`load_with_opts`](Self::load_with_opts)).
+    /// Offsets within reference `tid` whose base the build replaced, ascending.
+    ///
+    /// Empty for almost every reference: across the whole GENCODE v44 human
+    /// transcriptome there are four such bases. Callers can therefore treat the
+    /// empty case as the fast path without measuring.
+    pub fn ambiguous_offsets(&self, tid: usize) -> &[u32] {
+        let tid = tid as u32;
+        // Sorted by `(tid, offset)`, so one reference's offsets are contiguous.
+        let start = self.ambiguous_tid.partition_point(|&t| t < tid);
+        let end = self.ambiguous_tid.partition_point(|&t| t <= tid);
+        &self.ambiguous_off[start..end]
+    }
+
     pub fn refseq_loaded(&self) -> bool {
         self.refseq_loaded
     }
@@ -1310,6 +1430,38 @@ fn read_info(dir: &Path) -> Result<IndexInfo> {
 
 #[cfg(test)]
 mod tests {
+    /// The ambiguous-base table has to survive a write/read round trip, and an
+    /// index built before it existed has to keep loading.
+    #[test]
+    fn ambiguous_positions_round_trip_and_tolerate_absence() {
+        let dir = tempfile::tempdir().unwrap();
+        // Absent: not an error, and nothing recorded.
+        assert_eq!(
+            super::read_ambiguous_positions(dir.path()).unwrap(),
+            (Vec::new(), Vec::new())
+        );
+        let pairs: Vec<(u32, u32)> = vec![(0, 5), (0, 9), (7, 2)];
+        let mut buf = (pairs.len() as u64).to_le_bytes().to_vec();
+        for (tid, offset) in &pairs {
+            buf.extend_from_slice(&tid.to_le_bytes());
+            buf.extend_from_slice(&offset.to_le_bytes());
+        }
+        std::fs::write(dir.path().join(super::AMBIGUOUS_FILE), &buf).unwrap();
+        let (tids, offsets) = super::read_ambiguous_positions(dir.path()).unwrap();
+        assert_eq!(tids, vec![0, 0, 7]);
+        assert_eq!(offsets, vec![5, 9, 2]);
+    }
+
+    /// A truncated table is a corrupt index, not something to read past.
+    #[test]
+    fn a_truncated_ambiguous_table_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut buf = 3u64.to_le_bytes().to_vec();
+        buf.extend_from_slice(&[0, 0, 0, 0]);
+        std::fs::write(dir.path().join(super::AMBIGUOUS_FILE), &buf).unwrap();
+        assert!(super::read_ambiguous_positions(dir.path()).is_err());
+    }
+
     use super::*;
     use std::io::Write;
 

--- a/crates/salmon-map/src/lib.rs
+++ b/crates/salmon-map/src/lib.rs
@@ -52,6 +52,7 @@ pub mod extend;
 pub mod mapper;
 pub mod mem;
 pub mod pair;
+pub mod realize;
 pub mod score;
 pub mod sketch;
 
@@ -71,6 +72,9 @@ pub use mapper::{
 };
 pub use mem::Mem;
 pub use pair::{join_reads_and_filter, JointMapping, PairingConfig};
+pub use realize::{
+    push_op, realize, reference_span, CigarOp, CigarOpKind, RealizeScratch, RealizedAlignment,
+};
 pub use salmon_core::RefProvider;
 pub use score::{
     filter_sketch_decoys, finalize_mappings, DedupScratch, MapScratch, RawMapping, ScoreConfig,

--- a/crates/salmon-map/src/realize.rs
+++ b/crates/salmon-map/src/realize.rs
@@ -1,0 +1,1219 @@
+//! Base-level alignment realization for SAM/BAM output.
+//!
+//! # Why this is separate from [`crate::align`]
+//!
+//! Mapping only ever needs a *score*: is this candidate placement good enough to
+//! keep? [`crate::align`] therefore runs ksw2 in `KSW_EZ_SCORE_ONLY` mode, which
+//! skips the traceback matrix entirely, the single largest cost in a banded DP.
+//! That is the right trade for the hot path, where the aligner runs once per
+//! candidate across every read in the library.
+//!
+//! Writing a SAM or BAM record needs more than a score. A record has to say *how*
+//! the read lines up: where each insertion and deletion falls (the CIGAR), how
+//! many bases differ from the reference (`NM`), and which reference bases they
+//! were (`MD`). None of that survives a score-only DP.
+//!
+//! So this module re-derives the alignment, with traceback, for the placements
+//! that actually get written. That is a much smaller set than the candidates the
+//! mapper scored: only the placements that survived filtering, and only when
+//! `--writeMappings`/`--writeBam` is on. A run without mapping output never calls
+//! into this module at all, so the mapping hot path is untouched.
+//!
+//! # What "realizing" a placement means
+//!
+//! The mapper hands over an approximate start position on a transcript. This
+//! module aligns the read against a window starting there and reports:
+//!
+//! * the CIGAR, with real `I`/`D` operations where the read has indels and `S`
+//!   where it overhangs a transcript end,
+//! * `ref_start`, the leftmost reference base the alignment actually consumes,
+//! * `NM`, the edit distance (mismatches + inserted + deleted bases),
+//! * `MD`, the string that lets a reader reconstruct the reference from the read.
+//!
+//! # Gap placement
+//!
+//! ksw2 is run *without* `KSW_EZ_RIGHT` here, unlike the scoring path. That flag
+//! right-aligns gaps; SAM convention (and every downstream variant caller) wants
+//! them left-aligned, so the CIGAR this module produces is the conventional one
+//! even though the score it implies is identical either way.
+
+use crate::align::AlignConfig;
+
+/// A CIGAR operation code, using the BAM numeric encoding so that both writers
+/// and the genome projector can share one vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CigarOpKind {
+    /// `M`: consumes read and reference (match *or* mismatch, SAM's `M` does not
+    /// distinguish them; `MD`/`NM` carry that information).
+    Match = 0,
+    /// `I`: bases present in the read, absent from the reference.
+    Insertion = 1,
+    /// `D`: bases present in the reference, absent from the read.
+    Deletion = 2,
+    /// `N`: reference skipped without the read crossing it. Only produced by the
+    /// genome projector, for introns; a transcriptome alignment never has one.
+    Skip = 3,
+    /// `S`: bases present in the read but not aligned, and still stored in `SEQ`.
+    SoftClip = 4,
+}
+
+impl CigarOpKind {
+    /// The SAM letter for this operation.
+    pub fn letter(self) -> char {
+        match self {
+            Self::Match => 'M',
+            Self::Insertion => 'I',
+            Self::Deletion => 'D',
+            Self::Skip => 'N',
+            Self::SoftClip => 'S',
+        }
+    }
+
+    /// Whether this operation advances the position in the read.
+    pub fn consumes_read(self) -> bool {
+        matches!(self, Self::Match | Self::Insertion | Self::SoftClip)
+    }
+
+    /// Whether this operation advances the position on the reference.
+    pub fn consumes_reference(self) -> bool {
+        matches!(self, Self::Match | Self::Deletion | Self::Skip)
+    }
+}
+
+/// One CIGAR operation: a kind and how many bases it covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CigarOp {
+    pub kind: CigarOpKind,
+    pub len: u32,
+}
+
+impl CigarOp {
+    pub fn new(kind: CigarOpKind, len: u32) -> Self {
+        Self { kind, len }
+    }
+}
+
+/// Append `op`, merging it into the previous operation when they are the same
+/// kind. Zero-length operations are dropped: they are legal to *produce* while
+/// stitching an alignment together but illegal to write into a record.
+pub fn push_op(ops: &mut Vec<CigarOp>, kind: CigarOpKind, len: u32) {
+    if len == 0 {
+        return;
+    }
+    match ops.last_mut() {
+        Some(last) if last.kind == kind => last.len += len,
+        _ => ops.push(CigarOp::new(kind, len)),
+    }
+}
+
+/// A realized alignment: everything a SAM/BAM record needs beyond the fields the
+/// mapper already knows.
+///
+/// Buffers are owned so one instance can be reused across every record a worker
+/// writes; [`RealizedAlignment::clear`] resets it without freeing.
+#[derive(Debug, Default, Clone)]
+pub struct RealizedAlignment {
+    /// CIGAR operations, in reference order (5'→3' on the forward strand).
+    pub ops: Vec<CigarOp>,
+    /// Leftmost reference position the alignment consumes, 0-based.
+    pub ref_start: i32,
+    /// Edit distance: mismatches plus inserted plus deleted bases (SAM `NM`).
+    pub edit_distance: u32,
+    /// SAM `MD`: matched run lengths, mismatched reference bases, and `^`-prefixed
+    /// deleted reference stretches.
+    pub md: String,
+    /// Alignment score of the realized alignment under the configured affine
+    /// scoring. Reported separately from the mapper's `AS` so the two never get
+    /// confused.
+    pub score: i32,
+}
+
+impl RealizedAlignment {
+    pub fn clear(&mut self) {
+        self.ops.clear();
+        self.ref_start = 0;
+        self.edit_distance = 0;
+        self.md.clear();
+        self.score = 0;
+    }
+}
+
+/// Scratch buffers for [`realize`], so realizing a record allocates nothing after
+/// the first call on a given worker.
+#[derive(Default)]
+pub struct RealizeScratch {
+    aligner: ksw2rs::Aligner,
+    query_codes: Vec<u8>,
+    target_codes: Vec<u8>,
+    /// The read in reference-forward orientation.
+    oriented: Vec<u8>,
+    /// Candidate starts from the probe search, reused across records.
+    candidates: Vec<i32>,
+}
+
+/// DNA5 code for a base: `A,C,G,T` → `0..3`, anything else → `4`.
+fn dna5(base: u8) -> u8 {
+    match base {
+        b'A' | b'a' => 0,
+        b'C' | b'c' => 1,
+        b'G' | b'g' => 2,
+        b'T' | b't' => 3,
+        _ => 4,
+    }
+}
+
+fn complement(base: u8) -> u8 {
+    match base {
+        b'A' | b'a' => b'T',
+        b'C' | b'c' => b'G',
+        b'G' | b'g' => b'C',
+        b'T' | b't' => b'A',
+        _ => b'N',
+    }
+}
+
+/// 5x5 DNA5 scoring matrix, matching [`crate::align`]'s.
+fn dna5_matrix(cfg: &AlignConfig) -> [i8; 25] {
+    let mut mat = [-cfg.mismatch_pen; 25];
+    for i in 0..5 {
+        mat[i * 5 + i] = cfg.match_score;
+    }
+    mat[24] = 0;
+    mat
+}
+
+/// Two bases count as a match for `MD`/`NM` only if they are the same known base.
+/// An `N` on either side is a mismatch, which is what samtools' own `calmd` does.
+fn bases_match(read: u8, reference: u8) -> bool {
+    let (r, t) = (read.to_ascii_uppercase(), reference.to_ascii_uppercase());
+    r == t && matches!(r, b'A' | b'C' | b'G' | b'T')
+}
+
+/// Realize the placement of `read` at approximately `approx_pos` on `ref_seq`.
+///
+/// `is_forward` says whether the read aligns to the reference's forward strand;
+/// when it does not, the reverse complement is what gets aligned, which is also
+/// what SAM stores in `SEQ`. `approx_pos` is the mapper's implied start and may
+/// fall outside the reference: a negative position means the read overhangs the
+/// 5' end, and a position plus read length beyond the reference means it
+/// overhangs the 3' end. Both become soft clips.
+///
+/// Returns `false`, leaving `out` cleared, when no alignment can be formed at all
+/// (an empty read or reference, or a window that lands entirely off the
+/// reference). Callers fall back to the spoofed CIGAR in that case.
+#[allow(clippy::too_many_arguments)]
+pub fn realize(
+    read: &[u8],
+    is_forward: bool,
+    ref_seq: &[u8],
+    ambiguous: &[u32],
+    approx_pos: i32,
+    cfg: &AlignConfig,
+    scratch: &mut RealizeScratch,
+    out: &mut RealizedAlignment,
+) -> bool {
+    out.clear();
+    if read.is_empty() || ref_seq.is_empty() {
+        return false;
+    }
+
+    // SEQ is stored on the reference's forward strand, so that is the orientation
+    // every coordinate below is expressed in.
+    scratch.oriented.clear();
+    if is_forward {
+        scratch.oriented.extend_from_slice(read);
+    } else {
+        scratch
+            .oriented
+            .extend(read.iter().rev().map(|&b| complement(b)));
+    }
+    let query = std::mem::take(&mut scratch.oriented);
+    let realized = realize_anchored(&query, ref_seq, ambiguous, approx_pos, cfg, scratch, out);
+    scratch.oriented = query;
+    realized
+}
+
+/// Mismatches when the read is laid down ungapped at `pos`, or `None` when it
+/// would not fit inside the reference there.
+fn ungapped_mismatches(query: &[u8], ref_seq: &[u8], pos: i32) -> Option<i32> {
+    if pos < 0 || pos as usize + query.len() > ref_seq.len() {
+        return None;
+    }
+    let reference = &ref_seq[pos as usize..pos as usize + query.len()];
+    Some(
+        query
+            .iter()
+            .zip(reference)
+            .filter(|(&read, &base)| !bases_match(read, base))
+            .count() as i32,
+    )
+}
+
+/// Whether an ungapped alignment with `mismatches` is provably optimal: no
+/// alignment containing a gap can score better. See [`realize_oriented`] for the
+/// derivation.
+fn ungapped_is_optimal(mismatches: i32, cfg: &AlignConfig) -> bool {
+    mismatches * (cfg.match_score + cfg.mismatch_pen) as i32
+        <= cfg.gap_open_pen as i32 + cfg.gap_extend_pen as i32
+}
+
+/// Length of the exact probe used to locate a misplaced read. Long enough to be
+/// specific over the few hundred bases searched, short enough that a 1% error
+/// rate usually leaves at least one of the two probes clean.
+const PROBE: usize = 20;
+
+/// Candidate starts for `query` near `approx_pos`, found by locating an exact
+/// probe from the read inside the surrounding window.
+///
+/// Comparing the whole read at every offset answers the question but costs the
+/// read length at each one, and the sweep has to reach a read length in either
+/// direction. Searching for one exact substring costs the window instead of the
+/// window times the read, and every occurrence of it names a start directly.
+///
+/// Two probes are taken, a third and two thirds of the way in, because a single
+/// probe landing on a sequencing error finds nothing. Ends are avoided: they are
+/// where reads are worst and where a genuine indel is most likely to sit.
+fn probe_candidates(query: &[u8], ref_seq: &[u8], approx_pos: i32, reach: i32, out: &mut Vec<i32>) {
+    out.clear();
+    if query.len() < PROBE * 2 {
+        return;
+    }
+    let low = (approx_pos - reach).max(0) as usize;
+    let high = ((approx_pos + reach) as usize + query.len()).min(ref_seq.len());
+    if high <= low + PROBE {
+        return;
+    }
+    let window = &ref_seq[low..high];
+    for offset in [query.len() / 3, query.len() * 2 / 3] {
+        let Some(probe) = query.get(offset..offset + PROBE) else {
+            continue;
+        };
+        for (index, candidate) in window.windows(PROBE).enumerate() {
+            if candidate == probe {
+                let start = low as i32 + index as i32 - offset as i32;
+                if start >= 0 && !out.contains(&start) {
+                    out.push(start);
+                }
+            }
+        }
+    }
+}
+
+/// Find where the read actually starts, when it plainly does not start where the
+/// mapper said, and report how many mismatches it has there.
+///
+/// The mapper's position comes from a seed chain, and a mismatch near the read's
+/// 5' end pushes that chain rightwards. A read can also be anchored so close to a
+/// transcript end that it hangs off it, which turns into a soft-clipped record
+/// that quietly throws bases away when the read often belongs further in and
+/// matches in full.
+///
+/// The scan is gated on the read looking badly placed to begin with. A handful of
+/// sequencing errors is not evidence of a wrong anchor, and relocating a read that
+/// is already where it belongs would cost more than it saves.
+fn repair_anchor(
+    query: &[u8],
+    ref_seq: &[u8],
+    approx_pos: i32,
+    cfg: &AlignConfig,
+    candidates: &mut Vec<i32>,
+) -> Option<(i32, i32)> {
+    // A read that does not even fit inside the reference where it was placed is
+    // as badly anchored as one that mismatches everywhere, and is the case most
+    // worth looking at. Treating "does not fit" as "matches nothing" is what lets
+    // the search run there at all.
+    let here = ungapped_mismatches(query, ref_seq, approx_pos).unwrap_or(query.len() as i32);
+    // An eighth of the read differing is far past what sequencing error explains,
+    // and squarely in "this is not where the read goes" territory.
+    if here <= (query.len() as i32) / 8 {
+        return None;
+    }
+    // How far the anchor can be wrong is not a question about indel size, which is
+    // what `indel_margin` bounds. A seed chain on a repeat or a paralogous stretch
+    // can imply a start most of a read length away.
+    let reach = query.len() as i32 + cfg.indel_margin as i32;
+    probe_candidates(query, ref_seq, approx_pos, reach, candidates);
+    let mut best = (here, approx_pos);
+    let consider = |best: &mut (i32, i32), candidate: i32| {
+        if let Some(mismatches) = ungapped_mismatches(query, ref_seq, candidate) {
+            if mismatches < best.0 {
+                *best = (mismatches, candidate);
+            }
+        }
+    };
+    for &candidate in candidates.iter() {
+        consider(&mut best, candidate);
+    }
+    // Both probes can land on a sequencing error, and a read shorter than two
+    // probes has none to offer. That leaves a read the cheap search cannot place,
+    // and the alternative to placing it is a record with no base-level alignment
+    // at all, so it is worth the exhaustive sweep. This runs on a fraction of a
+    // percent of records, which is what makes it affordable.
+    if best.1 == approx_pos {
+        for delta in 1..=reach {
+            consider(&mut best, approx_pos - delta);
+            consider(&mut best, approx_pos + delta);
+            if ungapped_is_optimal(best.0, cfg) {
+                break;
+            }
+        }
+    }
+    (best.1 != approx_pos).then_some((best.1, best.0))
+}
+
+/// Realize at `approx_pos`, repairing the anchor first when the read plainly does
+/// not sit there.
+///
+/// ksw2's extension pins the read's first base to the window's first base, so the
+/// alignment can grow rightwards but never shift left. That is fine when the
+/// mapper's position is the read's true start, and wrong when it is not: the DP
+/// then has no way to express "the read starts earlier" except by opening a
+/// leading insertion, which is both a worse alignment and a false one.
+///
+/// [`repair_anchor`] settles that before the DP runs, by comparison rather than
+/// alignment. What remains afterwards is a safety net for the cases it declines
+/// to act on: a leading insertion of `n` bases is itself the statement that the
+/// read began `n` bases earlier, so shift by that and realize again.
+#[allow(clippy::too_many_arguments)]
+fn realize_anchored(
+    query: &[u8],
+    ref_seq: &[u8],
+    ambiguous: &[u32],
+    approx_pos: i32,
+    cfg: &AlignConfig,
+    scratch: &mut RealizeScratch,
+    out: &mut RealizedAlignment,
+) -> bool {
+    let mut anchor = approx_pos;
+    if !realize_oriented(query, ref_seq, ambiguous, approx_pos, cfg, scratch, out) {
+        return false;
+    }
+    // A repaired anchor is a hypothesis, not a verdict. Reads with a genuine
+    // deletion also look badly placed to an ungapped scan, since every base past
+    // the gap is shifted, so the scan can talk itself into relocating a read that
+    // was where it belonged. Realizing at both anchors and keeping the better
+    // score makes the repair unable to do harm: the worst it can do is cost one
+    // extra alignment on a read that already looked wrong.
+    let mut candidates = std::mem::take(&mut scratch.candidates);
+    let repaired = repair_anchor(query, ref_seq, approx_pos, cfg, &mut candidates);
+    scratch.candidates = candidates;
+    if let Some((repaired, mismatches)) = repaired {
+        let mut alternative = RealizedAlignment::default();
+        if realize_oriented(
+            query,
+            ref_seq,
+            ambiguous,
+            repaired,
+            cfg,
+            scratch,
+            &mut alternative,
+        ) && (alternative.score > out.score || ungapped_is_optimal(mismatches, cfg))
+        {
+            *out = alternative;
+            anchor = repaired;
+        }
+    }
+    // Refuse to publish an alignment the mapper itself would have rejected.
+    //
+    // When the anchor is wrong by more than the search could reach, the banded DP
+    // still returns *an* alignment: a sawtooth of one-base insertions and
+    // deletions that walks the read diagonally across the reference. It is a
+    // valid CIGAR and a completely false claim, and it contradicts the `AS` on
+    // the same record, which came from the mapper and says the read aligned well.
+    // `min_accepted_score` is the mapper's own bar for believing a placement, so
+    // an alignment below it is one this module has no business asserting. Falling
+    // back to the spoofed CIGAR says "no base-level alignment here", which is at
+    // least true.
+    //
+    // The bar is set by the bases the alignment actually claims, not by the whole
+    // read: a read hanging off a transcript end is soft-clipped, and its clipped
+    // bases are not evidence of anything either way.
+    let claimed: u32 = out
+        .ops
+        .iter()
+        .filter(|op| matches!(op.kind, CigarOpKind::Match | CigarOpKind::Insertion))
+        .map(|op| op.len)
+        .sum();
+    if out.score < crate::align::min_accepted_score(claimed as usize, cfg) {
+        out.clear();
+        return false;
+    }
+    let leading_insertion = match out.ops.first() {
+        Some(op) if op.kind == CigarOpKind::Insertion => op.len as i32,
+        _ => 0,
+    };
+    if leading_insertion > 0 && anchor - leading_insertion >= 0 {
+        let mut retried = RealizedAlignment::default();
+        std::mem::swap(out, &mut retried);
+        if realize_oriented(
+            query,
+            ref_seq,
+            ambiguous,
+            anchor - leading_insertion,
+            cfg,
+            scratch,
+            out,
+        ) && out.score >= retried.score
+        {
+            return true;
+        }
+        // The retry did not help, so keep the original rather than a worse one.
+        std::mem::swap(out, &mut retried);
+    }
+    // An insertion at either edge is a legal CIGAR but a meaningless claim: those
+    // bases are not aligned to anything, which is what a soft clip says.
+    clip_edge_insertions(out);
+    true
+}
+
+/// Turn insertions at the very start or end of the alignment into soft clips.
+///
+/// Both consume read bases and no reference, so the CIGAR stays consistent
+/// either way, but only the clip is honest: an insertion says "these bases are
+/// present in the read and absent from the reference at this point", which at
+/// the edge of an alignment is a claim about nothing. It also inflates `NM`,
+/// so the edit distance gives those bases back.
+fn clip_edge_insertions(out: &mut RealizedAlignment) {
+    let mut clipped = 0;
+    let mut clip = |ops: &mut [CigarOp], index: usize| {
+        if let Some(op) = ops.get_mut(index) {
+            if op.kind == CigarOpKind::Insertion {
+                op.kind = CigarOpKind::SoftClip;
+                clipped += op.len;
+            }
+        }
+    };
+    // The edge is the first operation, or the second when a clip already leads.
+    let leading = usize::from(out.ops.first().map(|op| op.kind) == Some(CigarOpKind::SoftClip));
+    clip(&mut out.ops, leading);
+    let last = out.ops.len().saturating_sub(1);
+    let trailing = if out.ops.last().map(|op| op.kind) == Some(CigarOpKind::SoftClip) {
+        last.saturating_sub(1)
+    } else {
+        last
+    };
+    if trailing > leading {
+        clip(&mut out.ops, trailing);
+    }
+    out.edit_distance = out.edit_distance.saturating_sub(clipped);
+    // Converting next to an existing clip leaves two clips in a row.
+    let mut merged: Vec<CigarOp> = Vec::with_capacity(out.ops.len());
+    for op in &out.ops {
+        push_op(&mut merged, op.kind, op.len);
+    }
+    out.ops = merged;
+}
+
+/// Record the ungapped alignment: one `M` run over the whole read, with `NM` and
+/// `MD` derived from a single pass over the bases.
+fn finish_ungapped(
+    query: &[u8],
+    ref_seq: &[u8],
+    window_start: i32,
+    query_len: i32,
+    score: i32,
+    out: &mut RealizedAlignment,
+) {
+    out.ref_start = window_start;
+    out.score = score;
+    push_op(&mut out.ops, CigarOpKind::Match, query_len as u32);
+    fill_md_and_edit_distance(query, ref_seq, &[], out);
+}
+
+/// The body of [`realize`], with the query already in reference orientation.
+#[allow(clippy::too_many_arguments)]
+fn realize_oriented(
+    query: &[u8],
+    ref_seq: &[u8],
+    ambiguous: &[u32],
+    approx_pos: i32,
+    cfg: &AlignConfig,
+    scratch: &mut RealizeScratch,
+    out: &mut RealizedAlignment,
+) -> bool {
+    let ref_len = ref_seq.len() as i32;
+    let query_len = query.len() as i32;
+
+    // A read hanging off the 5' end contributes a leading soft clip; alignment
+    // starts at reference 0 with whatever bases are left.
+    let (leading_clip, window_start) = if approx_pos < 0 {
+        ((-approx_pos).min(query_len), 0)
+    } else {
+        (0, approx_pos.min(ref_len))
+    };
+    let aligned_query = &query[leading_clip as usize..];
+    if aligned_query.is_empty() || window_start >= ref_len {
+        // Nothing of the read reaches the reference: it is all clip, which is not
+        // a record worth spoofing a CIGAR for.
+        return false;
+    }
+
+    // Most records do not need a dynamic program at all. A read placed where the
+    // mapper put it usually lines up base for base, differing only by
+    // substitutions, and for that alignment the CIGAR is a single `M` run whose
+    // `NM` and `MD` fall out of one pass over the bases.
+    //
+    // The question is when that ungapped alignment is not merely plausible but
+    // *optimal*, since anything less would make the output depend on a shortcut.
+    // Affine scoring answers it: any alignment containing a gap pays at least
+    // `gap_open + gap_extend`, and the very best it can do with the rest is match
+    // everywhere, so its score cannot exceed `perfect - (gap_open +
+    // gap_extend)`. The ungapped alignment scores `perfect - mismatches *
+    // (match + mismatch)`. Whenever the second is at least the first, no gapped
+    // alignment can win, and the DP would only spend time rediscovering that.
+    //
+    // At salmon's defaults (match 2, mismatch 4, open 6, extend 2) the rule
+    // admits up to one mismatch, which covers most reads at realistic error
+    // rates. `ungapped_score` is kept for the second shortcut below.
+    // A reference whose bases the build had to replace cannot answer "does this
+    // read match here" from the stored sequence alone, so the shortcuts that rest
+    // on that answer are skipped and the full walk decides. This costs nothing in
+    // practice: it is four references in the human transcriptome.
+    let ungapped_mismatch_count = (leading_clip == 0 && ambiguous.is_empty())
+        .then(|| ungapped_mismatches(query, ref_seq, window_start))
+        .flatten();
+    let ungapped = ungapped_mismatch_count.map(|mismatches| {
+        query_len * cfg.match_score as i32
+            - mismatches * (cfg.match_score + cfg.mismatch_pen) as i32
+    });
+    if let (Some(mismatches), Some(ungapped_score)) = (ungapped_mismatch_count, ungapped) {
+        if ungapped_is_optimal(mismatches, cfg) {
+            finish_ungapped(query, ref_seq, window_start, query_len, ungapped_score, out);
+            return true;
+        }
+    }
+
+    // Give the aligner room past the read length so a net deletion in the read
+    // still has reference to consume.
+    let window_end =
+        (window_start + aligned_query.len() as i32 + cfg.indel_margin as i32).min(ref_len);
+    let window = &ref_seq[window_start as usize..window_end as usize];
+
+    let matrix = dna5_matrix(cfg);
+    encode_into(aligned_query, &mut scratch.query_codes);
+    encode_into(window, &mut scratch.target_codes);
+
+    // Pass 1, score only: find how much of the window the best full-query
+    // alignment consumes (`mqe_t`). ksw2's extension anchors at (0, 0), which is
+    // exactly the "read starts here" constraint we want.
+    let (query_end_target, query_end_reachable, target_end_query, query_end_score) = {
+        let input = ksw2rs::Extz2Input {
+            query: &scratch.query_codes,
+            target: &scratch.target_codes,
+            m: 5,
+            mat: &matrix,
+            q: cfg.gap_open_pen,
+            e: cfg.gap_extend_pen,
+            // salmon's own `dpBandwidth`. It used to have to cover
+            // `indel_margin` as well, because the anchor correction read its
+            // offset off a leading insertion and could not see one wider than
+            // the band. `repair_anchor` now settles the anchor by comparison
+            // before the DP runs, so the band only has to cover genuine indels,
+            // and a banded DP is linear in its width.
+            w: cfg.bandwidth,
+            zdrop: -1,
+            end_bonus: 0,
+            flag: ksw2rs::KSW_EZ_SCORE_ONLY,
+        };
+        let ez = scratch.aligner.align(&input);
+        (ez.mqe_t, ez.mqe > ksw2rs::KSW_NEG_INF, ez.mte_q, ez.mqe)
+    };
+
+    // The DP has now priced the optimal alignment. When that price is the one the
+    // ungapped alignment already pays, the traceback would only redraw a single
+    // `M` run, so skip it: filling and walking the traceback matrix is the
+    // expensive half of a banded alignment, and this is the case where it buys
+    // nothing. Reads with several mismatches but no indel land here.
+    if let Some(ungapped_score) = ungapped {
+        // The optimal full-query alignment ends exactly `query_len` bases into
+        // the window (so it has no net indel) and scores what the ungapped one
+        // scores: the ungapped alignment is therefore an optimal one, and the
+        // conventional choice among any ties.
+        if query_end_reachable
+            && query_end_target == query_len - 1
+            && query_end_score == ungapped_score
+        {
+            finish_ungapped(query, ref_seq, window_start, query_len, ungapped_score, out);
+            return true;
+        }
+    }
+
+    // How much window the traceback pass should align against, and how much of
+    // the read's tail is soft-clipped.
+    //
+    // The read reaching its end inside the window is the normal case. It stops
+    // being the right answer when the read is simply longer than the reference
+    // left to align against: the DP can still "reach the query end" by dumping
+    // every leftover base into an insertion at the last reference position, which
+    // scores worse than clipping and describes an alignment nobody believes. A
+    // read overhanging a transcript's 3' end is exactly that case, so when the
+    // query cannot fit in the window at all, clip the tail instead.
+    let overhangs_reference_end = aligned_query.len() > window.len();
+    let (target_len, trailing_clip) =
+        if query_end_reachable && query_end_target >= 0 && !overhangs_reference_end {
+            ((query_end_target + 1).min(window.len() as i32), 0)
+        } else if target_end_query >= 0 {
+            (
+                window.len() as i32,
+                aligned_query.len() as i32 - (target_end_query + 1),
+            )
+        } else {
+            return false;
+        };
+    if target_len <= 0 || trailing_clip < 0 {
+        return false;
+    }
+    let aligned_query = &aligned_query[..aligned_query.len() - trailing_clip as usize];
+    if aligned_query.is_empty() {
+        return false;
+    }
+
+    // Pass 2, with traceback: a global alignment of the read (minus clips) to the
+    // window prefix picked above. No `KSW_EZ_RIGHT`, so gaps come out
+    // left-aligned as SAM expects.
+    encode_into(aligned_query, &mut scratch.query_codes);
+    let target = &window[..target_len as usize];
+    encode_into(target, &mut scratch.target_codes);
+    let (packed, score) = {
+        let input = ksw2rs::Extz2Input {
+            query: &scratch.query_codes,
+            target: &scratch.target_codes,
+            m: 5,
+            mat: &matrix,
+            q: cfg.gap_open_pen,
+            e: cfg.gap_extend_pen,
+            w: cfg
+                .bandwidth
+                .max((aligned_query.len() as i32 - target_len).abs() + 4),
+            zdrop: -1,
+            end_bonus: 0,
+            flag: 0,
+        };
+        let ez = scratch.aligner.align(&input);
+        (ez.cigar.clone(), ez.score)
+    };
+    if packed.is_empty() {
+        return false;
+    }
+
+    out.ref_start = window_start;
+    out.score = score;
+    push_op(&mut out.ops, CigarOpKind::SoftClip, leading_clip as u32);
+    for entry in &packed {
+        let len = entry >> 4;
+        let kind = match entry & 0xf {
+            0 => CigarOpKind::Match,
+            1 => CigarOpKind::Insertion,
+            2 => CigarOpKind::Deletion,
+            other => {
+                debug_assert!(false, "ksw2 emitted an unexpected CIGAR op {other}");
+                return false;
+            }
+        };
+        push_op(&mut out.ops, kind, len);
+    }
+    push_op(&mut out.ops, CigarOpKind::SoftClip, trailing_clip as u32);
+
+    // A leading or trailing deletion is a legal DP result but a meaningless
+    // record: it claims reference bases outside the read's span. Trim them and
+    // move the start position accordingly.
+    trim_edge_deletions(out);
+    fill_md_and_edit_distance(query, ref_seq, ambiguous, out);
+    true
+}
+
+/// Drop `D`/`N` operations at either end of the CIGAR, shifting `ref_start` past
+/// a leading one.
+fn trim_edge_deletions(out: &mut RealizedAlignment) {
+    while let Some(first) = out.ops.first().copied() {
+        // A leading clip is fine; look past it for a deletion.
+        let index = if first.kind == CigarOpKind::SoftClip {
+            1
+        } else {
+            0
+        };
+        match out.ops.get(index).copied() {
+            Some(op) if matches!(op.kind, CigarOpKind::Deletion | CigarOpKind::Skip) => {
+                out.ref_start += op.len as i32;
+                out.ops.remove(index);
+            }
+            _ => break,
+        }
+    }
+    while let Some(&last) = out.ops.last() {
+        let index = if last.kind == CigarOpKind::SoftClip {
+            out.ops.len().saturating_sub(2)
+        } else {
+            out.ops.len() - 1
+        };
+        match out.ops.get(index).copied() {
+            Some(op) if matches!(op.kind, CigarOpKind::Deletion | CigarOpKind::Skip) => {
+                out.ops.remove(index);
+            }
+            _ => break,
+        }
+    }
+}
+
+/// Walk the finished CIGAR against read and reference to fill in `MD` and `NM`.
+///
+/// `MD` alternates: a count of reference bases that matched, then either the
+/// reference base at a mismatch or `^` followed by the deleted reference bases. A
+/// count is emitted between every pair of those, including zero-length ones, which
+/// is what makes the string unambiguously parseable.
+pub(crate) fn fill_md_and_edit_distance(
+    query: &[u8],
+    ref_seq: &[u8],
+    ambiguous: &[u32],
+    out: &mut RealizedAlignment,
+) {
+    use std::fmt::Write as _;
+
+    let mut read_pos = 0usize;
+    let mut ref_pos = out.ref_start as usize;
+    let mut matched_run = 0u32;
+    let mut edit_distance = 0u32;
+
+    for op in &out.ops {
+        match op.kind {
+            CigarOpKind::Match => {
+                for _ in 0..op.len {
+                    let read_base = query.get(read_pos).copied().unwrap_or(b'N');
+                    // A base the build replaced is reported as the `N` it was, not
+                    // as the substitute the index carries: the record describes the
+                    // reference the user supplied.
+                    let ref_base = if ambiguous.binary_search(&(ref_pos as u32)).is_ok() {
+                        b'N'
+                    } else {
+                        ref_seq.get(ref_pos).copied().unwrap_or(b'N')
+                    };
+                    if bases_match(read_base, ref_base) {
+                        matched_run += 1;
+                    } else {
+                        let _ = write!(out.md, "{matched_run}");
+                        out.md.push(ref_base.to_ascii_uppercase() as char);
+                        matched_run = 0;
+                        edit_distance += 1;
+                    }
+                    read_pos += 1;
+                    ref_pos += 1;
+                }
+            }
+            CigarOpKind::Insertion => {
+                edit_distance += op.len;
+                read_pos += op.len as usize;
+            }
+            CigarOpKind::Deletion => {
+                let _ = write!(out.md, "{matched_run}");
+                matched_run = 0;
+                out.md.push('^');
+                for _ in 0..op.len {
+                    let ref_base = if ambiguous.binary_search(&(ref_pos as u32)).is_ok() {
+                        b'N'
+                    } else {
+                        ref_seq.get(ref_pos).copied().unwrap_or(b'N')
+                    };
+                    out.md.push(ref_base.to_ascii_uppercase() as char);
+                    ref_pos += 1;
+                }
+                edit_distance += op.len;
+            }
+            // An intron is not an edit: the read simply does not cross it, and MD
+            // is defined over the aligned blocks only.
+            CigarOpKind::Skip => ref_pos += op.len as usize,
+            CigarOpKind::SoftClip => read_pos += op.len as usize,
+        }
+    }
+    let _ = write!(out.md, "{matched_run}");
+    out.edit_distance = edit_distance;
+}
+
+fn encode_into(seq: &[u8], out: &mut Vec<u8>) {
+    out.clear();
+    out.reserve(seq.len());
+    out.extend(seq.iter().map(|&b| dna5(b)));
+}
+
+/// How many reference bases a CIGAR spans.
+pub fn reference_span(ops: &[CigarOp]) -> i32 {
+    ops.iter()
+        .filter(|op| op.kind.consumes_reference())
+        .map(|op| op.len as i32)
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> AlignConfig {
+        AlignConfig::default()
+    }
+
+    /// A deterministic sequence with no repeats long enough to give the anchor
+    /// repair a second equally good home for a read. A periodic reference would
+    /// make these tests assert on an arbitrary choice between ties.
+    fn nonrepeating(len: usize) -> Vec<u8> {
+        let mut state: u64 = 0x2545F4914F6CDD1D;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                b"ACGT"[((state >> 33) % 4) as usize]
+            })
+            .collect()
+    }
+
+    fn realize_at(read: &[u8], reference: &[u8], pos: i32) -> RealizedAlignment {
+        let mut scratch = RealizeScratch::default();
+        let mut out = RealizedAlignment::default();
+        assert!(realize(
+            read,
+            true,
+            reference,
+            &[],
+            pos,
+            &config(),
+            &mut scratch,
+            &mut out
+        ));
+        out
+    }
+
+    fn cigar_string(out: &RealizedAlignment) -> String {
+        out.ops
+            .iter()
+            .map(|op| format!("{}{}", op.len, op.kind.letter()))
+            .collect()
+    }
+
+    /// A read that matches the reference exactly is one `M` run, no edits, and an
+    /// `MD` that is just its length.
+    #[test]
+    fn exact_match_has_no_edits() {
+        let reference = b"ACGTACGTACGTACGTACGTACGTACGTACGT";
+        let out = realize_at(&reference[4..24], reference, 4);
+        assert_eq!(cigar_string(&out), "20M");
+        assert_eq!(out.ref_start, 4);
+        assert_eq!(out.edit_distance, 0);
+        assert_eq!(out.md, "20");
+    }
+
+    /// A single substitution stays one `M` run, SAM's `M` covers mismatches, and
+    /// shows up in `NM` and as a reference base in `MD`.
+    #[test]
+    fn substitution_is_reported_in_md_not_cigar() {
+        let reference = b"ACGTACGTACGTACGTACGTACGTACGTACGT";
+        let mut read = reference[4..24].to_vec();
+        read[5] = b'A'; // reference has C here
+        let out = realize_at(&read, reference, 4);
+        assert_eq!(cigar_string(&out), "20M");
+        assert_eq!(out.edit_distance, 1);
+        assert_eq!(out.md, "5C14");
+    }
+
+    /// A deleted reference stretch becomes a `D` operation, is counted in `NM`,
+    /// and is spelled out after a `^` in `MD`.
+    #[test]
+    fn deletion_produces_a_d_operation_and_caret_in_md() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAA";
+        let mut read = Vec::new();
+        read.extend_from_slice(&reference[2..12]);
+        read.extend_from_slice(&reference[15..27]);
+        let out = realize_at(&read, reference, 2);
+        assert_eq!(out.ref_start, 2);
+        assert_eq!(cigar_string(&out), "10M3D12M");
+        assert_eq!(out.edit_distance, 3);
+        assert!(
+            out.md.contains('^'),
+            "MD should mark the deletion: {}",
+            out.md
+        );
+    }
+
+    /// Bases inserted in the read become an `I` operation and count toward `NM`,
+    /// but leave no trace in `MD`, `MD` describes the reference.
+    #[test]
+    fn insertion_produces_an_i_operation() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAA";
+        let mut read = Vec::new();
+        read.extend_from_slice(&reference[2..14]);
+        read.extend_from_slice(b"GTA");
+        read.extend_from_slice(&reference[14..26]);
+        let out = realize_at(&read, reference, 2);
+        assert_eq!(cigar_string(&out), "12M3I12M");
+        assert_eq!(out.edit_distance, 3);
+        assert_eq!(out.md, "24");
+    }
+
+    /// A read hanging off the 5' end of the transcript is clipped, not placed at a
+    /// negative position.
+    #[test]
+    fn overhang_at_the_start_becomes_a_leading_clip() {
+        let reference = b"ACGTACGTACGTACGTACGTACGTACGTACGT";
+        let mut read = b"TTTT".to_vec();
+        read.extend_from_slice(&reference[0..16]);
+        let out = realize_at(&read, reference, -4);
+        assert_eq!(out.ref_start, 0);
+        assert_eq!(cigar_string(&out), "4S16M");
+        assert_eq!(out.edit_distance, 0);
+    }
+
+    /// A read running past the 3' end is clipped there instead of claiming
+    /// reference bases that do not exist.
+    #[test]
+    fn overhang_at_the_end_becomes_a_trailing_clip() {
+        let reference = b"ACGTACGTACGTACGTACGTACGTACGTACGT";
+        let mut read = reference[24..].to_vec();
+        read.extend_from_slice(b"TTTTTT");
+        let out = realize_at(&read, reference, 24);
+        assert_eq!(out.ref_start, 24);
+        assert_eq!(cigar_string(&out), "8M6S");
+    }
+
+    /// A reverse-strand read is realized against the forward reference, matching
+    /// what SAM stores in `SEQ`.
+    #[test]
+    fn reverse_strand_reads_are_realized_on_the_forward_strand() {
+        let reference = b"ACGTACGTTTGGCCAAGGTTACGTACGTACGT";
+        let forward = &reference[6..26];
+        let read: Vec<u8> = forward.iter().rev().map(|&b| complement(b)).collect();
+        let mut scratch = RealizeScratch::default();
+        let mut out = RealizedAlignment::default();
+        assert!(realize(
+            &read,
+            false,
+            reference,
+            &[],
+            6,
+            &config(),
+            &mut scratch,
+            &mut out
+        ));
+        assert_eq!(cigar_string(&out), "20M");
+        assert_eq!(out.edit_distance, 0);
+        assert_eq!(out.md, "20");
+    }
+
+    /// The mapper's position comes from a seed chain, and a mismatch near the
+    /// read's 5' end pushes that chain rightwards. Anchoring the read there
+    /// leaves the DP no way to say "it started earlier" except with a leading
+    /// insertion, which is a worse alignment and a false one. The anchor has to
+    /// be corrected from the alignment itself.
+    #[test]
+    fn a_late_anchor_is_pulled_back_instead_of_becoming_an_insertion() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAAACGTACGTTTGGCCAA";
+        let mut read = reference[4..44].to_vec();
+        read[3] = complement(read[3]);
+        // Hand it a position 8 bases past the read's true start.
+        let out = realize_at(&read, reference, 12);
+        assert_eq!(cigar_string(&out), "40M");
+        assert_eq!(out.ref_start, 4);
+        assert_eq!(out.edit_distance, 1);
+    }
+
+    /// The anchor repair has to see offsets the DP's band cannot, which is the
+    /// whole reason it exists: it slides the read by comparison, so a start that
+    /// is wrong by more than the bandwidth is still found.
+    #[test]
+    fn a_badly_placed_read_is_slid_back_further_than_the_band() {
+        let cfg = config();
+        assert!(
+            cfg.indel_margin as i32 > cfg.bandwidth,
+            "this test is only meaningful when the offset can exceed the band"
+        );
+        let reference = nonrepeating(400);
+        let read = &reference[60..160];
+        // Anchored 25 bases late, well past the bandwidth of 15.
+        assert_eq!(
+            repair_anchor(read, &reference, 85, &cfg, &mut Vec::new()).map(|(p, _)| p),
+            Some(60)
+        );
+        let out = realize_at(read, &reference, 85);
+        assert_eq!(cigar_string(&out), "100M");
+        assert_eq!(out.ref_start, 60);
+        assert_eq!(out.edit_distance, 0);
+    }
+
+    /// A read that is where it belongs must not be slid. Sequencing errors are
+    /// not evidence of a wrong anchor, and scanning for one would cost more than
+    /// the alignment it replaces.
+    #[test]
+    fn a_correctly_placed_read_is_left_alone() {
+        let cfg = config();
+        let reference = nonrepeating(400);
+        let mut read = reference[60..160].to_vec();
+        for i in [10usize, 41, 77] {
+            read[i] = complement(read[i]);
+        }
+        assert_eq!(
+            repair_anchor(&read, &reference, 60, &cfg, &mut Vec::new()),
+            None
+        );
+        let out = realize_at(&read, &reference, 60);
+        assert_eq!(cigar_string(&out), "100M");
+        assert_eq!(out.ref_start, 60);
+        assert_eq!(out.edit_distance, 3);
+    }
+
+    /// A seed chain on a repeat can imply a start most of a read away from the
+    /// truth. The old search reached only `indel_margin`, which is a bound on
+    /// indel size and has nothing to do with how wrong an anchor can be, so the
+    /// banded DP was left to describe a read that was nowhere near where it was
+    /// placed. It obliged, with a sawtooth of one-base indels walking the read
+    /// diagonally across the reference: a valid CIGAR and a false claim.
+    #[test]
+    fn an_anchor_wrong_by_most_of_a_read_is_still_found() {
+        let reference = nonrepeating(600);
+        let read = &reference[200..300];
+        // 69 bases late, far past indel_margin.
+        let out = realize_at(read, &reference, 269);
+        assert_eq!(cigar_string(&out), "100M");
+        assert_eq!(out.ref_start, 200);
+        assert_eq!(out.edit_distance, 0);
+    }
+
+    /// When no anchor produces an alignment the mapper would have accepted, the
+    /// honest answer is no base-level alignment at all. Publishing the DP's
+    /// best-effort sawtooth would contradict the `AS` on the same record.
+    #[test]
+    fn an_unplaceable_read_is_refused_rather_than_described() {
+        let reference = nonrepeating(600);
+        let read = nonrepeating(100);
+        let mut scratch = RealizeScratch::default();
+        let mut out = RealizedAlignment::default();
+        assert!(
+            !realize(
+                &read,
+                true,
+                &reference,
+                &[],
+                250,
+                &config(),
+                &mut scratch,
+                &mut out
+            ),
+            "an unrelated read should not be given a CIGAR"
+        );
+        assert!(out.ops.is_empty());
+    }
+
+    /// An insertion at the very edge of an alignment claims nothing and inflates
+    /// NM; a soft clip says the same thing honestly.
+    #[test]
+    fn edge_insertions_become_soft_clips() {
+        let mut out = RealizedAlignment {
+            ops: vec![
+                CigarOp::new(CigarOpKind::Insertion, 3),
+                CigarOp::new(CigarOpKind::Match, 20),
+                CigarOp::new(CigarOpKind::Insertion, 2),
+            ],
+            edit_distance: 5,
+            ..RealizedAlignment::default()
+        };
+        clip_edge_insertions(&mut out);
+        assert_eq!(cigar_string(&out), "3S20M2S");
+        assert_eq!(out.edit_distance, 0);
+    }
+
+    /// A base the index had to replace is reported as the `N` it was in the
+    /// input, not as the substitute the index stores. Otherwise the record
+    /// describes a reference the user never supplied, and disagrees with the
+    /// `M5` on its own `@SQ` line.
+    #[test]
+    fn a_replaced_base_is_reported_as_n() {
+        let reference = nonrepeating(200);
+        let read = &reference[50..150];
+        // Offset 80 of the reference held a non-ACGT base at index time.
+        let mut scratch = RealizeScratch::default();
+        let mut out = RealizedAlignment::default();
+        assert!(realize(
+            read,
+            true,
+            &reference,
+            &[80],
+            50,
+            &config(),
+            &mut scratch,
+            &mut out
+        ));
+        assert_eq!(cigar_string(&out), "100M");
+        // The read agrees with the stored base, but the reference base is unknown,
+        // so it counts as an edit and MD names it.
+        assert_eq!(out.edit_distance, 1);
+        assert_eq!(out.md, "30N69");
+    }
+
+    /// `MD` and `NM` must be consistent with the CIGAR: every `M` base is either
+    /// counted in a run or named as a mismatch, so the run lengths plus the named
+    /// bases add back up to the aligned length.
+    #[test]
+    fn md_covers_every_aligned_reference_base() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAA";
+        let mut read = reference[3..30].to_vec();
+        read[4] = complement(read[4]);
+        read[19] = complement(read[19]);
+        let out = realize_at(&read, reference, 3);
+        let mut covered = 0usize;
+        let mut digits = String::new();
+        let mut chars = out.md.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c.is_ascii_digit() {
+                digits.push(c);
+                continue;
+            }
+            covered += digits.parse::<usize>().unwrap_or(0);
+            digits.clear();
+            if c == '^' {
+                while chars.peek().is_some_and(|n| n.is_ascii_alphabetic()) {
+                    chars.next();
+                    covered += 1;
+                }
+            } else {
+                covered += 1;
+            }
+        }
+        covered += digits.parse::<usize>().unwrap_or(0);
+        assert_eq!(covered, reference_span(&out.ops) as usize);
+        assert_eq!(out.edit_distance, 2);
+    }
+
+    /// Realizing must never produce a CIGAR whose read length disagrees with the
+    /// read: that is the single check every SAM validator makes first.
+    #[test]
+    fn cigar_read_length_always_matches_the_read() {
+        let reference = b"ACGTTTTTGGGGCCCCAAAATTTTGGGGCCCCAAAAACGTACGT";
+        for start in 0..20i32 {
+            for len in [12usize, 25, 31] {
+                let end = (start as usize + len).min(reference.len());
+                if end <= start as usize {
+                    continue;
+                }
+                let read = &reference[start as usize..end];
+                let mut scratch = RealizeScratch::default();
+                let mut out = RealizedAlignment::default();
+                if !realize(
+                    read,
+                    true,
+                    reference,
+                    &[],
+                    start,
+                    &config(),
+                    &mut scratch,
+                    &mut out,
+                ) {
+                    continue;
+                }
+                let consumed: u32 = out
+                    .ops
+                    .iter()
+                    .filter(|op| op.kind.consumes_read())
+                    .map(|op| op.len)
+                    .sum();
+                assert_eq!(consumed as usize, read.len(), "start={start} len={len}");
+            }
+        }
+    }
+}

--- a/crates/salmon-quant/src/bam.rs
+++ b/crates/salmon-quant/src/bam.rs
@@ -48,7 +48,7 @@ use noodles_bgzf as bgzf;
 use salmon_index::SalmonIndex;
 use salmon_map::ScoredMapping;
 
-use crate::mapping_record::{self, AlignmentRecord, CigarKind};
+use crate::mapping_record::{self, AlignmentRecord, EmitScratch, RecordOptions};
 
 /// Hand a chunk to the writer once it reaches this size. Large enough that the
 /// per-chunk handoff is negligible, small enough to bound queued memory.
@@ -318,6 +318,7 @@ impl BamScratch<'_> {
     /// therefore contiguous in one chunk, and chunks are written whole. That is
     /// what keeps the output collated by fragment even though nothing else
     /// about the record order is constrained.
+    #[allow(clippy::too_many_arguments)]
     pub fn write_fragment(
         &mut self,
         salmon: &SalmonIndex,
@@ -325,10 +326,20 @@ impl BamScratch<'_> {
         r1_seq: &[u8],
         r2: Option<(&[u8], &[u8])>,
         maps: &[ScoredMapping],
+        options: &RecordOptions<'_>,
+        scratch: &mut EmitScratch,
     ) -> io::Result<()> {
-        mapping_record::emit_fragment_records(salmon, r1_id, r1_seq, r2, maps, |record| {
-            encode_record(&mut self.buffer, record)
-        })?;
+        let buffer = &mut self.buffer;
+        mapping_record::emit_fragment_records(
+            salmon,
+            r1_id,
+            r1_seq,
+            r2,
+            maps,
+            options,
+            scratch,
+            |record| encode_record(buffer, record),
+        )?;
         if self.buffer.len() >= CHUNK_TARGET {
             self.flush()?;
         }
@@ -457,6 +468,14 @@ fn push_aux_i64(buf: &mut Vec<u8>, tag: [u8; 2], value: i64) {
     }
 }
 
+/// Append a NUL-terminated string tag (`Z`).
+fn push_aux_str(buf: &mut Vec<u8>, tag: [u8; 2], value: &str) {
+    buf.extend_from_slice(&tag);
+    buf.push(b'Z');
+    buf.extend_from_slice(value.as_bytes());
+    buf.push(0);
+}
+
 /// Encode one record in BAM's binary layout: a fixed 32-byte header, then the
 /// variable-length name, CIGAR, packed sequence, qualities and tags.
 ///
@@ -466,23 +485,29 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
     // reserve the four bytes now and patch them in below.
     let block_start = buf.len();
     push_u32(buf, 0);
-    push_i32(buf, record.reference_id as i32);
-    push_i32(buf, record.position.max(0));
+    // An unmapped record has no reference and no position; BAM spells both -1.
+    push_i32(buf, record.reference_id.map_or(-1, |id| id as i32));
+    push_i32(
+        buf,
+        if record.reference_id.is_some() {
+            record.position.max(0)
+        } else {
+            -1
+        },
+    );
     let name_len = record.name.len() + 1;
-    let cigar_len = record.cigar.as_slice().len();
-    let reference_span: i32 = record
-        .cigar
-        .as_slice()
-        .iter()
-        .filter(|op| matches!(op.kind, CigarKind::Match))
-        .map(|op| op.len as i32)
-        .sum();
+    let cigar_len = record.cigar.len();
+    let reference_span = salmon_map::realize::reference_span(record.cigar);
     buf.push(u8::try_from(name_len).map_err(|_| io::Error::other("BAM read name too long"))?);
     buf.push(record.mapping_quality);
     buf.extend_from_slice(
         &reg2bin(record.position, record.position + reference_span).to_le_bytes(),
     );
-    buf.extend_from_slice(&(cigar_len as u16).to_le_bytes());
+    buf.extend_from_slice(
+        &u16::try_from(cigar_len)
+            .map_err(|_| io::Error::other("BAM CIGAR too long"))?
+            .to_le_bytes(),
+    );
     buf.extend_from_slice(&record.flags.to_le_bytes());
     push_i32(buf, record.sequence.len() as i32);
     push_i32(buf, record.mate_reference_id.map_or(-1, |id| id as i32));
@@ -490,12 +515,8 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
     push_i32(buf, record.template_length);
     buf.extend_from_slice(record.name);
     buf.push(0);
-    for op in record.cigar.as_slice() {
-        let code = match op.kind {
-            CigarKind::Match => 0,
-            CigarKind::SoftClip => 4,
-        };
-        push_u32(buf, ((op.len as u32) << 4) | code);
+    for op in record.cigar {
+        push_u32(buf, (op.len << 4) | op.kind as u32);
     }
     for i in (0..record.sequence.len()).step_by(2) {
         let high = base_code(record_base(record, i));
@@ -514,6 +535,12 @@ fn encode_record(buf: &mut Vec<u8>, record: &AlignmentRecord<'_>) -> io::Result<
     buf.extend_from_slice(b"XTA");
     buf.push(record.xt);
     push_aux_i64(buf, *b"AS", record.alignment_score as i64);
+    if let Some(edit_distance) = record.edit_distance {
+        push_aux_i64(buf, *b"NM", edit_distance as i64);
+    }
+    if let Some(md) = record.md {
+        push_aux_str(buf, *b"MD", md);
+    }
     // Patch the reserved length field now the record's extent is known (`- 4`
     // because the length itself is not counted).
     let block_size = u32::try_from(buf.len() - block_start - 4)

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -34,7 +34,7 @@
 
 mod bam;
 pub mod decode;
-mod mapping_record;
+pub mod mapping_record;
 mod output;
 mod processor;
 mod sam;
@@ -466,6 +466,14 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     } else {
         opts.num_threads
     };
+    // Run-wide mapping-output settings, shared by the header and every record so
+    // the two cannot disagree. Realizing a base-level CIGAR costs two banded DPs
+    // per emitted record, so it is only switched on when records are being
+    // written at all.
+    let record_options = mapping_record::RecordOptions {
+        align_config: (opts.write_mappings.is_some() || opts.write_bam.is_some())
+            .then_some(&opts.map_config.align),
+    };
     // SAM sink for `--writeMappings` (header written here).
     let sam_writer: Option<sam::SamWriter> = match &opts.write_mappings {
         Some(path) => {
@@ -685,6 +693,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         )?;
 
         let shared = Shared {
+            record_options: &record_options,
             busy: &plan.busy,
             salmon: &salmon,
             eq: &eq_builder,

--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -9,24 +9,39 @@
 //! [`emit_fragment_records`], and hands each format a borrowed record to
 //! serialize. The header is shared the same way, via [`header_text`].
 //!
-//! "Borrowed" means the record points at the caller's read name and sequence
-//! rather than copying them, so emitting a mapping allocates nothing.
+//! "Borrowed" means the record points at the caller's read name, sequence and
+//! qualities rather than copying them, so emitting a mapping allocates nothing
+//! beyond the reusable scratch in [`EmitScratch`].
 //!
 //! # Background: SAM records
 //!
 //! A SAM record describes one read's placement: which reference, at what
 //! position, in which orientation, and how the read's bases line up with the
-//! reference. The alignment shape is a CIGAR string — here only `M` (bases
-//! consuming both read and reference) and `S` (soft-clipped: present in the read,
-//! not aligned). salmon does not compute a base-level alignment, so it emits a
-//! spoofed `<readLen>M` with soft clips where the read overhangs a transcript end.
+//! reference. The alignment shape is a CIGAR string.
+//!
+//! # Two grades of CIGAR
+//!
+//! Mapping scores candidate placements without keeping a base-level alignment
+//! (see [`salmon_map::realize`] for why), so there are two ways to describe a
+//! placement:
+//!
+//! * **Realized**, the placement is re-aligned with traceback, giving real `I`
+//!   and `D` operations, an `NM` edit distance and an `MD` string. This is what
+//!   gets written whenever the reference sequence is available, and it is what
+//!   makes the output usable by tools that expect a genuine alignment.
+//! * **Spoofed**, `<readLen>M` with soft clips where the read overhangs a
+//!   transcript end. The fallback for when realization cannot run (an index
+//!   without reference sequence) or cannot form an alignment.
 
 use std::io;
 
 use salmon_core::MateStatus;
 use salmon_core::RefProvider as _;
 use salmon_index::SalmonIndex;
-use salmon_map::ScoredMapping;
+use salmon_map::realize::{
+    push_op, realize, CigarOp, CigarOpKind, RealizeScratch, RealizedAlignment,
+};
+use salmon_map::{AlignConfig, ScoredMapping};
 
 // SAM FLAG bits (a bitfield in field 2 of every record). Each names one yes/no
 // property of the alignment; a record's flags are these OR-ed together.
@@ -34,6 +49,8 @@ use salmon_map::ScoredMapping;
 pub const PAIRED: u16 = 0x1;
 /// Both mates placed consistently (right orientation, plausible distance).
 pub const PROPER_PAIR: u16 = 0x2;
+/// This read did not map anywhere.
+pub const UNMAPPED: u16 = 0x4;
 /// This read's mate did not map (an orphan).
 pub const MATE_UNMAPPED: u16 = 0x8;
 /// This read aligns to the reverse strand, so its stored sequence is the
@@ -50,58 +67,59 @@ pub const READ2: u16 = 0x80;
 /// avoid counting a multi-mapping fragment several times.
 pub const SECONDARY: u16 = 0x100;
 
-#[derive(Clone, Copy)]
-pub enum CigarKind {
-    Match,
-    SoftClip,
-}
-
-#[derive(Clone, Copy)]
-pub struct CigarOp {
-    pub kind: CigarKind,
-    pub len: usize,
-}
-
-/// A CIGAR of at most two operations, stored inline.
-///
-/// salmon's spoofed alignments never need more than two (`M`, or a clip plus a
-/// match at an overhanging end), so a fixed array avoids allocating one `Vec` per
-/// emitted record.
-#[derive(Clone, Copy)]
-pub struct Cigar {
-    ops: [CigarOp; 2],
-    len: usize,
-}
-
-impl Cigar {
-    pub fn as_slice(&self) -> &[CigarOp] {
-        &self.ops[..self.len]
-    }
-}
-
 /// One read's placement, with every field already in the form both writers need.
-/// The `'a` lifetime ties the borrowed name and sequence to the caller's buffers.
+/// The `'a` lifetime ties the borrowed name, sequence, qualities and CIGAR to the
+/// caller's buffers.
 pub struct AlignmentRecord<'a> {
     pub name: &'a [u8],
     pub flags: u16,
-    pub reference_id: usize,
+    /// `None` for an unmapped record, which SAM writes as `*` and BAM as `-1`.
+    pub reference_id: Option<usize>,
     pub position: i32,
     pub mapping_quality: u8,
-    pub cigar: Cigar,
+    pub cigar: &'a [CigarOp],
     pub mate_reference_id: Option<usize>,
     pub mate_position: Option<i32>,
     pub template_length: i32,
     pub sequence: &'a [u8],
+    /// Whether the stored sequence has to be reversed, because the read aligns to
+    /// the reverse strand and SAM stores everything on the reference's forward
+    /// strand.
     pub reverse_complement: bool,
     pub nh: usize,
     pub hi: usize,
     pub xt: u8,
     pub alignment_score: i32,
+    /// `NM`, present only for a realized alignment.
+    pub edit_distance: Option<u32>,
+    /// `MD`, present only for a realized alignment.
+    pub md: Option<&'a str>,
 }
 
-/// SAM version reported in `@HD VN:`. Shared by SAM and BAM so the two formats
-/// cannot drift; kept at `1.0` to match C++ salmon's `--writeMappings` header
-/// byte-for-byte.
+/// Everything about mapping output that is fixed for a whole run, rather than
+/// derived per record.
+#[derive(Default)]
+pub struct RecordOptions<'a> {
+    /// When set, placements are re-aligned to produce a real CIGAR plus `NM` and
+    /// `MD`. `None` keeps the spoofed `<readLen>M` CIGAR and omits both tags.
+    pub align_config: Option<&'a AlignConfig>,
+}
+
+/// Reusable per-worker buffers for record emission.
+///
+/// Realizing an alignment needs somewhere to put the CIGAR, the `MD` string and
+/// the aligner's own workspace. Keeping them here means a worker allocates them
+/// once rather than once per record.
+#[derive(Default)]
+pub struct EmitScratch {
+    realize_scratch: RealizeScratch,
+    /// Realized alignments for the two mates of the fragment being emitted.
+    realized: [RealizedAlignment; 2],
+    /// Spoofed CIGARs, used when realization is off or fails.
+    spoofed: [Vec<CigarOp>; 2],
+}
+
+/// SAM version reported in `@HD VN:`, kept at C++ salmon's value.
 const SAM_VERSION: &str = "1.0";
 
 /// The header text shared by both mapping-output formats: `@HD`, one `@SQ` per
@@ -137,7 +155,7 @@ pub fn header_text(salmon: &SalmonIndex, command: &str) -> String {
 /// a trailing `/1` or `/2` mate suffix removed.
 ///
 /// Both mates of a pair must carry the *same* name for a SAM/BAM reader to pair
-/// them up, but many FASTQ files distinguish them with that suffix — so it has to
+/// them up, but many FASTQ files distinguish them with that suffix, so it has to
 /// go.
 pub fn read_name(id: &[u8]) -> &[u8] {
     let end = id
@@ -198,86 +216,146 @@ pub fn mapping_quality(nh: usize) -> u8 {
 }
 
 /// The CIGAR and clamped position for a read placed at `pos` on a transcript of
-/// length `txp_len`.
+/// length `txp_len`, without a base-level alignment.
 ///
-/// A read can hang off either end of a transcript — the mapper places it by seed
+/// A read can hang off either end of a transcript, the mapper places it by seed
 /// position, and the fragment may genuinely extend past the annotated boundary.
 /// SAM cannot express a negative position or an alignment past the reference end,
 /// so the overhanging bases are soft-clipped and the position clamped into range.
-/// Returns the CIGAR and the position to report.
-fn overhang_cigar(pos: i32, read_len: i32, txp_len: i32) -> (Cigar, i32) {
-    let read_len = read_len.max(0) as usize;
-    let empty = CigarOp {
-        kind: CigarKind::Match,
-        len: 0,
-    };
-    let one = |kind, len| Cigar {
-        ops: [CigarOp { kind, len }, empty],
-        len: 1,
-    };
-    let two = |a, b| Cigar {
-        ops: [a, b],
-        len: 2,
-    };
-    if pos + (read_len as i32) < 0 {
-        (one(CigarKind::SoftClip, read_len), 0)
+fn overhang_cigar(ops: &mut Vec<CigarOp>, pos: i32, read_len: i32, txp_len: i32) -> i32 {
+    ops.clear();
+    let read_len_u = read_len.max(0) as u32;
+    if pos + read_len < 0 {
+        push_op(ops, CigarOpKind::SoftClip, read_len_u);
+        0
     } else if pos < 0 {
-        let matched = (read_len as i32 + pos).max(0) as usize;
-        (
-            two(
-                CigarOp {
-                    kind: CigarKind::SoftClip,
-                    len: read_len - matched,
-                },
-                CigarOp {
-                    kind: CigarKind::Match,
-                    len: matched,
-                },
-            ),
-            0,
-        )
+        let matched = (read_len + pos).max(0) as u32;
+        push_op(ops, CigarOpKind::SoftClip, read_len_u - matched);
+        push_op(ops, CigarOpKind::Match, matched);
+        0
     } else if pos > txp_len {
-        (one(CigarKind::SoftClip, read_len), pos)
-    } else if pos + read_len as i32 > txp_len {
-        let matched = (txp_len - pos).max(0) as usize;
-        (
-            two(
-                CigarOp {
-                    kind: CigarKind::Match,
-                    len: matched,
-                },
-                CigarOp {
-                    kind: CigarKind::SoftClip,
-                    len: read_len - matched,
-                },
-            ),
-            pos,
-        )
+        push_op(ops, CigarOpKind::SoftClip, read_len_u);
+        pos
+    } else if pos + read_len > txp_len {
+        let matched = (txp_len - pos).max(0) as u32;
+        push_op(ops, CigarOpKind::Match, matched);
+        push_op(ops, CigarOpKind::SoftClip, read_len_u - matched);
+        pos
     } else {
-        (one(CigarKind::Match, read_len), pos)
+        push_op(ops, CigarOpKind::Match, read_len_u);
+        pos
     }
 }
 
-/// Emit borrowed records immediately; no record, name, sequence, CIGAR, or tag
-/// allocation is retained between callback invocations.
+/// One mate's placement after CIGAR derivation: everything that differs between
+/// the realized and spoofed paths, resolved.
+struct Placed {
+    position: i32,
+    edit_distance: Option<u32>,
+    /// The realized alignment's own score, when there is one. `AS` reports this
+    /// in preference to the mapper's, so that the score, the CIGAR and `NM`
+    /// describe the same alignment.
+    score: Option<i32>,
+    /// Which of [`EmitScratch`]'s two mate slots holds this placement's CIGAR.
+    slot: usize,
+    /// Whether that CIGAR is in `realized` (`true`) or `spoofed` (`false`).
+    realized: bool,
+}
+
+/// Derive one mate's CIGAR and start position, realizing the alignment when the
+/// run asked for it and the reference sequence is there to align against.
+///
+/// Falls back to the spoofed CIGAR silently: a missing reference sequence is a
+/// property of the index, not an error, and a record with a spoofed CIGAR is
+/// still a valid record.
+#[allow(clippy::too_many_arguments)]
+fn place(
+    scratch: &mut EmitScratch,
+    slot: usize,
+    options: &RecordOptions<'_>,
+    salmon: &SalmonIndex,
+    tid: usize,
+    sequence: &[u8],
+    forward: bool,
+    pos: i32,
+    txp_len: i32,
+) -> Placed {
+    if let Some(cfg) = options.align_config {
+        let ref_seq = salmon.ref_seq(tid as u32);
+        if !ref_seq.is_empty() && !sequence.is_empty() {
+            let EmitScratch {
+                realize_scratch,
+                realized,
+                ..
+            } = scratch;
+            if realize(
+                sequence,
+                forward,
+                ref_seq,
+                salmon.ambiguous_offsets(tid),
+                pos,
+                cfg,
+                realize_scratch,
+                &mut realized[slot],
+            ) {
+                return Placed {
+                    position: realized[slot].ref_start,
+                    edit_distance: Some(realized[slot].edit_distance),
+                    score: Some(realized[slot].score),
+                    slot,
+                    realized: true,
+                };
+            }
+        }
+    }
+    let position = overhang_cigar(
+        &mut scratch.spoofed[slot],
+        pos,
+        sequence.len() as i32,
+        txp_len,
+    );
+    Placed {
+        position,
+        edit_distance: None,
+        score: None,
+        slot,
+        realized: false,
+    }
+}
+
+/// The CIGAR and `MD` a [`Placed`] refers to, borrowed out of the scratch.
+fn borrow_cigar<'s>(scratch: &'s EmitScratch, placed: &Placed) -> (&'s [CigarOp], Option<&'s str>) {
+    if placed.realized {
+        let realized = &scratch.realized[placed.slot];
+        (&realized.ops, Some(realized.md.as_str()))
+    } else {
+        (&scratch.spoofed[placed.slot], None)
+    }
+}
+
+/// Emit borrowed records immediately; no record, name, sequence or tag allocation
+/// is retained between callback invocations.
 ///
 /// This is the single source of truth for record bodies: one call per fragment
 /// produces every record that fragment implies (two per placement for a proper
 /// pair, one otherwise), and the caller's closure serializes them as SAM text or
-/// BAM binary. The callback style is what keeps it allocation-free — nothing is
-/// collected into a vector to be handed back.
+/// BAM binary.
+#[allow(clippy::too_many_arguments)]
 pub fn emit_fragment_records(
     salmon: &SalmonIndex,
     r1_id: &[u8],
     r1_seq: &[u8],
     r2: Option<(&[u8], &[u8])>,
     maps: &[ScoredMapping],
-    mut emit: impl FnMut(&AlignmentRecord<'_>) -> io::Result<()>,
+    options: &RecordOptions<'_>,
+    scratch: &mut EmitScratch,
+    emit_record: impl FnMut(&AlignmentRecord<'_>) -> io::Result<()>,
 ) -> io::Result<()> {
     let name1 = read_name(r1_id);
     let (name2, r2_seq) = r2.map_or((name1, &[][..]), |(id, seq)| (read_name(id), seq));
     let nh = maps.len();
     let mapq = mapping_quality(nh);
+    let mut emit = emit_record;
 
     for (index, mapping) in maps.iter().enumerate() {
         // The first placement is primary; the rest are marked secondary so a
@@ -287,18 +365,42 @@ pub fn emit_fragment_records(
         let hi = index + 1;
         let tid = mapping.tid as usize;
         let txp_len = salmon.ref_len(tid) as i32;
-        // salmon's XT tag: `T` for a transcript placement, `D` for a decoy, so a
-        // reader can tell which placements were sinks rather than real targets.
+        // salmon's XT tag. In practice it is always `T`: a placement on a decoy
+        // means the read probably came from no transcript at all, so scoring
+        // drops it long before a record is written, and a decoy-aware run was
+        // confirmed to emit no `D` at all. The branch stays because the tag is
+        // defined over the reference table, not over what currently survives
+        // filtering, and a future policy that kept decoy placements would need
+        // it to be right.
         let xt = if salmon.is_decoy(mapping.tid) {
             b'D'
         } else {
             b'T'
         };
-
         match mapping.status {
             MateStatus::PairedEndPaired => {
-                let (c1, p1) = overhang_cigar(mapping.r1_pos, r1_seq.len() as i32, txp_len);
-                let (c2, p2) = overhang_cigar(mapping.r2_pos, r2_seq.len() as i32, txp_len);
+                let p1 = place(
+                    scratch,
+                    0,
+                    options,
+                    salmon,
+                    tid,
+                    r1_seq,
+                    mapping.is_fw,
+                    mapping.r1_pos,
+                    txp_len,
+                );
+                let p2 = place(
+                    scratch,
+                    1,
+                    options,
+                    salmon,
+                    tid,
+                    r2_seq,
+                    mapping.r2_fw,
+                    mapping.r2_pos,
+                    txp_len,
+                );
                 // TLEN is the observed template (fragment) length, truncated at
                 // the transcript end for the same reason positions are clamped.
                 let mut fragment_length = mapping.fragment_len;
@@ -325,49 +427,65 @@ pub fn emit_fragment_records(
                     f2 |= IS_RC;
                     f1 |= MATE_RC;
                 }
+                let (cigar1, md1) = borrow_cigar(scratch, &p1);
+                let (cigar2, md2) = borrow_cigar(scratch, &p2);
                 emit(&AlignmentRecord {
                     name: name1,
                     flags: f1,
-                    reference_id: tid,
-                    position: p1,
+                    reference_id: Some(tid),
+                    position: p1.position,
                     mapping_quality: mapq,
-                    cigar: c1,
+                    cigar: cigar1,
                     mate_reference_id: Some(tid),
-                    mate_position: Some(p2),
+                    mate_position: Some(p2.position),
                     template_length: tlen1,
                     sequence: r1_seq,
                     reverse_complement: !mapping.is_fw,
                     nh,
                     hi,
                     xt,
-                    alignment_score: mapping.r1_score,
+                    alignment_score: p1.score.unwrap_or(mapping.r1_score),
+                    edit_distance: p1.edit_distance,
+                    md: md1,
                 })?;
                 emit(&AlignmentRecord {
                     name: name2,
                     flags: f2,
-                    reference_id: tid,
-                    position: p2,
+                    reference_id: Some(tid),
+                    position: p2.position,
                     mapping_quality: mapq,
-                    cigar: c2,
+                    cigar: cigar2,
                     mate_reference_id: Some(tid),
-                    mate_position: Some(p1),
+                    mate_position: Some(p1.position),
                     template_length: -tlen1,
                     sequence: r2_seq,
                     reverse_complement: !mapping.r2_fw,
                     nh,
                     hi,
                     xt,
-                    alignment_score: mapping.score - mapping.r1_score,
+                    alignment_score: p2.score.unwrap_or(mapping.score - mapping.r1_score),
+                    edit_distance: p2.edit_distance,
+                    md: md2,
                 })?;
             }
             MateStatus::SingleEnd => {
-                let (cigar, position) =
-                    overhang_cigar(mapping.r1_pos, r1_seq.len() as i32, txp_len);
+                let p = place(
+                    scratch,
+                    0,
+                    options,
+                    salmon,
+                    tid,
+                    r1_seq,
+                    mapping.is_fw,
+                    mapping.r1_pos,
+                    txp_len,
+                );
+                let (cigar, md) = borrow_cigar(scratch, &p);
                 emit(&AlignmentRecord {
                     name: name1,
                     flags: secondary | if mapping.is_fw { 0 } else { IS_RC },
-                    reference_id: tid,
-                    position,
+                    reference_id: Some(tid),
+                    position: p.position,
                     mapping_quality: mapq,
                     cigar,
                     mate_reference_id: None,
@@ -378,7 +496,9 @@ pub fn emit_fragment_records(
                     nh,
                     hi,
                     xt,
-                    alignment_score: mapping.r1_score,
+                    alignment_score: p.score.unwrap_or(mapping.r1_score),
+                    edit_distance: p.edit_distance,
+                    md,
                 })?;
             }
             // Orphan: one mate placed, the other not. One record is emitted, for
@@ -405,7 +525,10 @@ pub fn emit_fragment_records(
                         READ2,
                     )
                 };
-                let (cigar, position) = overhang_cigar(position, sequence.len() as i32, txp_len);
+                let p = place(
+                    scratch, 0, options, salmon, tid, sequence, forward, position, txp_len,
+                );
+                let (cigar, md) = borrow_cigar(scratch, &p);
                 emit(&AlignmentRecord {
                     name,
                     flags: PAIRED
@@ -413,10 +536,12 @@ pub fn emit_fragment_records(
                         | read_flag
                         | secondary
                         | if forward { 0 } else { IS_RC },
-                    reference_id: tid,
-                    position,
+                    reference_id: Some(tid),
+                    position: p.position,
                     mapping_quality: mapq,
                     cigar,
+                    // The mate did not map and no record is written for it, so
+                    // naming a mate position would be a dangling reference.
                     mate_reference_id: None,
                     mate_position: None,
                     template_length: 0,
@@ -425,11 +550,14 @@ pub fn emit_fragment_records(
                     nh,
                     hi,
                     xt,
-                    alignment_score: score,
+                    alignment_score: p.score.unwrap_or(score),
+                    edit_distance: p.edit_distance,
+                    md,
                 })?;
             }
         }
     }
+
     Ok(())
 }
 
@@ -437,7 +565,8 @@ pub fn emit_fragment_records(
 mod tests {
     use super::*;
 
-    /// MAPQ has to distinguish a uniquely placed fragment from an ambiguous one.
+    /// MAPQ has to distinguish a uniquely placed fragment from an ambiguous one;
+    /// the old constant 1 said "ambiguous" for every record ever written.
     #[test]
     fn mapping_quality_follows_the_star_convention() {
         assert_eq!(mapping_quality(1), 255);
@@ -445,7 +574,31 @@ mod tests {
         assert_eq!(mapping_quality(3), 1);
         assert_eq!(mapping_quality(4), 1);
         assert_eq!(mapping_quality(5), 0);
+        assert_eq!(mapping_quality(100), 0);
         // An unmapped record has no placement to be confident about.
         assert_eq!(mapping_quality(0), 0);
+    }
+
+    /// The spoofed CIGAR still has to describe the whole read, clip included, at
+    /// both transcript ends and when the read misses the transcript entirely.
+    #[test]
+    fn spoofed_cigar_always_covers_the_read() {
+        let mut ops = Vec::new();
+        for (pos, read_len, txp_len) in [
+            (0, 100, 1000),
+            (-20, 100, 1000),
+            (-200, 100, 1000),
+            (950, 100, 1000),
+            (1200, 100, 1000),
+        ] {
+            let reported = overhang_cigar(&mut ops, pos, read_len, txp_len);
+            let covered: u32 = ops
+                .iter()
+                .filter(|op| op.kind.consumes_read())
+                .map(|op| op.len)
+                .sum();
+            assert_eq!(covered as i32, read_len, "pos={pos}");
+            assert!(reported >= 0, "pos={pos} reported a negative position");
+        }
     }
 }

--- a/crates/salmon-quant/src/processor.rs
+++ b/crates/salmon-quant/src/processor.rs
@@ -190,6 +190,9 @@ pub(crate) struct Shared<'a> {
     pub unmapped_names: Option<&'a Mutex<UnmappedWriter>>,
     /// when set, write per-mapping SAM records (`--writeMappings`)
     pub sam: Option<&'a crate::sam::SamWriter>,
+    /// run-wide mapping-output settings: whether to realize a base-level CIGAR
+    /// for each written placement, and with what alignment parameters
+    pub record_options: &'a crate::mapping_record::RecordOptions<'a>,
     /// when set, encode per-mapping BAM records into reusable worker chunks
     pub bam: Option<&'a crate::bam::BamOutput>,
     /// when set, write per-fragment mappings to a RAD file (`--writeRad`)
@@ -393,6 +396,9 @@ pub(crate) struct QuantProcessor<'a> {
     /// per-thread RAD chunk buffer (flushed as one chunk per batch); `None`
     /// unless `--writeRad` is set
     pub rad_buf: Option<salmon_rad::FragmentChunkBuf>,
+    /// per-thread buffers for deriving record fields (realized CIGARs, MD
+    /// strings, the aligner workspace); allocated once per worker, not per record
+    pub emit_scratch: crate::mapping_record::EmitScratch,
 }
 
 impl<'a> QuantProcessor<'a> {
@@ -428,6 +434,7 @@ impl<'a> QuantProcessor<'a> {
             rad_buf: shared.rad.map(|rad| {
                 salmon_rad::FragmentChunkBuf::with_capacity_codec(64 * 1024, rad.codec())
             }),
+            emit_scratch: crate::mapping_record::EmitScratch::default(),
         }
     }
 }
@@ -1331,6 +1338,7 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             sam_buf,
             bam_scratch,
             rad_buf,
+            emit_scratch,
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -1429,6 +1437,8 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     s1.as_ref(),
                     Some((r2.id(), s2.as_ref())),
                     &placements,
+                    sh.record_options,
+                    emit_scratch,
                 );
             }
             if let Some(scratch) = bam_scratch.as_mut() {
@@ -1439,6 +1449,8 @@ impl<'a, 'r> PairedParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                         s1.as_ref(),
                         Some((r2.id(), s2.as_ref())),
                         &placements,
+                        sh.record_options,
+                        emit_scratch,
                     )?;
                 }
             }
@@ -1517,6 +1529,7 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
             sam_buf,
             bam_scratch,
             rad_buf,
+            emit_scratch,
         } = self;
         let sh = *shared;
         let idx = sh.salmon.inner();
@@ -1588,11 +1601,21 @@ impl<'a, 'r> ParallelProcessor<RefRecord<'r>> for QuantProcessor<'a> {
                     s.as_ref(),
                     None,
                     &placements,
+                    sh.record_options,
+                    emit_scratch,
                 );
             }
             if let Some(scratch) = bam_scratch.as_mut() {
                 if !placements.is_empty() {
-                    scratch.write_fragment(sh.salmon, rec.id(), s.as_ref(), None, &placements)?;
+                    scratch.write_fragment(
+                        sh.salmon,
+                        rec.id(),
+                        s.as_ref(),
+                        None,
+                        &placements,
+                        sh.record_options,
+                        emit_scratch,
+                    )?;
                 }
             }
             if let (Some(rad), Some(buf)) = (sh.rad, rad_buf.as_mut()) {

--- a/crates/salmon-quant/src/sam.rs
+++ b/crates/salmon-quant/src/sam.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 use salmon_index::SalmonIndex;
 use salmon_map::ScoredMapping;
 
-use crate::mapping_record::{self, AlignmentRecord, CigarKind};
+use crate::mapping_record::{self, AlignmentRecord, EmitScratch, RecordOptions};
 
 /// Shared SAM sink. Worker threads format whole blocks of records into their own
 /// string buffers and hand them over; the mutex is taken once per block rather
@@ -44,7 +44,7 @@ impl SamWriter {
     /// Append one worker's accumulated block of records.
     ///
     /// Blocks land in whatever order threads finish, so records for one fragment
-    /// are contiguous but no order is imposed across fragments — as documented
+    /// are contiguous but no order is imposed across fragments, as documented
     /// for `--writeMappings`.
     pub fn write_block(&self, block: &str) -> std::io::Result<()> {
         if block.is_empty() {
@@ -59,9 +59,13 @@ impl SamWriter {
 }
 
 /// Write the read's bases, reverse-complementing them when the alignment is on
-/// the reverse strand — SAM always stores the sequence as it appears on the
+/// the reverse strand: SAM always stores the sequence as it appears on the
 /// reference's forward strand.
 fn write_sequence(buf: &mut String, record: &AlignmentRecord<'_>) {
+    if record.sequence.is_empty() {
+        buf.push('*');
+        return;
+    }
     if record.reverse_complement {
         for &base in record.sequence.iter().rev() {
             buf.push(mapping_record::complement(base) as char);
@@ -77,27 +81,35 @@ fn write_sequence(buf: &mut String, record: &AlignmentRecord<'_>) {
 /// followed by salmon's optional tags.
 fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord<'_>) {
     let name = String::from_utf8_lossy(record.name);
-    let reference = salmon.ref_name(record.reference_id);
-    // QNAME, FLAG, RNAME, POS, MAPQ. SAM positions are 1-based, ours are 0-based.
-    let _ = write!(
-        buf,
-        "{name}\t{}\t{reference}\t{}\t{}",
-        record.flags,
-        record.position + 1,
-        record.mapping_quality
-    );
+    // QNAME, FLAG, RNAME, POS, MAPQ. SAM positions are 1-based, ours are 0-based,
+    // and an unmapped record has neither a reference nor a position.
+    let _ = write!(buf, "{name}\t{}\t", record.flags);
+    match record.reference_id {
+        Some(tid) => {
+            let _ = write!(
+                buf,
+                "{}\t{}\t{}",
+                salmon.ref_name(tid),
+                record.position + 1,
+                record.mapping_quality
+            );
+        }
+        None => {
+            let _ = write!(buf, "*\t0\t{}", record.mapping_quality);
+        }
+    }
     buf.push('\t');
-    for op in record.cigar.as_slice() {
-        let kind = match op.kind {
-            CigarKind::Match => 'M',
-            CigarKind::SoftClip => 'S',
-        };
-        let _ = write!(buf, "{}{kind}", op.len);
+    if record.cigar.is_empty() {
+        buf.push('*');
+    } else {
+        for op in record.cigar {
+            let _ = write!(buf, "{}{}", op.len, op.kind.letter());
+        }
     }
     // RNEXT, PNEXT, TLEN. `=` is SAM's shorthand for "same reference as this
     // record", which is always the case for a proper pair here.
     if let (Some(mate_id), Some(mate_position)) = (record.mate_reference_id, record.mate_position) {
-        let mate_reference = if mate_id == record.reference_id {
+        let mate_reference = if Some(mate_id) == record.reference_id {
             "="
         } else {
             salmon.ref_name(mate_id)
@@ -113,16 +125,32 @@ fn write_record(buf: &mut String, salmon: &SalmonIndex, record: &AlignmentRecord
     }
     buf.push('\t');
     write_sequence(buf, record);
-    // QUAL is `*` (not retained), then the tags: NH = number of placements for
-    // this fragment, HI = which one this is, XT = transcript/decoy, AS = score.
-    let _ = writeln!(
+    // QUAL: salmon does not retain base qualities, and `*` is SAM's spelling for
+    // "not available".
+    buf.push_str("\t*");
+    write_tags(buf, record);
+    buf.push('\n');
+}
+
+/// Append the optional tags: `NH` = number of placements for this fragment,
+/// `HI` = which one this is, `XT` = transcript/decoy, `AS` = the score of the
+/// alignment in this very record, and `NM`/`MD` describing that alignment.
+fn write_tags(buf: &mut String, record: &AlignmentRecord<'_>) {
+    let _ = write!(
         buf,
-        "\t*\tNH:i:{}\tHI:i:{}\tXT:A:{}\tAS:i:{}",
+        "\tNH:i:{}\tHI:i:{}\tXT:A:{}\tAS:i:{}",
         record.nh, record.hi, record.xt as char, record.alignment_score
     );
+    if let Some(edit_distance) = record.edit_distance {
+        let _ = write!(buf, "\tNM:i:{edit_distance}");
+    }
+    if let Some(md) = record.md {
+        let _ = write!(buf, "\tMD:Z:{md}");
+    }
 }
 
 /// Append every SAM record implied by one fragment's placements.
+#[allow(clippy::too_many_arguments)]
 pub fn write_fragment(
     buf: &mut String,
     salmon: &SalmonIndex,
@@ -130,10 +158,21 @@ pub fn write_fragment(
     r1_seq: &[u8],
     r2: Option<(&[u8], &[u8])>,
     maps: &[ScoredMapping],
+    options: &RecordOptions<'_>,
+    scratch: &mut EmitScratch,
 ) {
-    mapping_record::emit_fragment_records(salmon, r1_id, r1_seq, r2, maps, |record| {
-        write_record(buf, salmon, record);
-        Ok(())
-    })
+    mapping_record::emit_fragment_records(
+        salmon,
+        r1_id,
+        r1_seq,
+        r2,
+        maps,
+        options,
+        scratch,
+        |record| {
+            write_record(buf, salmon, record);
+            Ok(())
+        },
+    )
     .expect("writing to String is infallible");
 }

--- a/crates/salmon-quant/tests/mapping_output.rs
+++ b/crates/salmon-quant/tests/mapping_output.rs
@@ -1,0 +1,363 @@
+//! What a `--writeMappings` / `--writeBam` file has to contain.
+//!
+//! These tests are about the *output contract*, not about mapping: they build a
+//! tiny index, map a handful of reads whose correct placement is obvious by
+//! construction, and then assert on the records. What they defend is everything
+//! a reader is entitled to assume and that no unit test can see, because it only
+//! exists once the whole pipeline has run: that the header describes the file,
+//! that every record's fields agree with each other, and that the tags are
+//! actually there.
+//!
+//! The single most valuable assertion here is the one about CIGAR and read
+//! length. A record whose CIGAR does not account for exactly as many read bases
+//! as `SEQ` holds is rejected by every SAM reader in existence, and it is the
+//! failure mode that any change to CIGAR derivation risks introducing.
+
+use std::path::Path;
+
+use salmon_index::{build, IndexBuildOptions};
+use salmon_quant::{quantify, QuantOptions};
+
+/// Options for one fixture run, beyond the mapping output itself.
+#[derive(Default)]
+struct Run {
+    /// Quantify the first mates on their own, exercising the single-end path.
+    single_end: bool,
+}
+
+/// Build a two-transcript index, quantify the fixture reads against it with SAM
+/// output on, and return the file's text.
+fn run_with_mapping_output(dir: &Path, run: Run) -> String {
+    let transcripts = dir.join("txp.fa");
+    let (a, b) = fixture_transcripts();
+    std::fs::write(&transcripts, format!(">txA desc here\n{a}\n>txB\n{b}\n")).unwrap();
+
+    let (reads1, reads2) = fixture_reads(&a, &b);
+    let r1 = dir.join("r1.fq");
+    let r2 = dir.join("r2.fq");
+    std::fs::write(&r1, reads1).unwrap();
+    std::fs::write(&r2, reads2).unwrap();
+
+    let index = dir.join("idx");
+    let mut build_options = IndexBuildOptions::new(vec![transcripts], index.clone());
+    build_options.threads = 1;
+    build(&build_options).expect("building the index");
+
+    let sam = dir.join("mappings.sam");
+    let mut options = QuantOptions::new(index, dir.join("out"));
+    if run.single_end {
+        options.unmated = vec![r1];
+    } else {
+        options.mates1 = vec![r1];
+        options.mates2 = vec![r2];
+    }
+    options.lib_type = "IU".to_string();
+    options.num_threads = 1;
+    options.write_mappings = Some(sam.clone());
+    quantify(&options).expect("quantifying");
+
+    std::fs::read_to_string(&sam).expect("reading the SAM output")
+}
+
+/// Two transcripts sharing no k-mers, so every read has one obvious home.
+fn fixture_transcripts() -> (String, String) {
+    // A deterministic, non-repeating sequence: a linear congruential walk over
+    // the four bases, seeded differently per transcript so they do not share
+    // 31-mers.
+    fn walk(seed: u64, len: usize) -> String {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                b"ACGT"[((state >> 33) % 4) as usize] as char
+            })
+            .collect()
+    }
+    (walk(12345, 1200), walk(98765, 900))
+}
+
+/// Inward-facing pairs drawn from each transcript, one of them carrying a
+/// substitution so the output has a record with a non-trivial `MD`, and one
+/// homopolymer pair that maps nowhere so the unaligned path has something to
+/// write.
+fn fixture_reads(a: &str, b: &str) -> (String, String) {
+    let complement = |base: u8| match base {
+        b'A' => b'T',
+        b'C' => b'G',
+        b'G' => b'C',
+        _ => b'A',
+    };
+    let revcomp = |s: &str| -> String {
+        s.bytes()
+            .rev()
+            .map(|base| complement(base) as char)
+            .collect()
+    };
+    let mut r1 = String::new();
+    let mut r2 = String::new();
+    let mut emit = |name: &str, forward: &str, reverse: &str| {
+        let quality = "I".repeat(forward.len());
+        r1.push_str(&format!("@{name}/1\n{forward}\n+\n{quality}\n"));
+        let quality = "I".repeat(reverse.len());
+        r2.push_str(&format!("@{name}/2\n{reverse}\n+\n{quality}\n"));
+    };
+    for (index, start) in [40usize, 200, 480, 700].into_iter().enumerate() {
+        emit(
+            &format!("a{index}"),
+            &a[start..start + 60],
+            &revcomp(&a[start + 150..start + 210]),
+        );
+    }
+    for (index, start) in [30usize, 300, 500].into_iter().enumerate() {
+        emit(
+            &format!("b{index}"),
+            &b[start..start + 60],
+            &revcomp(&b[start + 120..start + 180]),
+        );
+    }
+    // One mismatched read, so MD and NM have something to say.
+    let mut mutated: Vec<u8> = a[600..660].bytes().collect();
+    mutated[25] = complement(mutated[25]);
+    emit(
+        "mismatch",
+        std::str::from_utf8(&mutated).unwrap(),
+        &revcomp(&a[750..810]),
+    );
+    // A fragment that cannot map anywhere in this fixture.
+    emit("nowhere", &"A".repeat(60), &"C".repeat(60));
+    // An orphan: read 1 comes from txA, read 2 from nowhere at all.
+    emit("orphan", &a[820..880], &"AC".repeat(30));
+    (r1, r2)
+}
+
+/// Split a SAM line into its mandatory fields plus the tags.
+fn fields(line: &str) -> Vec<&str> {
+    line.split('\t').collect()
+}
+
+fn tag<'a>(fields: &[&'a str], name: &str) -> Option<&'a str> {
+    fields
+        .iter()
+        .skip(11)
+        .find(|f| f.starts_with(name))
+        .copied()
+}
+
+fn records(sam: &str) -> Vec<Vec<&str>> {
+    sam.lines()
+        .filter(|line| !line.starts_with('@'))
+        .map(fields)
+        .collect()
+}
+
+/// How many read bases a CIGAR accounts for. `M`, `I` and `S` consume the read;
+/// `D` and `N` do not.
+fn cigar_read_length(cigar: &str) -> usize {
+    let mut total = 0;
+    let mut digits = String::new();
+    for c in cigar.chars() {
+        if c.is_ascii_digit() {
+            digits.push(c);
+        } else {
+            let len: usize = digits.parse().unwrap_or(0);
+            digits.clear();
+            if matches!(c, 'M' | 'I' | 'S' | '=' | 'X') {
+                total += len;
+            }
+        }
+    }
+    total
+}
+
+/// The header has to describe the file: its version, its ordering, one `@SQ` per
+/// reference with a checksum, and the program that wrote it.
+#[test]
+fn the_header_describes_the_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    let mut lines = sam.lines();
+
+    let hd = lines.next().expect("a header");
+    assert_eq!(hd, "@HD\tVN:1.0\tSO:unknown");
+
+    let sq: Vec<&str> = sam.lines().filter(|l| l.starts_with("@SQ")).collect();
+    assert_eq!(sq.len(), 2, "one @SQ per transcript");
+    for line in &sq {
+        assert!(line.contains("\tLN:"), "@SQ needs a length: {line}");
+    }
+    // The reference name stops at the first space: the rest of a FASTA header is
+    // a description, not part of the name.
+    assert!(
+        sq.iter().any(|l| l.contains("\tSN:txA\t")),
+        "reference name should not include the FASTA description: {sq:?}"
+    );
+
+    assert!(
+        sam.lines().any(|l| l.starts_with("@PG\tID:salmon")),
+        "the header must record what wrote the file"
+    );
+}
+
+/// Every record has to be internally consistent. This is the check a SAM reader
+/// makes, so it is the check that decides whether the output is usable at all.
+#[test]
+fn every_record_is_internally_consistent() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    let records = records(&sam);
+    assert!(!records.is_empty(), "the run produced no records");
+
+    for record in &records {
+        assert!(record.len() >= 11, "too few fields: {record:?}");
+        let name = record[0];
+        let flags: u16 = record[1].parse().expect("FLAG is a number");
+        let cigar = record[5];
+        let sequence = record[9];
+
+        assert!(
+            !name.ends_with("/1") && !name.ends_with("/2"),
+            "the mate suffix has to go, or a reader cannot pair the mates: {name}"
+        );
+        assert_eq!(
+            cigar_read_length(cigar),
+            sequence.len(),
+            "CIGAR and SEQ disagree for {name}: {cigar} vs {} bases",
+            sequence.len()
+        );
+        // Every mate here is part of a pair, so the pairing bits have to be set
+        // and the mate reference named.
+        assert!(flags & 0x1 != 0, "reads were paired: {name} has {flags}");
+        assert!(
+            record[6] == "=" || record[6] == "*",
+            "both mates are on one transcript: {name} has RNEXT {}",
+            record[6]
+        );
+    }
+}
+
+/// The tags are the point of the exercise: without them the file says nothing
+/// beyond where the read landed.
+#[test]
+fn records_carry_the_tags_readers_expect() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    let records = records(&sam);
+
+    for record in &records {
+        // An unmapped record has no placement, so none of the placement tags.
+        if record[1].parse::<u16>().unwrap() & 0x4 != 0 {
+            continue;
+        }
+        for name in ["NH:i:", "HI:i:", "AS:i:", "NM:i:", "MD:Z:"] {
+            assert!(
+                tag(record, name).is_some(),
+                "{} is missing {name}: {record:?}",
+                record[0]
+            );
+        }
+    }
+
+    // MAPQ has to distinguish unique placements from ambiguous ones. These
+    // transcripts share no k-mers, so every fragment is placed once.
+    for record in records.iter().filter(|r| {
+        let flags: u16 = r[1].parse().unwrap();
+        flags & 0x4 == 0
+    }) {
+        assert_eq!(
+            tag(record, "NH:i:"),
+            Some("NH:i:1"),
+            "fixture transcripts should not be ambiguous: {record:?}"
+        );
+        assert_eq!(record[4], "255", "a unique placement gets MAPQ 255");
+    }
+
+    // The mismatched read is the one record whose MD is not a bare run length.
+    let mismatched = records
+        .iter()
+        .find(|r| r[0] == "mismatch" && r[1].parse::<u16>().unwrap() & 0x40 != 0)
+        .expect("the mismatched read should be in the output");
+    assert_eq!(tag(mismatched, "NM:i:"), Some("NM:i:1"));
+    let md = tag(mismatched, "MD:Z:").unwrap();
+    assert!(
+        md.bytes().any(|b| b.is_ascii_alphabetic()),
+        "MD should name the reference base at the mismatch: {md}"
+    );
+}
+
+/// Single-end runs go through a separate path in the processor and a separate
+/// branch of the record builder, and get their own kind of wrong: a stray
+/// pairing bit, or a mate tag describing a mate that does not exist.
+#[test]
+fn single_end_records_claim_no_mate() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run { single_end: true });
+    let records = records(&sam);
+    assert!(
+        !records.is_empty(),
+        "the single-end run produced no records"
+    );
+    for record in &records {
+        let flags: u16 = record[1].parse().unwrap();
+        assert_eq!(
+            flags & 0x1,
+            0,
+            "a single-end read is not paired: {} has {flags}",
+            record[0]
+        );
+        // Every bit that describes a mate is meaningless without one.
+        assert_eq!(
+            flags & (0x2 | 0x8 | 0x20 | 0x40 | 0x80),
+            0,
+            "{} carries pairing flags: {flags}",
+            record[0]
+        );
+        assert_eq!(record[6], "*", "no mate reference: {record:?}");
+        assert_eq!(record[7], "0", "no mate position: {record:?}");
+        assert_eq!(record[8], "0", "no template length: {record:?}");
+        assert!(tag(record, "MC:Z:").is_none(), "{} has MC", record[0]);
+        assert!(tag(record, "MQ:i:").is_none(), "{} has MQ", record[0]);
+        if flags & 0x4 == 0 {
+            assert!(tag(record, "NM:i:").is_some(), "{} lacks NM", record[0]);
+        }
+    }
+}
+
+/// `AS` has to describe the alignment in the same record, not a different one.
+///
+/// It used to be the mapper's own score while the CIGAR, `NM` and `MD` came from
+/// re-aligning the placement, so a record could claim a good score beside an
+/// alignment full of edits. Anything that reads both, and every filter on `AS`
+/// does, was being told two different stories.
+#[test]
+fn the_score_describes_the_alignment_in_its_own_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = run_with_mapping_output(dir.path(), Run::default());
+    for record in records(&sam) {
+        let (Some(score), Some(edits)) = (tag(&record, "AS:i:"), tag(&record, "NM:i:")) else {
+            // A record without a base-level alignment carries neither, which is
+            // the honest answer rather than a mismatched pair.
+            assert_eq!(
+                tag(&record, "NM:i:").is_none(),
+                tag(&record, "MD:Z:").is_none(),
+                "NM and MD go together: {record:?}"
+            );
+            continue;
+        };
+        let score: i32 = score.trim_start_matches("AS:i:").parse().unwrap();
+        let edits: i32 = edits.trim_start_matches("NM:i:").parse().unwrap();
+        let cigar = record[5];
+        // Ungapped alignments are the ones whose score follows directly from the
+        // edit count: matched bases earn 2, each mismatch swings 6.
+        if !cigar.contains('I') && !cigar.contains('D') && !cigar.contains('S') {
+            let aligned = cigar_read_length(cigar) as i32;
+            assert_eq!(
+                score,
+                2 * aligned - 6 * edits,
+                "AS and NM disagree for {}: {cigar}",
+                record[0]
+            );
+        }
+    }
+}

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -51,7 +51,7 @@ misbehaves.
 
 | Flag | Status | Notes |
 |------|--------|-------|
-| `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. `MAPQ` is derived from the placement count on STAR's scale (255 unique, 3, 1, 0); other unwritten fields keep salmon's pseudobam conventions. |
+| `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. Records carry real base-level CIGARs (`I`/`D`/`S`) with `NM` and `MD` describing the alignment they report, `MAPQ` derived from the placement count on STAR's scale (255 unique, 3, 1, 0), and `NH`/`HI`/`XT`/`AS` tags. |
 | `--bamCompressThreads` | ✅ | BGZF compression pool for `--writeBam`; defaults to ~1 worker per 3 mapping threads (max 8), balancing measured deflate throughput against record production. Rust-port feature; not in this salmon build. |
 | `--useEM` | ✅ | VBEM is the default; `--useEM` selects plain EM. |
 | `--meta` | ✅ | Metagenomic preset: plain EM, no range-factorized eq-classes, uniform init (the Rust EM already inits uniformly). Overrides `--useEM`/`--rangeFactorizationBins`. |

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -457,32 +457,32 @@ formats cannot drift apart.
 Both options apply to the read-mapping path only. In alignment mode (`-a`) and
 RAD-input mode (`--rad`) they are accepted but ignored, with a warning.
 
-### The pseudoalignment output contract
+### What a record contains
 
-This output is a **diagnostic view of salmon's mappings**, not a
-general-purpose aligner output, and several fields are deliberately nominal —
-for brevity, and because the mapping path computes scores without base-level
-alignments (score-only dynamic programming, no traceback) and does not compute
-them just because output was requested:
+The header is unchanged: `@HD`, one `@SQ` per reference with its length, and
+`@PG`.
 
-- **`CIGAR`** is synthesized from the read length (`<readLen>M`, plus a clip at
-  a transcript end). It records *where* the mapping is, not a base-level
-  alignment; indels are not represented, and no `NM`/`MD` accompany it.
-- **`AS`** is the score salmon's mapper assigned to the placement — the same
-  number quantification used — not a score recomputed from the record's own
-  CIGAR. It is comparable across records within one run, not across aligners.
-  **In sketch mode (`--sketch`) there is no such score**: pseudoalignment maps
-  by k-mer/equivalence-class compatibility without computing a per-placement
-  alignment score, so `AS` is reported as `0` and every reported mapping is a
-  co-equal best mapping for the read as assessed by the algorithm. A meaningful
-  `AS` appears only under selective alignment (the default), which computes a
-  banded alignment score per candidate.
-- **`MAPQ`** reflects only the placement count, not alignment confidence — see
-  below.
+Each record carries:
 
-Treat the records as positions + pairing + the quantifier's scores. If you need
-true base-level alignments, run a general-purpose aligner; a possible opt-in
-"realized alignment" output mode is under discussion (see #1141).
+| Field | Value |
+|-------|-------|
+| `MAPQ` | Derived from the number of placements, on STAR's scale: 255 for a uniquely placed fragment, 3 for two placements, 1 for three or four, 0 beyond. `-q 255` therefore means "uniquely placed", as it does for STAR output. |
+| `CIGAR` | A base-level alignment with real `I` and `D` operations, and `S` where a read overhangs a transcript end. The placement is re-aligned with traceback when the record is written, which is work a run without mapping output never does. |
+| `NM` / `MD` | Edit distance and the reference bases at each mismatch, matching what `samtools calmd` recomputes from the input FASTA. Indexing has to replace non-ACGT bases with ACGT, since the k-mer structure cannot hold them, but the build records where it did so and the record reports the `N` that was there rather than the substitute. |
+| `NH` / `HI` | How many placements this fragment has, and which one this record is. |
+| `AS` | The score of the alignment in this same record. |
+| `XT` | `T` for a transcript placement, `D` for a decoy. In practice always `T`: a fragment whose best placement is a decoy is dropped by scoring before any record is written, so a decoy-aware index changes which fragments appear, not what `XT` says about them. |
+
+`QUAL` is still `*`: salmon does not carry base qualities into the record
+builder. That is an omission the format allows, unlike a CIGAR that does not
+describe the alignment it sits beside.
+
+In sketch mode (`--sketch`) there is no per-placement alignment score:
+pseudoalignment maps by k-mer/equivalence-class compatibility without computing
+one, so `AS` is reported as `0` and every reported mapping is a co-equal best
+mapping for the read as assessed by the algorithm. A meaningful `AS` appears
+only under selective alignment (the default), which computes a banded alignment
+score per candidate.
 
 ### `MAPQ`
 


### PR DESCRIPTION
Split out of #1123 (the third slice of it). This PR carries only the part where the current output **states something false about salmon's own mappings**. The additive fields SAM allows to be absent are in the PR stacked on top of this one, and the genome projection stays in #1123.

`--writeMappings` has always been a diagnostic view of salmon's mappings rather than a general-purpose aligner output, and that is the right scope. No new output mode is added here. The view just stops misdescribing what it shows.

## What is false on `develop` today

| Statement the file makes | Why it is false |
|---|---|
| `CIGAR` = `<readLen>M` (plus a clip at a transcript end), synthesized from the read length | A placement with an indel is written as if it had none, so every base past the gap sits at the wrong reference offset. The `Cigar` type itself holds at most two operations and cannot express an indel. |
| `AS` = the mapper's chain score | Nothing in the record could be checked against it. Auditing `AS` against a recomputed `NM` over a whole output found **2.4% of records self-contradicting**: a `15M1I1D15M1I1D...` sawtooth at `NM:i:80` on a 100 base read, beside an `AS` claiming about three mismatches. Both cannot be true. |
| `MAPQ` = `1`, always | `samtools view -q 255`, the standard "uniquely placed" filter, discards the entire file. A constant that says "ambiguous" for a uniquely placed fragment is not an estimate, it is a wrong one. |

## What this PR changes

Records carry the CIGAR of an alignment actually realized for that placement, with real `I`/`D` operations, the `NM` and `MD` that describe it, the score of that same alignment, and `MAPQ` derived from the placement count on STAR's scale (255 unique, 3, 1, 0), which is what the tools downstream already filter on.

Three separate causes behind the self-contradicting records, each of which alone produces a false one:

- **The anchor search reached only `indel_margin`.** That bounds indel size and says nothing about how wrong a seed-derived position can be: a chain on a repeat or a paralogous stretch can imply a start most of a read away. One offending read belonged 69 bases earlier, where it matched with three mismatches. Out of reach, the banded DP still returned an alignment, the sawtooth above. The search now covers a read length either side.
- **The search gave up when the read did not fit inside the reference at its anchor**, which is exactly the case most worth looking at: an anchor near a transcript end becomes a soft-clipped record that throws bases away when the read often belongs further in and matches in full.
- **ksw2's extension pins the read's first base to the window's first base**, so a realized alignment can grow rightwards but never shift left, and a mismatch near the 5' end left the DP no way to say "the read started earlier" except by opening a leading insertion: `26I34M` at `NM 26` where the answer is `60M` at `NM 1`.

A repaired anchor is a hypothesis, not a verdict: a read with a genuine deletion also looks badly placed to an ungapped scan, so both anchors are realized and the better score wins. An alignment scoring below the mapper's own `min_accepted_score` for the bases it claims is refused, and the record falls back to the synthesized CIGAR with no `NM`/`MD`, which at least says "no base-level alignment here".

Also here, because `NM`/`MD` cannot be honest without it: the index now writes `ambiguous.bin`, the offsets of reference bases indexing had to replace (non-ACGT cannot live in the k-mer structure). Without it `NM` counted a match where the input had an `N` and `MD` named the substitute. 40 bytes for the whole human transcriptome, and **an index built before this file existed loads as "none recorded" and behaves exactly as it did**.

## Cost

Realization runs only for placements that are written, and only when mapping output is on: a run without `--writeMappings`/`--writeBam` never enters `salmon_map::realize`. Two things keep the written path affordable: an affine-scoring bound that proves the ungapped alignment optimal (no DP at all for up to one mismatch at salmon's defaults), and skipping the traceback when the banded optimum equals the ungapped score over the full read.

1M fragments, `-p 8`, order-alternated, best of 3, on 20k unique transcripts and on 5k genes x 4 isoforms (2.5 placements per fragment):

| | `master` | this branch |
|---|---|---|
| no mapping output, single-mapping | 0.89s | 0.89s |
| no mapping output, multi-mapping | 0.94s | 0.92s |
| `--writeBam`, single-mapping | 1.04s | 1.94s |
| `--writeBam`, multi-mapping | 1.36s | 3.28s |

The default path is unchanged. The cost is per written record, so it grows with multi-mapping rather than shrinking.

## Verification

Against samtools 1.24, on the two simulated fixtures, human chr22 (hg38) + GENCODE v44, and real reads (DRR028171, 457366 pairs of 151 bases):

- **`NM`/`MD` match `samtools calmd`** on every record that carries them, including for the transcript containing an `N`.
- **`AS` agrees with `NM` and the CIGAR** on every ungapped record: the score describes the alignment in its own record.
- Every record's CIGAR accounts for exactly as many read bases as `SEQ` holds, pinned by an integration test (`crates/salmon-quant/tests/mapping_output.rs`) alongside the header, the tag set and the single-end path.
- `samtools quickcheck` passes; SAM output round-trips through `samtools view -b`.
- Full workspace suite green.

## Not in this PR

`QUAL` (still `*`), `@SQ M5`/`UR`, `MC`/`MQ`, `ZW`, `@RG`/`--rgLine`, and unmapped records. Those are omissions the format allows, which is a different argument from a CIGAR that does not describe the alignment beside it, so they are in the stacked PR. Genome-coordinate output (`--spliced`) stays in #1123.
