### PR TITLE
fix(cli): forward the inference knobs --deterministic was dropping (#1140 PR A)

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1085,8 +1085,30 @@ fn write_gene_level(
 /// passed silently did nothing. That is how `--biasSpeedSamp` and
 /// `--noBiasLengthThreshold` came to be ignored under `--deterministic`.
 ///
-/// `ref_seqs` is deliberately not set here; it needs to read the index from disk
-/// and only the caller knows whether bias correction asked for it.
+/// # Deliberately not forwarded
+///
+/// The point of the function is to make "audited and correctly omitted"
+/// distinguishable from "forgotten", which a test cannot do for an absence. Every
+/// field of `AlignQuantOptions` this leaves alone is here, with why:
+///
+/// * `ref_seqs`: needs to read the index from disk, and only the caller knows
+///   whether bias correction asked for it. Set immediately after this returns.
+/// * `explicit_fld_args`, `fld_policy`: phase 1 already folded the user's FLD
+///   prior into the bake. Forwarding them would have phase 2 warn that a baked
+///   FLD overrides the run's own `--fldMean`, against a bake that came from that
+///   very argument.
+/// * `forgetting_factor`, `num_aux_model_samples`, `num_pre_aux_model_samples`:
+///   online-inference knobs. Phase 2 has no online phase to apply them to.
+/// * `num_error_bins`, `discard_orphans`, `no_error_model`,
+///   `deterministic_error_model`: BAM-side knobs. Phase 2 reads a RAD whose
+///   placements were already scored and filtered during mapping.
+/// * `bam`, `output_dir`, `progress`: set by the caller, which owns the paths and
+///   the run's lifecycle.
+///
+/// One absence here is a bug rather than a decision: `skip_quant` is set on
+/// phase 1 unconditionally (its job is to map and write the RAD) and never
+/// reaches phase 2, so `--skipQuant --deterministic` quantifies anyway. Being
+/// able to see that from this list is the argument for the list.
 fn requant_options(
     map_opts: &QuantOptions,
     rad_path: &std::path::Path,

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1076,6 +1076,52 @@ fn write_gene_level(
     Ok(())
 }
 
+/// The phase-2 options for a deterministic reads-mode run: every knob from the
+/// reads-mode request that the RAD quantifier can honour, carried across.
+///
+/// This is a separate function so the forwarding can be asserted field by field
+/// in a test. A knob that is simply forgotten here does not fail loudly: the
+/// second pass runs with the default, the run succeeds, and the flag the user
+/// passed silently did nothing. That is how `--biasSpeedSamp` and
+/// `--noBiasLengthThreshold` came to be ignored under `--deterministic`.
+///
+/// `ref_seqs` is deliberately not set here; it needs to read the index from disk
+/// and only the caller knows whether bias correction asked for it.
+fn requant_options(
+    map_opts: &QuantOptions,
+    rad_path: &std::path::Path,
+    out_dir: &std::path::Path,
+    bias_targets: Option<PathBuf>,
+) -> AlignQuantOptions {
+    let mut q = AlignQuantOptions::new(rad_path.to_path_buf(), out_dir.to_path_buf());
+    q.lib_type = map_opts.lib_type.clone();
+    q.em = map_opts.em.clone();
+    q.range_factorization_bins = map_opts.range_factorization_bins;
+    q.transcripts = bias_targets;
+    q.seq_bias = map_opts.seq_bias;
+    q.gc_bias = map_opts.gc_bias;
+    q.pos_bias = map_opts.pos_bias;
+    q.bias_seed_em_iters = map_opts.bias_seed_em_iters;
+    q.score_exp = map_opts.map_config.score.score_exp;
+    q.incompat_prior = map_opts.incompat_prior;
+    q.sig_digits = map_opts.sig_digits;
+    q.fld_mean = map_opts.fld_mean;
+    q.fld_sd = map_opts.fld_sd;
+    q.fld_max = map_opts.fld_max;
+    q.gc_bins = map_opts.gc_bins;
+    q.cond_gc_bins = map_opts.cond_gc_bins;
+    q.num_bootstraps = map_opts.num_bootstraps;
+    q.num_gibbs_samples = map_opts.num_gibbs_samples;
+    q.thinning_factor = map_opts.thinning_factor;
+    // The three below were missing until #1140's audit. They are not
+    // online-only knobs: the RAD quantifier honours all three, so dropping them
+    // meant the flag was accepted and then ignored.
+    q.bias_speed_samp = map_opts.bias_speed_samp;
+    q.no_bias_length_threshold = map_opts.no_bias_length_threshold;
+    q.init_uniform = map_opts.init_uniform;
+    q
+}
+
 /// Deterministic reads-mode quantification: map the FASTQ once to an
 /// intermediate RAD (baking a fixed, order-independent FLD and the resolved
 /// library format), then quantify from that RAD via [`quantify_rad`]. Because the
@@ -1131,35 +1177,16 @@ fn run_deterministic(
 
     // Phase 2 — deterministic quant from the RAD (fixed baked FLD + library
     // format ⇒ order-independent eq-classes + EM). Mirrors the `--rad` knob wiring.
-    let mut q = AlignQuantOptions::new(rad_path.clone(), out_dir.to_path_buf());
-    q.lib_type = map_opts.lib_type.clone();
-    q.em = map_opts.em.clone();
-    q.range_factorization_bins = map_opts.range_factorization_bins;
+    let mut q = requant_options(&map_opts, &rad_path, out_dir, bias_targets);
     // Bias needs the reference sequence. Prefer the index's own sequences (we
     // already built the index for phase 1), so the user need not pass `-t`; an
     // explicit `-t` is still honoured as a fallback.
-    q.transcripts = bias_targets;
     if bias_on {
         q.ref_seqs = Some(
             salmon_index::load_ref_seqs(&map_opts.index_dir)
                 .context("loading reference sequences from the index for deterministic bias")?,
         );
     }
-    q.seq_bias = map_opts.seq_bias;
-    q.gc_bias = map_opts.gc_bias;
-    q.pos_bias = map_opts.pos_bias;
-    q.bias_seed_em_iters = map_opts.bias_seed_em_iters;
-    q.score_exp = map_opts.map_config.score.score_exp;
-    q.incompat_prior = map_opts.incompat_prior;
-    q.sig_digits = map_opts.sig_digits;
-    q.fld_mean = map_opts.fld_mean;
-    q.fld_sd = map_opts.fld_sd;
-    q.fld_max = map_opts.fld_max;
-    q.gc_bins = map_opts.gc_bins;
-    q.cond_gc_bins = map_opts.cond_gc_bins;
-    q.num_bootstraps = map_opts.num_bootstraps;
-    q.num_gibbs_samples = map_opts.num_gibbs_samples;
-    q.thinning_factor = map_opts.thinning_factor;
     let res = quantify_rad(&q, &rad_path).context("deterministic requant pass failed")?;
     let pct2 = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
@@ -1770,6 +1797,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.fld_max = args.fld_max.unwrap_or(DEFAULT_FLD_MAX);
     warn_unsupported_fld_policy(args.fld_policy, "reads mode");
     opts.forgetting_factor = args.forgetting_factor;
+    opts.init_uniform = args.init_uniform;
 
     // Deterministic mode: map once to an intermediate RAD, then quantify from it
     // with a fixed FLD (byte-identical output, no second mapping pass).
@@ -1782,6 +1810,17 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             args.targets.clone(),
             gene_map.as_ref(),
             &out_dir,
+        );
+    }
+    // `--initUniform` reaches the EM through the RAD quantifier, which the
+    // one-pass reads path does not use: the online EM starts from its own
+    // running abundances, and there is no point at which a uniform
+    // initialisation could be applied. Say so rather than accepting the flag and
+    // doing nothing with it.
+    if args.init_uniform {
+        tracing::warn!(
+            "--initUniform has no effect in one-pass reads mode: the online EM has no separate \
+             initialisation step. It applies to alignment input (-a) and to --deterministic."
         );
     }
 
@@ -2077,6 +2116,93 @@ mod tests {
             Command::Quant(args) => Ok(args),
             _ => unreachable!("parsed a non-quant subcommand"),
         }
+    }
+
+    use std::path::Path;
+
+    /// Every knob phase 2 can honour has to survive the hand-off, and the only
+    /// way to be sure is to check them one by one.
+    ///
+    /// A forgotten field is invisible at runtime: the requant runs with the
+    /// default, the run succeeds, and the flag the user passed did nothing.
+    /// `--biasSpeedSamp` and `--noBiasLengthThreshold` were dropped exactly that
+    /// way (COMBINE-lab/salmon#1140), and `--initUniform` never reached reads
+    /// mode at all. Each value below is deliberately different from the
+    /// `AlignQuantOptions` default, so a field that is not forwarded fails here
+    /// rather than merely looking plausible.
+    #[test]
+    fn deterministic_requant_forwards_every_supported_knob() {
+        let mut map_opts = QuantOptions::new(PathBuf::from("idx"), PathBuf::from("out"));
+        map_opts.lib_type = "ISR".to_string();
+        map_opts.em.vb_prior = 0.017;
+        map_opts.em.use_vbem = false;
+        map_opts.range_factorization_bins = 7;
+        map_opts.seq_bias = true;
+        map_opts.gc_bias = true;
+        map_opts.pos_bias = true;
+        map_opts.bias_seed_em_iters = 13;
+        map_opts.map_config.score.score_exp = 1.75;
+        map_opts.incompat_prior = 1e-7;
+        map_opts.sig_digits = 5;
+        map_opts.fld_mean = 271.0;
+        map_opts.fld_sd = 33.0;
+        map_opts.fld_max = 777;
+        map_opts.gc_bins = 17;
+        map_opts.cond_gc_bins = 5;
+        map_opts.num_bootstraps = 11;
+        map_opts.num_gibbs_samples = 23;
+        map_opts.thinning_factor = 9;
+        map_opts.bias_speed_samp = 25;
+        map_opts.no_bias_length_threshold = true;
+        map_opts.init_uniform = true;
+
+        let q = requant_options(
+            &map_opts,
+            Path::new("inter.rad"),
+            Path::new("out"),
+            Some(PathBuf::from("targets.fa")),
+        );
+
+        assert_eq!(q.bam, PathBuf::from("inter.rad"));
+        assert_eq!(q.output_dir, PathBuf::from("out"));
+        assert_eq!(q.lib_type, "ISR");
+        assert_eq!(q.em.vb_prior, 0.017);
+        assert!(!q.em.use_vbem);
+        assert_eq!(q.range_factorization_bins, 7);
+        assert_eq!(q.transcripts, Some(PathBuf::from("targets.fa")));
+        assert!(q.seq_bias && q.gc_bias && q.pos_bias);
+        assert_eq!(q.bias_seed_em_iters, 13);
+        assert_eq!(q.score_exp, 1.75);
+        assert_eq!(q.incompat_prior, 1e-7);
+        assert_eq!(q.sig_digits, 5);
+        assert_eq!(q.fld_mean, 271.0);
+        assert_eq!(q.fld_sd, 33.0);
+        assert_eq!(q.fld_max, 777);
+        assert_eq!(q.gc_bins, 17);
+        assert_eq!(q.cond_gc_bins, 5);
+        assert_eq!(q.num_bootstraps, 11);
+        assert_eq!(q.num_gibbs_samples, 23);
+        assert_eq!(q.thinning_factor, 9);
+        assert_eq!(q.bias_speed_samp, 25);
+        assert!(q.no_bias_length_threshold);
+        assert!(q.init_uniform);
+    }
+
+    /// The three knobs #1140 found dropped, checked against a default request
+    /// rather than against each other: with none of them set, phase 2 must see
+    /// the `AlignQuantOptions` defaults, so the test above is measuring
+    /// forwarding and not a coincidence.
+    #[test]
+    fn deterministic_requant_leaves_unset_knobs_at_their_defaults() {
+        let map_opts = QuantOptions::new(PathBuf::from("idx"), PathBuf::from("out"));
+        let defaults = AlignQuantOptions::new(PathBuf::from("inter.rad"), PathBuf::from("out"));
+        let q = requant_options(&map_opts, Path::new("inter.rad"), Path::new("out"), None);
+        assert_eq!(q.bias_speed_samp, defaults.bias_speed_samp);
+        assert_eq!(
+            q.no_bias_length_threshold,
+            defaults.no_bias_length_threshold
+        );
+        assert_eq!(q.init_uniform, defaults.init_uniform);
     }
 
     /// `--writeSam` is a spelling of `--writeMappings`, giving SAM output a

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -187,6 +187,14 @@ pub struct QuantOptions {
     /// disable the lower barrier on how short bias correction may make an
     /// effective length (salmon's `--noBiasLengthThreshold`)
     pub no_bias_length_threshold: bool,
+    /// `--initUniform`: start the EM from a uniform abundance vector instead of
+    /// from the counts the mapping pass observed.
+    ///
+    /// Only the RAD quantifier has an initialisation step to apply this to, so
+    /// it takes effect under `--deterministic` (and for `-a`/`--rad` input). The
+    /// one-pass reads path has no such step: its EM starts from the running
+    /// abundances it accumulated while mapping.
+    pub init_uniform: bool,
     /// number of fragment-GC bins in the GC bias model (salmon's `--numGCBins`,
     /// default 25)
     pub gc_bins: usize,
@@ -255,6 +263,7 @@ impl QuantOptions {
             bias_speed_samp: 5,
             num_aux_model_samples: 5_000_000,
             no_bias_length_threshold: false,
+            init_uniform: false,
             gc_bins: salmon_model::gcbias::DEFAULT_GC_BINS,
             cond_gc_bins: salmon_model::gcbias::DEFAULT_COND_BINS,
             skip_quant: false,


### PR DESCRIPTION
PR A of #1140. `run_deterministic` hand-copies the reads-mode request into the `AlignQuantOptions` the requant pass takes, and three knobs never made the trip: the flag was accepted, the run succeeded, and nothing happened.

## What was dropped

| flag | effect it should have | status before |
|---|---|---|
| `--biasSpeedSamp` | fragment-length stride of the GC effective-length convolution | forwarded nowhere; `AlignQuantOptions` default (5) used |
| `--noBiasLengthThreshold` | accept a bias-corrected effective length outright instead of flooring it at the lower barrier | same |
| `--initUniform` | start the EM from a uniform abundance vector | `QuantOptions` had no such field at all, so reads mode never carried it in either path |

`--initUniform` is now a `QuantOptions` field, per your note that the flip will want it there anyway.

## The seam, since the block was the root cause

The forwarding is now `requant_options(&map_opts, rad_path, out_dir, bias_targets) -> AlignQuantOptions`, with two unit tests: one sets every forwarded knob to a value different from its `AlignQuantOptions` default and asserts each one arrives, the other asserts an unset request leaves them at the defaults, so the first test is measuring forwarding rather than a coincidence. A field dropped from that mapping now fails a test instead of failing silently at runtime.

`ref_seqs` stays with the caller: it reads the index from disk, and only the caller knows whether bias correction asked for it.

## End-to-end, and what it can honestly show

`--biasSpeedSamp 25` with `--gcBias` under `--deterministic`, 3000-transcript fixture, 300k pairs:

```
before   quant.sf md5 57985fee3ebe9037e05071f3789efc06   (identical with and without the flag)
after    quant.sf md5 d5058db964800db47fa0146ddba4d74a   (differs from the no-flag run)
```

The other two produce no observable diff on that fixture, and I would rather say why than quietly omit them:

- `--noBiasLengthThreshold` removes a floor that only binds when a bias-corrected length falls below the uncorrected one. That never happens on this fixture, so the corrected lengths are the same either way.
- `--initUniform` changes where the EM starts, and it converges to the same optimum from either start on a well-conditioned input.

Both are forwarded and covered by the unit test. Neither absence of a diff is evidence that they are not.

## Out of scope, deliberately

`--initUniform` still does nothing in one-pass reads mode: there is no initialisation step there, since the online EM starts from the abundances it accumulated while mapping. Per your scoping this PR does not invent behaviour for a path headed for deprecation; it only stops the flag from being silently inert, with a warning naming where the flag does apply. Say the word if you would rather drop even the warning from this PR and let the flip handle it.
