### PR TITLE
feat(align): warn when a BAM has no usable AS to score by (#1140 PR D)

### DIFF
--- a/crates/salmon-align/src/bam_rad.rs
+++ b/crates/salmon-align/src/bam_rad.rs
@@ -72,6 +72,13 @@ const ERROR_MODEL_ALPHA: f64 = 1.0;
 pub struct AlignRadSummary {
     pub num_processed: u64,
     pub num_mapped: u64,
+    /// What was wrong with the BAM's `AS` tags, when the run scored by them and
+    /// they could not carry that weight. `None` when the tags were usable, or
+    /// when `--errorModel` scored the alignments instead.
+    ///
+    /// Returned as well as logged so a caller (and a test) can see the judgement
+    /// without capturing log output.
+    pub score_tag_warning: Option<String>,
 }
 
 /// Project a name-grouped transcriptome BAM into a fully-baked salmon RAD at
@@ -186,7 +193,22 @@ pub fn write_alignment_rad(
         let sums = stream_grouped(&opts.bam, nthreads, || {
             WriteWorker::new(&writer, &fld, naive.as_ref())
         })?;
-        reduce_summary(sums)
+        // The scores these records carry are only as good as the tags they came
+        // from, and a BAM without them fails silently: say so before the numbers
+        // are used for anything.
+        let mut tags = ScoreTagTally::new();
+        let mut plain = Vec::with_capacity(sums.len());
+        for (processed, mapped, worker_tags) in sums {
+            tags.merge(&worker_tags);
+            plain.push((processed, mapped));
+        }
+        let complaint = tags.warning();
+        if let Some(text) = &complaint {
+            tracing::warn!("{text}");
+        }
+        let mut summary = reduce_summary(plain);
+        summary.score_tag_warning = complaint;
+        summary
     };
 
     // ---- end-of-pass bake (single quant pass) ----------------------------
@@ -228,6 +250,84 @@ pub fn write_alignment_rad(
     Ok(summary)
 }
 
+/// What the one-pass writer saw of the BAM's `AS` tags, so the run can say when
+/// it had nothing to score with.
+///
+/// Without `--errorModel`, deterministic alignment mode takes each placement's
+/// weight from the BAM's `AS`. A missing tag parses as score 0, so a BAM with no
+/// `AS` at all (or one constant value) leaves every placement equally weighted
+/// and the EM apportions multireads by effective length alone. On a stripped-`AS`
+/// BAM that measured 3x the MARD of the same file with its tags intact
+/// (COMBINE-lab/salmon#1140), which is far too large a difference to leave
+/// unremarked.
+#[derive(Clone, Copy)]
+struct ScoreTagTally {
+    records: u64,
+    with_tag: u64,
+    min: i32,
+    max: i32,
+}
+
+impl ScoreTagTally {
+    const fn new() -> Self {
+        Self {
+            records: 0,
+            with_tag: 0,
+            min: i32::MAX,
+            max: i32::MIN,
+        }
+    }
+
+    fn observe(&mut self, has_tag: bool, score: i32) {
+        self.records += 1;
+        if has_tag {
+            self.with_tag += 1;
+            self.min = self.min.min(score);
+            self.max = self.max.max(score);
+        }
+    }
+
+    fn merge(&mut self, other: &Self) {
+        self.records += other.records;
+        self.with_tag += other.with_tag;
+        self.min = self.min.min(other.min);
+        self.max = self.max.max(other.max);
+    }
+
+    /// The complaint to make about this BAM, if any. Ordered by how badly the
+    /// scores are degraded, and silent when the tags are usable.
+    fn warning(&self) -> Option<String> {
+        if self.records == 0 {
+            return None;
+        }
+        let advice = "scoring falls back to equal weights for every placement of a fragment, so \
+                      multireads are apportioned by effective length alone; pass --errorModel \
+                      with -t <transcripts.fa> to score the alignments from their own bases \
+                      instead";
+        if self.with_tag == 0 {
+            return Some(format!(
+                "no alignment in this BAM carries an AS tag ({} records read): {advice}",
+                self.records
+            ));
+        }
+        if self.with_tag < self.records {
+            return Some(format!(
+                "{} of {} alignment records carry no AS tag: those score 0 while the rest keep \
+                 the aligner's score, which is not a comparison between them. {advice}",
+                self.records - self.with_tag,
+                self.records
+            ));
+        }
+        if self.min == self.max {
+            return Some(format!(
+                "every alignment in this BAM reports the same AS ({}): {advice}",
+                self.min
+            ));
+        }
+        None
+    }
+}
+
 fn reduce_summary(parts: Vec<(u64, u64)>) -> AlignRadSummary {
     let (mut num_processed, mut num_mapped) = (0u64, 0u64);
     for (p, m) in parts {
@@ -237,6 +337,7 @@ fn reduce_summary(parts: Vec<(u64, u64)>) -> AlignRadSummary {
     AlignRadSummary {
         num_processed,
         num_mapped,
+        score_tag_warning: None,
     }
 }
 
@@ -413,6 +514,8 @@ struct WriteWorker<'a> {
     scratch: Vec<FragRecord>,
     processed: u64,
     mapped: u64,
+    /// what this worker saw of the `AS` tags it is scoring by
+    tags: ScoreTagTally,
 }
 
 impl<'a> WriteWorker<'a> {
@@ -429,12 +532,13 @@ impl<'a> WriteWorker<'a> {
             scratch: Vec::new(),
             processed: 0,
             mapped: 0,
+            tags: ScoreTagTally::new(),
         }
     }
 }
 
 impl GroupWorker for WriteWorker<'_> {
-    type Output = (u64, u64);
+    type Output = (u64, u64, ScoreTagTally);
     fn handle<R: sam::alignment::Record>(&mut self, header: &Header, group: &[R]) -> Result<()> {
         self.processed += 1;
         let Some(data) = analyze_group(group, header, false, &mut self.scratch) else {
@@ -448,16 +552,23 @@ impl GroupWorker for WriteWorker<'_> {
             .collect();
         write_record(&data, &scores, &mut self.buf, self.writer)?;
         tally_fld_naive(&data, self.fld, self.naive);
+        // Per record, which is where the tag either is or is not. Judging
+        // constancy on the per-placement sum instead would miss a BAM whose
+        // every record says AS:i:100, since a pair sums to 200 and an orphan to
+        // 100 and the two look like variation.
+        for frag in &data.frags {
+            self.tags.observe(frag.has_score, frag.score);
+        }
         self.mapped += 1;
         self.scratch = data.frags;
         Ok(())
     }
-    fn finish(mut self) -> Result<(u64, u64)> {
+    fn finish(mut self) -> Result<(u64, u64, ScoreTagTally)> {
         if self.buf.nrec() > 0 {
             let bytes = self.buf.take_bytes()?;
             self.writer.append_chunk_bytes(&bytes)?;
         }
-        Ok((self.processed, self.mapped))
+        Ok((self.processed, self.mapped, self.tags))
     }
 }
 

--- a/crates/salmon-align/src/bam_rad.rs
+++ b/crates/salmon-align/src/bam_rad.rs
@@ -319,8 +319,14 @@ impl ScoreTagTally {
             ));
         }
         if self.min == self.max {
+            // Legitimately reachable: error-free reads of one length through an
+            // end-to-end aligner all score the same, which simulated data does
+            // routinely. The consequence holds either way, so the wording says
+            // what the column cannot do rather than implying the BAM is broken.
             return Some(format!(
-                "every alignment in this BAM reports the same AS ({}): {advice}",
+                "every alignment in this BAM reports the same AS ({}), which can be legitimate \
+                 for error-free reads of uniform length, but means the scores cannot distinguish \
+                 one placement from another: {advice}",
                 self.min
             ));
         }

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -652,6 +652,10 @@ struct FragRecord {
     /// salmon's behavior for CIGAR-bearing aligners (see [`salmon-align-as-weighting`]).
     #[allow(dead_code)]
     score: i32,
+    /// whether the record actually carried an `AS` tag. A missing tag reads as
+    /// `score: 0`, which is indistinguishable from a genuine zero, so presence
+    /// has to be recorded where the tag is read rather than inferred later.
+    has_score: bool,
     frag_len: i32,
     /// reverse-strand alignment (BAM `0x10` flag)
     is_reverse: bool,
@@ -797,12 +801,13 @@ fn record_to_frag<R: sam::alignment::Record>(
         .map(|(_, l)| l)
         .sum();
     let ops = if need_seq { ops } else { Vec::new() };
-    let score = record
+    let parsed_score = record
         .data()
         .get(&Tag::ALIGNMENT_SCORE)
         .and_then(|r| r.ok())
-        .and_then(|v| value_as_i32(&v))
-        .unwrap_or(0);
+        .and_then(|v| value_as_i32(&v));
+    let score = parsed_score.unwrap_or(0);
+    let has_score = parsed_score.is_some();
     let frag_len = record.template_length().map(|t| t.abs()).unwrap_or(0);
     let is_reverse = flags.is_reverse_complemented();
     let is_read1 = flags.is_first_segment();
@@ -834,6 +839,7 @@ fn record_to_frag<R: sam::alignment::Record>(
             read_2bit,
             ops,
             score,
+            has_score,
             frag_len,
             is_reverse,
             is_read1,
@@ -2899,6 +2905,7 @@ mod tests {
             read_2bit: Vec::new(),
             ops: Vec::new(),
             score: 0,
+            has_score: false,
             frag_len: 0,
             is_reverse,
             is_read1,

--- a/crates/salmon-align/tests/deterministic_bam.rs
+++ b/crates/salmon-align/tests/deterministic_bam.rs
@@ -247,3 +247,121 @@ fn deterministic_bam_is_reproducible() {
         "deterministic alignment quant must reproduce"
     );
 }
+
+// ---- AS-tag diagnostics ---------------------------------------------------
+
+/// Deterministic alignment mode without `--errorModel` scores each placement by
+/// the BAM's `AS`. These tests cover what the run says when that tag cannot
+/// carry the weight, because the failure is otherwise invisible: a missing tag
+/// reads as score 0, every placement ties, and multireads end up apportioned by
+/// effective length alone. On a stripped-`AS` BAM that measured three times the
+/// MARD of the same file with its tags intact (COMBINE-lab/salmon#1140).
+///
+/// `policy` decides the tag written on each record: `None` writes none.
+fn write_sam_with_as(dir: &Path, name: &str, policy: impl Fn(usize) -> Option<i32>) -> PathBuf {
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(f, "@HD\tVN:1.6\tSO:queryname").unwrap();
+    writeln!(f, "@SQ\tSN:txA\tLN:5000").unwrap();
+    writeln!(f, "@SQ\tSN:txB\tLN:5000").unwrap();
+    let mut pos = 1usize;
+    for i in 0..40 {
+        let (l, r) = (pos + 1, pos + 201);
+        let tag = |idx: usize| match policy(idx) {
+            Some(score) => format!("\tAS:i:{score}"),
+            None => String::new(),
+        };
+        writeln!(
+            f,
+            "a{i}\t99\ttxA\t{l}\t60\t100M\t=\t{r}\t300\t*\t*{}",
+            tag(2 * i)
+        )
+        .unwrap();
+        writeln!(
+            f,
+            "a{i}\t147\ttxA\t{r}\t60\t100M\t=\t{l}\t-300\t*\t*{}",
+            tag(2 * i + 1)
+        )
+        .unwrap();
+        pos += 400;
+    }
+    path
+}
+
+fn warning_for(dir: &Path, name: &str, policy: impl Fn(usize) -> Option<i32>) -> Option<String> {
+    let sam = write_sam_with_as(dir, name, policy);
+    let out = dir.join(format!("{name}.out"));
+    std::fs::create_dir_all(&out).unwrap();
+    let opts = opts_for(&sam, &out);
+    let rad = dir.join(format!("{name}.rad"));
+    write_alignment_rad(&opts, &rad, ChunkCodec::None)
+        .unwrap()
+        .score_tag_warning
+}
+
+#[test]
+/// A BAM with no `AS` at all cannot be scored, and the run has to say so rather
+/// than reporting numbers derived from an all-zero score column.
+fn an_as_less_bam_is_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    let warning = warning_for(dir.path(), "no_as.sam", |_| None).expect("a warning");
+    assert!(
+        warning.contains("no alignment in this BAM carries an AS tag"),
+        "{warning}"
+    );
+    assert!(
+        warning.contains("--errorModel"),
+        "the warning has to name the way out: {warning}"
+    );
+}
+
+#[test]
+/// One constant `AS` conveys exactly as much as none, and has to be caught at
+/// the record level: a proper pair sums to twice an orphan's score, so judging
+/// constancy on the per-placement sum would call a constant BAM varied.
+fn a_constant_as_is_reported_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let warning = warning_for(dir.path(), "const_as.sam", |_| Some(100)).expect("a warning");
+    assert!(
+        warning.contains("every alignment in this BAM reports the same AS (100)"),
+        "{warning}"
+    );
+}
+
+#[test]
+/// A partially tagged BAM is worse than either: the untagged records score 0
+/// against real scores, which is not a comparison between them.
+fn a_partially_tagged_bam_is_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    let warning = warning_for(dir.path(), "partial_as.sam", |i| {
+        (i % 2 == 0).then_some(200 - i as i32)
+    })
+    .expect("a warning");
+    assert!(warning.contains("carry no AS tag"), "{warning}");
+}
+
+#[test]
+/// Varying tags are exactly what the mode expects, so nothing is said.
+fn usable_as_tags_draw_no_complaint() {
+    let dir = tempfile::tempdir().unwrap();
+    let warning = warning_for(dir.path(), "good_as.sam", |i| Some(150 + (i as i32 % 7)));
+    assert!(warning.is_none(), "unexpected complaint: {warning:?}");
+}
+
+#[test]
+/// With `--errorModel` the scores come from the alignments' own bases, so the
+/// state of the `AS` tags is irrelevant and saying anything about them would be
+/// noise.
+fn the_error_model_path_says_nothing_about_as() {
+    let dir = tempfile::tempdir().unwrap();
+    let (sam, fasta) = write_seq_fixture(dir.path());
+    let out = dir.path().join("em.out");
+    std::fs::create_dir_all(&out).unwrap();
+    let mut opts = AlignQuantOptions::new(sam, out);
+    opts.lib_type = "IU".to_string();
+    opts.deterministic_error_model = true;
+    opts.transcripts = Some(fasta);
+    let rad = dir.path().join("em.rad");
+    let summary = write_alignment_rad(&opts, &rad, ChunkCodec::None).unwrap();
+    assert!(summary.score_tag_warning.is_none());
+}


### PR DESCRIPTION
PR D of #1140. Deterministic alignment mode without `--errorModel` weights each placement by the BAM's `AS`. A missing tag parses as score 0, indistinguishable from a genuine zero, so a BAM with no `AS` leaves every placement of a fragment tied and the EM apportions multireads by effective length alone. Same exit code, same output shape, quietly worse numbers.

## The cost of staying silent

Same BAM, once as produced and once with the tags stripped, against the truth in the read names (3000-transcript fixture, 300k pairs):

| input | mode | Spearman | MARD |
|---|---|---|---|
| with `AS` | det | 0.92081 | 0.02294 |
| no `AS` | det | **0.76235** | **0.06890** |
| no `AS` | det `--errorModel -t` | 0.90438 | 0.02443 |

Three times the MARD, and the remedy already exists.

## What this adds

Presence is counted where the tag is read, per your note that `record_to_frag` maps a missing `AS` to 0: by the time scores exist, absent and zero are the same number. Each worker tallies `(records, records_with_AS, min, max)`; the tallies merge alongside the existing summary reduction.

Three states draw a complaint, each naming `--errorModel -t` as the way out:

- no record carries `AS`
- some records carry it and some do not, so zeros compete with real scores
- every record reports the same value

The third is why the count is per record rather than per placement, as you suggested optionally: a proper pair sums to twice an orphan's score, so a BAM whose every record says `AS:i:100` looks varied if you judge the sums.

Observed on the three fixtures:

```
with_as   (no warning)
no_as     no alignment in this BAM carries an AS tag (890098 records read): scoring falls back to
          equal weights for every placement of a fragment, so multireads are apportioned by
          effective length alone; pass --errorModel with -t <transcripts.fa> to score the
          alignments from their own bases instead
const_as  every alignment in this BAM reports the same AS (100): [same advice]
```

## Scope

The error-model path never reads `AS`, so it says nothing (structurally: the tally only exists in the branch that scores by the tag). Genome projection goes through `project_genome_bam_to_rad` and scores by bramble similarities, so it is untouched, per your exemption.

## Testing

The verdict is returned on `AlignRadSummary` as well as logged, so the tests assert on a value rather than capturing log output. Five cases in `crates/salmon-align/tests/deterministic_bam.rs`: absent, constant, partial, varying (silent), and the error-model path (silent). The existing fixture in that file carries no `AS` at all, which is how the absent case gets a realistic input for free.
