### PR TITLE
Run-spanning `total_time_seconds` and `inference_path` in `meta_info.json`

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -187,6 +187,14 @@ pub struct AlignQuantOptions {
     /// initialize the EM uniformly instead of with the online-estimate-blended
     /// warm start (`--initUniform`)
     pub init_uniform: bool,
+    /// wall-clock seconds a driver already spent before this call (phase 1 of
+    /// `--deterministic`, or genome projection); added to the reported
+    /// `total_time_seconds` so `meta_info.json` covers the whole run rather
+    /// than only the quantification pass
+    pub prior_seconds: f64,
+    /// start time (asctime) of that earlier phase; when set, reported as the
+    /// run's `start_time` instead of this pass's own
+    pub external_start_time: Option<String>,
     /// significant digits for the EffectiveLength and NumReads columns of
     /// `quant.sf` (`--sigDigits`, salmon default 3)
     pub sig_digits: u32,
@@ -252,6 +260,8 @@ impl AlignQuantOptions {
             explicit_fld_args: ExplicitFldArgs::default(),
             forgetting_factor: 0.65,
             init_uniform: false,
+            prior_seconds: 0.0,
+            external_start_time: None,
             sig_digits: 3,
             num_error_bins: 4,
             discard_orphans: false,
@@ -356,7 +366,7 @@ pub struct AlignQuantResult {
 }
 
 /// Current local time as an asctime-style string, matching salmon's timestamps.
-fn asctime_now() -> String {
+pub fn asctime_now() -> String {
     jiff::Zoned::now()
         .strftime("%a %b %e %H:%M:%S %Y")
         .to_string()
@@ -2015,7 +2025,7 @@ fn apply_bias_correction(
 
 /// Run alignment-based quantification end-to-end.
 pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult> {
-    let start_time = asctime_now();
+    let start_time = opts.external_start_time.clone().unwrap_or_else(asctime_now);
     let run_timer = std::time::Instant::now();
     let mut timer = PhaseTimer::new();
     let header = read_alignment_header(&opts.bam)?;
@@ -2491,7 +2501,7 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
         em_iters,
         em_converged,
         detected_library_type,
-        total_seconds: run_timer.elapsed().as_secs_f64(),
+        total_seconds: opts.prior_seconds + run_timer.elapsed().as_secs_f64(),
         peak_rss_kb: salmon_core::peak_rss_kb(),
         diagnostics,
     };
@@ -2589,6 +2599,11 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         num_em_iterations: u32,
         em_converged: bool,
         detected_library_type: Option<String>,
+        /// which inference path produced these results: `deterministic` (RAD
+        /// input — including `--deterministic`'s phase 2) or `online` (the
+        /// streaming BAM pass). Makes the online-to-deterministic transition
+        /// auditable from existing output (#1140).
+        inference_path: &'static str,
         total_time_seconds: f64,
         peak_rss_kb: u64,
         diagnostics: Vec<salmon_core::Diagnostic>,
@@ -2714,6 +2729,10 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         num_em_iterations: res.em_iters,
         em_converged: res.em_converged,
         detected_library_type: res.detected_library_type.clone(),
+        inference_path: match res.source {
+            FragmentSource::Rad => "deterministic",
+            FragmentSource::Bam => "online",
+        },
         total_time_seconds: res.total_seconds,
         peak_rss_kb: res.peak_rss_kb,
         diagnostics: res.diagnostics.clone(),

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -1621,7 +1621,7 @@ where
 
 /// Quantify from a RAD file (`salmon quant --rad`).
 pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQuantResult> {
-    let start_time = asctime_now();
+    let start_time = opts.external_start_time.clone().unwrap_or_else(asctime_now);
     let run_timer = std::time::Instant::now();
     let mut timer = PhaseTimer::new();
 
@@ -2233,7 +2233,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         em_iters,
         em_converged,
         detected_library_type,
-        total_seconds: run_timer.elapsed().as_secs_f64(),
+        total_seconds: opts.prior_seconds + run_timer.elapsed().as_secs_f64(),
         peak_rss_kb: salmon_core::peak_rss_kb(),
         diagnostics,
     };

--- a/crates/salmon-align/tests/rad_lib_format_counts.rs
+++ b/crates/salmon-align/tests/rad_lib_format_counts.rs
@@ -239,3 +239,38 @@ fn rad_requant_baked_library_format_is_authoritative() {
     assert_eq!(u64_field(&v, "ISF"), 30);
     assert_eq!(u64_field(&v, "ISR"), 20);
 }
+
+/// A two-phase driver hands its phase-1 timing to the requant, and
+/// `meta_info.json` must report the whole run plus which inference path ran
+/// (#1140): `total_time_seconds` previously covered only the second pass
+/// (0.4s reported against minutes of wall on real data), and nothing recorded
+/// that the deterministic path produced the output.
+#[test]
+fn requant_reports_run_spanning_time_and_inference_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("timed.rad");
+    write_mixed_orientation_rad(&rad, 30, 20);
+    let out = tmp.path().join("timed_out");
+    let mut o = AlignQuantOptions::new(rad.clone(), out.clone());
+    o.lib_type = "IU".to_string();
+    o.fld_mean = 200.0;
+    o.fld_sd = 20.0;
+    o.prior_seconds = 100.0;
+    o.external_start_time = Some("Thu Jan  1 00:00:00 2026".to_string());
+    let res = quantify_rad(&o, &rad).expect("quantify_rad");
+    assert!(
+        res.total_seconds >= 100.0,
+        "total_seconds {} must include the driver's prior phase",
+        res.total_seconds
+    );
+    let meta: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(meta["total_time_seconds"].as_f64().unwrap() >= 100.0);
+    assert_eq!(
+        meta["start_time"].as_str().unwrap(),
+        "Thu Jan  1 00:00:00 2026"
+    );
+    assert_eq!(meta["inference_path"].as_str().unwrap(), "deterministic");
+}

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1097,6 +1097,11 @@ fn run_deterministic(
     gene_map: Option<&GeneMapOpts>,
     out_dir: &std::path::Path,
 ) -> Result<()> {
+    // Wall-clock accounting spans both phases: phase 2 rewrites
+    // `meta_info.json` into the final output directory, and its
+    // `total_time_seconds` must cover the whole run, not just the requant
+    // (#1140: a 10M-pair run otherwise reports ~0.4s against minutes of wall).
+    let run_start = std::time::Instant::now();
     let bias_on = map_opts.seq_bias || map_opts.gc_bias || map_opts.pos_bias;
     // An explicit `--writeRad PATH` is honoured (and kept — it was a requested
     // output); otherwise a temp under the output directory, removed on success
@@ -1160,6 +1165,8 @@ fn run_deterministic(
     q.num_bootstraps = map_opts.num_bootstraps;
     q.num_gibbs_samples = map_opts.num_gibbs_samples;
     q.thinning_factor = map_opts.thinning_factor;
+    q.prior_seconds = run_start.elapsed().as_secs_f64();
+    q.external_start_time = Some(map_res.start_time.clone());
     let res = quantify_rad(&q, &rad_path).context("deterministic requant pass failed")?;
     let pct2 = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
@@ -1205,12 +1212,15 @@ fn run_deterministic(
 /// BAM `AS` tag); the online alignment error model is not used in this mode.
 // The same two-pass split for alignment input: BAM to RAD, then quantify.
 fn run_deterministic_align(
-    opts: AlignQuantOptions,
+    mut opts: AlignQuantOptions,
     rad_out: Option<PathBuf>,
     keep_rad: bool,
     gene_map: Option<&GeneMapOpts>,
     codec: ChunkCodec,
 ) -> Result<()> {
+    // Both phases count toward the reported run time (see run_deterministic).
+    let run_start = std::time::Instant::now();
+    let start_time = salmon_align::asctime_now();
     let out_dir = opts.output_dir.clone();
     // An explicit `--writeRad PATH` is honoured and kept; otherwise a temp under
     // the output dir, removed on success unless `--keepRad` (or `--skipQuant`,
@@ -1237,6 +1247,8 @@ fn run_deterministic_align(
     );
 
     // Phase 2 — quantify from the fully-baked RAD (single pass, order-independent).
+    opts.prior_seconds = run_start.elapsed().as_secs_f64();
+    opts.external_start_time = Some(start_time);
     let res = quantify_rad(&opts, &rad_path).context("deterministic requant pass failed")?;
     let pct2 = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
@@ -1298,6 +1310,9 @@ fn run_genome_project(
     keep_rad: bool,
     gene_map: Option<&GeneMapOpts>,
 ) -> Result<()> {
+    // Both phases count toward the reported run time (see run_deterministic).
+    let run_start = std::time::Instant::now();
+    let start_time = salmon_align::asctime_now();
     let out_dir = q.output_dir.clone();
     let explicit = rad_out.is_some();
     let rad_path = rad_out.unwrap_or_else(|| out_dir.join("genome_projected.rad"));
@@ -1325,6 +1340,8 @@ fn run_genome_project(
     if q.ref_seqs.is_none() {
         q.ref_seqs = art.ref_seqs;
     }
+    q.prior_seconds = run_start.elapsed().as_secs_f64();
+    q.external_start_time = Some(start_time);
     let res = quantify_rad(&q, &rad_path).context("genome-projected quantification failed")?;
     tracing::info!(
         "{} fragments from projected RAD, {} quantified; {} equivalence classes",

--- a/crates/salmon-quant/src/output.rs
+++ b/crates/salmon-quant/src/output.rs
@@ -363,6 +363,12 @@ struct MetaInfo {
     em_converged: bool,
     /// library format observed by the auto-detector (null if not observed)
     detected_library_type: Option<String>,
+    /// which inference path produced these results: `online` (the one-pass
+    /// streaming quant), or `none` for a mapping-only `--skipQuant` pass (a
+    /// `--deterministic` run's phase 2 rewrites this file with
+    /// `deterministic`). Makes the online-to-deterministic transition
+    /// auditable from existing output (#1140).
+    inference_path: &'static str,
     /// total wall-clock seconds and peak resident set size (KiB, Linux)
     total_time_seconds: f64,
     peak_rss_kb: u64,
@@ -461,6 +467,7 @@ fn write_meta_info(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Resul
         num_em_iterations: res.em_iters,
         em_converged: res.em_converged,
         detected_library_type: res.detected_library_type.clone(),
+        inference_path: if opts.skip_quant { "none" } else { "online" },
         total_time_seconds: res.total_seconds,
         peak_rss_kb: res.peak_rss_kb,
         diagnostics: res.diagnostics.clone(),

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -189,6 +189,14 @@ fn selective_alignment_quantification_tracks_truth() {
     assert!(out.join("quant.sf").exists());
     assert!(out.join("aux_info").join("meta_info.json").exists());
 
+    // The one-pass path labels itself in meta_info (#1140), so the
+    // online-to-deterministic transition is auditable from existing output.
+    let meta: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(meta["inference_path"].as_str().unwrap(), "online");
+
     // quant.sf has a header + one row per transcript.
     let sf = std::fs::read_to_string(out.join("quant.sf")).unwrap();
     assert!(sf.starts_with("Name\tLength\tEffectiveLength\tTPM\tNumReads\n"));


### PR DESCRIPTION
First of the maintainer-side items from #1140 (issues 3 and the `inference_path` suggestion from @BenjaminDEMAILLE's review).

- **`total_time_seconds` spans the whole run.** `AlignQuantOptions` gains `prior_seconds` / `external_start_time`; the three two-phase drivers (reads `--deterministic`, `-a --deterministic`, genome projection) capture phase-1 wall time and start stamp and hand them to `quantify_rad`. Previously the file reported only the requant (Ben measured 0.447s against 18.2s wall — 40× off).
- **`inference_path` in `meta_info.json`**: `"deterministic"` (RAD input, incl. `--deterministic` phase 2), `"online"` (one-pass reads / streaming BAM), `"none"` (mapping-only `--skipQuant` pass whose file a phase 2 would rewrite). Makes the default flip auditable from existing output.

Tests pin both: `quantify_rad` with `prior_seconds = 100` reports ≥100 s with the external start stamp and `"deterministic"`; the reads e2e asserts `"online"`.

Refs #1140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs