### PR TITLE
Disk-aware deterministic intermediate: `--radScratchDir`, space preflight, fast ENOSPC, failure cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ name = "salmon-core"
 version = "2.5.1"
 dependencies = [
  "flate2",
+ "libc",
  "niffler",
  "serde",
  "serde_json",

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -187,6 +187,14 @@ pub struct AlignQuantOptions {
     /// initialize the EM uniformly instead of with the online-estimate-blended
     /// warm start (`--initUniform`)
     pub init_uniform: bool,
+    /// wall-clock seconds a driver already spent before this call (phase 1 of
+    /// `--deterministic`, or genome projection); added to the reported
+    /// `total_time_seconds` so `meta_info.json` covers the whole run rather
+    /// than only the quantification pass
+    pub prior_seconds: f64,
+    /// start time (asctime) of that earlier phase; when set, reported as the
+    /// run's `start_time` instead of this pass's own
+    pub external_start_time: Option<String>,
     /// significant digits for the EffectiveLength and NumReads columns of
     /// `quant.sf` (`--sigDigits`, salmon default 3)
     pub sig_digits: u32,
@@ -252,6 +260,8 @@ impl AlignQuantOptions {
             explicit_fld_args: ExplicitFldArgs::default(),
             forgetting_factor: 0.65,
             init_uniform: false,
+            prior_seconds: 0.0,
+            external_start_time: None,
             sig_digits: 3,
             num_error_bins: 4,
             discard_orphans: false,
@@ -356,7 +366,7 @@ pub struct AlignQuantResult {
 }
 
 /// Current local time as an asctime-style string, matching salmon's timestamps.
-fn asctime_now() -> String {
+pub fn asctime_now() -> String {
     jiff::Zoned::now()
         .strftime("%a %b %e %H:%M:%S %Y")
         .to_string()
@@ -2015,7 +2025,7 @@ fn apply_bias_correction(
 
 /// Run alignment-based quantification end-to-end.
 pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult> {
-    let start_time = asctime_now();
+    let start_time = opts.external_start_time.clone().unwrap_or_else(asctime_now);
     let run_timer = std::time::Instant::now();
     let mut timer = PhaseTimer::new();
     let header = read_alignment_header(&opts.bam)?;
@@ -2491,7 +2501,7 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
         em_iters,
         em_converged,
         detected_library_type,
-        total_seconds: run_timer.elapsed().as_secs_f64(),
+        total_seconds: opts.prior_seconds + run_timer.elapsed().as_secs_f64(),
         peak_rss_kb: salmon_core::peak_rss_kb(),
         diagnostics,
     };
@@ -2589,6 +2599,11 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         num_em_iterations: u32,
         em_converged: bool,
         detected_library_type: Option<String>,
+        /// which inference path produced these results: `deterministic` (RAD
+        /// input — including `--deterministic`'s phase 2) or `online` (the
+        /// streaming BAM pass). Makes the online-to-deterministic transition
+        /// auditable from existing output (#1140).
+        inference_path: &'static str,
         total_time_seconds: f64,
         peak_rss_kb: u64,
         diagnostics: Vec<salmon_core::Diagnostic>,
@@ -2714,6 +2729,10 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         num_em_iterations: res.em_iters,
         em_converged: res.em_converged,
         detected_library_type: res.detected_library_type.clone(),
+        inference_path: match res.source {
+            FragmentSource::Rad => "deterministic",
+            FragmentSource::Bam => "online",
+        },
         total_time_seconds: res.total_seconds,
         peak_rss_kb: res.peak_rss_kb,
         diagnostics: res.diagnostics.clone(),

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -1621,7 +1621,7 @@ where
 
 /// Quantify from a RAD file (`salmon quant --rad`).
 pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQuantResult> {
-    let start_time = asctime_now();
+    let start_time = opts.external_start_time.clone().unwrap_or_else(asctime_now);
     let run_timer = std::time::Instant::now();
     let mut timer = PhaseTimer::new();
 
@@ -2233,7 +2233,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         em_iters,
         em_converged,
         detected_library_type,
-        total_seconds: run_timer.elapsed().as_secs_f64(),
+        total_seconds: opts.prior_seconds + run_timer.elapsed().as_secs_f64(),
         peak_rss_kb: salmon_core::peak_rss_kb(),
         diagnostics,
     };

--- a/crates/salmon-align/tests/rad_lib_format_counts.rs
+++ b/crates/salmon-align/tests/rad_lib_format_counts.rs
@@ -239,3 +239,38 @@ fn rad_requant_baked_library_format_is_authoritative() {
     assert_eq!(u64_field(&v, "ISF"), 30);
     assert_eq!(u64_field(&v, "ISR"), 20);
 }
+
+/// A two-phase driver hands its phase-1 timing to the requant, and
+/// `meta_info.json` must report the whole run plus which inference path ran
+/// (#1140): `total_time_seconds` previously covered only the second pass
+/// (0.4s reported against minutes of wall on real data), and nothing recorded
+/// that the deterministic path produced the output.
+#[test]
+fn requant_reports_run_spanning_time_and_inference_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("timed.rad");
+    write_mixed_orientation_rad(&rad, 30, 20);
+    let out = tmp.path().join("timed_out");
+    let mut o = AlignQuantOptions::new(rad.clone(), out.clone());
+    o.lib_type = "IU".to_string();
+    o.fld_mean = 200.0;
+    o.fld_sd = 20.0;
+    o.prior_seconds = 100.0;
+    o.external_start_time = Some("Thu Jan  1 00:00:00 2026".to_string());
+    let res = quantify_rad(&o, &rad).expect("quantify_rad");
+    assert!(
+        res.total_seconds >= 100.0,
+        "total_seconds {} must include the driver's prior phase",
+        res.total_seconds
+    );
+    let meta: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(meta["total_time_seconds"].as_f64().unwrap() >= 100.0);
+    assert_eq!(
+        meta["start_time"].as_str().unwrap(),
+        "Thu Jan  1 00:00:00 2026"
+    );
+    assert_eq!(meta["inference_path"].as_str().unwrap(), "deterministic");
+}

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -556,6 +556,12 @@ struct QuantArgs {
     /// deleted once quantification finishes). Ignored without --deterministic.
     #[arg(long = "keepRad")]
     keep_rad: bool,
+    /// Directory for the intermediate RAD written by --deterministic (default:
+    /// the output directory). Point this at node-local or memory-backed
+    /// storage (e.g. /dev/shm) when the output volume is slow, networked, or
+    /// space-constrained. Ignored when --writeRad names an explicit path.
+    #[arg(long = "radScratchDir")]
+    rad_scratch_dir: Option<PathBuf>,
     /// Enable sequence-specific bias correction.
     #[arg(long = "seqBias")]
     seq_bias: bool,
@@ -1085,6 +1091,83 @@ fn write_gene_level(
 /// Bias correction needs the reference sequence, but since we control both passes
 /// and phase 1 loads the index, we hand the index's sequences to phase 2 — so
 /// `--deterministic --seqBias/--gcBias/--posBias` needs no separate `-t`.
+/// Where a two-phase run's salmon-owned intermediate RAD lives: in
+/// `--radScratchDir` when given (created if needed; pid-suffixed so concurrent
+/// runs sharing one scratch volume cannot collide at the finalize rename), else
+/// under the output directory as before.
+fn intermediate_rad_path(
+    out_dir: &std::path::Path,
+    scratch_dir: Option<&std::path::Path>,
+    stem: &str,
+) -> Result<PathBuf> {
+    match scratch_dir {
+        Some(d) => {
+            std::fs::create_dir_all(d)
+                .with_context(|| format!("creating --radScratchDir {}", d.display()))?;
+            Ok(d.join(format!("{stem}-{}.rad", std::process::id())))
+        }
+        None => Ok(out_dir.join(format!("{stem}.rad"))),
+    }
+}
+
+/// Best-effort removal of a salmon-owned intermediate RAD after a failed phase:
+/// the finalized file if it exists, and any `.partial-*` sibling a failed
+/// mapping pass left behind. The failure that fills a disk is precisely the one
+/// where the user needs the space back (#1140); an explicit `--writeRad` path
+/// is user-owned evidence and is never cleaned here.
+fn cleanup_intermediate_rad(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    if let (Some(dir), Some(name)) = (path.parent(), path.file_name().and_then(|n| n.to_str())) {
+        let prefix = format!("{name}.partial-");
+        if let Ok(rd) = std::fs::read_dir(dir) {
+            for e in rd.flatten() {
+                if e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with(&prefix))
+                {
+                    let _ = std::fs::remove_file(e.path());
+                }
+            }
+        }
+    }
+}
+
+/// Total size of the given input files, for the intermediate-RAD space
+/// preflight; unreadable paths contribute 0 (the mapping pass will report them
+/// properly).
+fn total_file_bytes<'a>(paths: impl IntoIterator<Item = &'a PathBuf>) -> u64 {
+    paths
+        .into_iter()
+        .filter_map(|p| std::fs::metadata(p).ok())
+        .map(|m| m.len())
+        .sum()
+}
+
+/// Warn up front when the volume that will hold the intermediate RAD has less
+/// free space than the total compressed input. The lz4 intermediate is
+/// typically of the same order as the compressed input (and grows with the
+/// multimapping rate, so no fixed per-fragment constant is safe — #1140); this
+/// is a warning rather than an error because the estimate is a proxy, and the
+/// RAD writer's periodic low-space check turns a genuinely filling disk into a
+/// prompt, actionable failure.
+fn preflight_rad_space(rad_path: &std::path::Path, input_bytes: u64) {
+    let dir = rad_path.parent().unwrap_or(std::path::Path::new("."));
+    if let Some(free) = salmon_core::free_disk_bytes(dir) {
+        if free < input_bytes {
+            let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
+            tracing::warn!(
+                "{} has {:.1} GiB free, less than the {:.1} GiB of input; the \
+                 deterministic intermediate RAD is typically of the same order as \
+                 the compressed input and may not fit. Consider --radScratchDir \
+                 <dir> (e.g. /dev/shm or node-local scratch) or --radCompress zstd.",
+                dir.display(),
+                gib(free),
+                gib(input_bytes)
+            );
+        }
+    }
+}
+
 // `--deterministic` (reads mode): a two-pass run. The first pass maps to a RAD
 // with order-independent models baked into the header; the second quantifies
 // from it. Splitting the run this way is what makes the result independent of
@@ -1092,6 +1175,7 @@ fn write_gene_level(
 fn run_deterministic(
     mut map_opts: QuantOptions,
     rad_out: Option<PathBuf>,
+    scratch_dir: Option<&std::path::Path>,
     keep_rad: bool,
     bias_targets: Option<PathBuf>,
     gene_map: Option<&GeneMapOpts>,
@@ -1107,11 +1191,27 @@ fn run_deterministic(
     // output); otherwise a temp under the output directory, removed on success
     // unless `--keepRad`.
     let explicit = rad_out.is_some();
-    let rad_path = rad_out.unwrap_or_else(|| out_dir.join("intermediate_mappings.rad"));
+    if explicit && scratch_dir.is_some() {
+        tracing::warn!("--radScratchDir is ignored when --writeRad names an explicit path");
+    }
+    let rad_path = match rad_out {
+        Some(p) => p,
+        None => intermediate_rad_path(out_dir, scratch_dir, "intermediate_mappings")?,
+    };
     // The RAD writer opens its file before the mapping pass, so the output
     // directory (where the default intermediate lives) must exist first.
     std::fs::create_dir_all(out_dir)
         .with_context(|| format!("creating output directory {}", out_dir.display()))?;
+    preflight_rad_space(
+        &rad_path,
+        total_file_bytes(
+            map_opts
+                .mates1
+                .iter()
+                .chain(map_opts.mates2.iter())
+                .chain(map_opts.unmated.iter()),
+        ),
+    );
 
     // Phase 1 — map once, write the RAD (bakes the deterministic FLD + resolved
     // library format), skipping the online EM: quantification happens in phase 2.
@@ -1121,7 +1221,15 @@ fn run_deterministic(
     // bake them (see `QuantOptions::deterministic_fld`), so phase 2 is a single
     // pass and the whole result is byte-identical across thread counts.
     map_opts.deterministic_fld = true;
-    let map_res = quantify(&map_opts).context("deterministic mapping pass failed")?;
+    let map_res = match quantify(&map_opts) {
+        Ok(r) => r,
+        Err(e) => {
+            if !explicit {
+                cleanup_intermediate_rad(&rad_path);
+            }
+            return Err(e).context("deterministic mapping pass failed");
+        }
+    };
     let pct = if map_res.num_processed > 0 {
         100.0 * map_res.num_mapped as f64 / map_res.num_processed as f64
     } else {
@@ -1167,7 +1275,15 @@ fn run_deterministic(
     q.thinning_factor = map_opts.thinning_factor;
     q.prior_seconds = run_start.elapsed().as_secs_f64();
     q.external_start_time = Some(map_res.start_time.clone());
-    let res = quantify_rad(&q, &rad_path).context("deterministic requant pass failed")?;
+    let res = match quantify_rad(&q, &rad_path) {
+        Ok(r) => r,
+        Err(e) => {
+            if !explicit && !keep_rad {
+                cleanup_intermediate_rad(&rad_path);
+            }
+            return Err(e).context("deterministic requant pass failed");
+        }
+    };
     let pct2 = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
     } else {
@@ -1214,6 +1330,7 @@ fn run_deterministic(
 fn run_deterministic_align(
     mut opts: AlignQuantOptions,
     rad_out: Option<PathBuf>,
+    scratch_dir: Option<&std::path::Path>,
     keep_rad: bool,
     gene_map: Option<&GeneMapOpts>,
     codec: ChunkCodec,
@@ -1226,14 +1343,28 @@ fn run_deterministic_align(
     // the output dir, removed on success unless `--keepRad` (or `--skipQuant`,
     // where the RAD is the deliverable).
     let explicit = rad_out.is_some();
-    let rad_path = rad_out.unwrap_or_else(|| out_dir.join("intermediate_alignments.rad"));
+    if explicit && scratch_dir.is_some() {
+        tracing::warn!("--radScratchDir is ignored when --writeRad names an explicit path");
+    }
+    let rad_path = match rad_out {
+        Some(p) => p,
+        None => intermediate_rad_path(&out_dir, scratch_dir, "intermediate_alignments")?,
+    };
     std::fs::create_dir_all(&out_dir)
         .with_context(|| format!("creating output directory {}", out_dir.display()))?;
+    preflight_rad_space(&rad_path, total_file_bytes(std::iter::once(&opts.bam)));
 
     // Phase 1 — one BAM pass: write placements + bake FLD / library format
     // (+ rough abundances when bias is on) so phase 2 is a single baked pass.
-    let summary = salmon_align::write_alignment_rad(&opts, &rad_path, codec)
-        .context("deterministic alignment RAD-write pass failed")?;
+    let summary = match salmon_align::write_alignment_rad(&opts, &rad_path, codec) {
+        Ok(r) => r,
+        Err(e) => {
+            if !explicit {
+                cleanup_intermediate_rad(&rad_path);
+            }
+            return Err(e).context("deterministic alignment RAD-write pass failed");
+        }
+    };
     let pct = if summary.num_processed > 0 {
         100.0 * summary.num_mapped as f64 / summary.num_processed as f64
     } else {
@@ -1249,7 +1380,15 @@ fn run_deterministic_align(
     // Phase 2 — quantify from the fully-baked RAD (single pass, order-independent).
     opts.prior_seconds = run_start.elapsed().as_secs_f64();
     opts.external_start_time = Some(start_time);
-    let res = quantify_rad(&opts, &rad_path).context("deterministic requant pass failed")?;
+    let res = match quantify_rad(&opts, &rad_path) {
+        Ok(r) => r,
+        Err(e) => {
+            if !explicit && !keep_rad && !opts.skip_quant {
+                cleanup_intermediate_rad(&rad_path);
+            }
+            return Err(e).context("deterministic requant pass failed");
+        }
+    };
     let pct2 = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
     } else {
@@ -1307,6 +1446,7 @@ fn run_genome_project(
     gp: GenomeProjectOptions,
     q: AlignQuantOptions,
     rad_out: Option<PathBuf>,
+    scratch_dir: Option<&std::path::Path>,
     keep_rad: bool,
     gene_map: Option<&GeneMapOpts>,
 ) -> Result<()> {
@@ -1315,12 +1455,27 @@ fn run_genome_project(
     let start_time = salmon_align::asctime_now();
     let out_dir = q.output_dir.clone();
     let explicit = rad_out.is_some();
-    let rad_path = rad_out.unwrap_or_else(|| out_dir.join("genome_projected.rad"));
+    if explicit && scratch_dir.is_some() {
+        tracing::warn!("--radScratchDir is ignored when --writeRad names an explicit path");
+    }
+    let rad_path = match rad_out {
+        Some(p) => p,
+        None => intermediate_rad_path(&out_dir, scratch_dir, "genome_projected")?,
+    };
     std::fs::create_dir_all(&out_dir)
         .with_context(|| format!("creating output directory {}", out_dir.display()))?;
+    preflight_rad_space(&rad_path, total_file_bytes(std::iter::once(&gp.bam)));
 
     // Phase 1 — project the genome BAM into a fully-baked transcriptome RAD.
-    let art = project_genome_bam_to_rad(&gp, &rad_path).context("genome projection pass failed")?;
+    let art = match project_genome_bam_to_rad(&gp, &rad_path) {
+        Ok(r) => r,
+        Err(e) => {
+            if !explicit {
+                cleanup_intermediate_rad(&rad_path);
+            }
+            return Err(e).context("genome projection pass failed");
+        }
+    };
     let pct = if art.num_processed > 0 {
         100.0 * art.num_mapped as f64 / art.num_processed as f64
     } else {
@@ -1342,7 +1497,15 @@ fn run_genome_project(
     }
     q.prior_seconds = run_start.elapsed().as_secs_f64();
     q.external_start_time = Some(start_time);
-    let res = quantify_rad(&q, &rad_path).context("genome-projected quantification failed")?;
+    let res = match quantify_rad(&q, &rad_path) {
+        Ok(r) => r,
+        Err(e) => {
+            if !explicit && !keep_rad {
+                cleanup_intermediate_rad(&rad_path);
+            }
+            return Err(e).context("genome-projected quantification failed");
+        }
+    };
     tracing::info!(
         "{} fragments from projected RAD, {} quantified; {} equivalence classes",
         res.num_processed,
@@ -1530,6 +1693,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
                 gp,
                 opts,
                 args.write_rad.clone(),
+                args.rad_scratch_dir.as_deref(),
                 args.keep_rad,
                 gene_map.as_ref(),
             );
@@ -1544,6 +1708,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             return run_deterministic_align(
                 opts,
                 args.write_rad.clone(),
+                args.rad_scratch_dir.as_deref(),
                 args.keep_rad,
                 gene_map.as_ref(),
                 codec,
@@ -1795,6 +1960,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         return run_deterministic(
             opts,
             rad_out,
+            args.rad_scratch_dir.as_deref(),
             args.keep_rad,
             args.targets.clone(),
             gene_map.as_ref(),
@@ -2248,5 +2414,48 @@ mod tests {
         assert!(opts.ignore_tx_version);
         assert_eq!(opts.map.get("T1").map(String::as_str), Some("G1"));
         assert_eq!(opts.map.get("T2").map(String::as_str), Some("G1"));
+    }
+
+    /// The salmon-owned intermediate goes to the scratch dir (pid-suffixed so
+    /// concurrent runs sharing one scratch volume cannot collide) when given,
+    /// else under the output directory with the historical fixed name.
+    #[test]
+    fn intermediate_rad_path_placement() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("out");
+        let scratch = tmp.path().join("scratch");
+
+        let p = intermediate_rad_path(&out, None, "intermediate_mappings").unwrap();
+        assert_eq!(p, out.join("intermediate_mappings.rad"));
+
+        let p = intermediate_rad_path(&out, Some(&scratch), "intermediate_mappings").unwrap();
+        assert!(scratch.is_dir(), "scratch dir must be created");
+        assert_eq!(p.parent().unwrap(), scratch);
+        let name = p.file_name().unwrap().to_str().unwrap();
+        assert!(
+            name.starts_with("intermediate_mappings-") && name.ends_with(".rad"),
+            "pid-suffixed name, got {name}"
+        );
+    }
+
+    /// After a failed pass, cleanup removes the finalized intermediate and any
+    /// `.partial-*` sibling, and touches nothing else in the directory.
+    #[test]
+    fn cleanup_intermediate_rad_removes_file_and_partials() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rad = tmp.path().join("intermediate_mappings.rad");
+        let partial = tmp.path().join("intermediate_mappings.rad.partial-12345");
+        let bystander = tmp.path().join("quant.sf");
+        std::fs::write(&rad, b"x").unwrap();
+        std::fs::write(&partial, b"x").unwrap();
+        std::fs::write(&bystander, b"x").unwrap();
+
+        cleanup_intermediate_rad(&rad);
+        assert!(!rad.exists());
+        assert!(!partial.exists());
+        assert!(bystander.exists());
+
+        // Idempotent on an already-clean directory.
+        cleanup_intermediate_rad(&rad);
     }
 }

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1097,6 +1097,11 @@ fn run_deterministic(
     gene_map: Option<&GeneMapOpts>,
     out_dir: &std::path::Path,
 ) -> Result<()> {
+    // Wall-clock accounting spans both phases: phase 2 rewrites
+    // `meta_info.json` into the final output directory, and its
+    // `total_time_seconds` must cover the whole run, not just the requant
+    // (#1140: a 10M-pair run otherwise reports ~0.4s against minutes of wall).
+    let run_start = std::time::Instant::now();
     let bias_on = map_opts.seq_bias || map_opts.gc_bias || map_opts.pos_bias;
     // An explicit `--writeRad PATH` is honoured (and kept — it was a requested
     // output); otherwise a temp under the output directory, removed on success
@@ -1160,6 +1165,8 @@ fn run_deterministic(
     q.num_bootstraps = map_opts.num_bootstraps;
     q.num_gibbs_samples = map_opts.num_gibbs_samples;
     q.thinning_factor = map_opts.thinning_factor;
+    q.prior_seconds = run_start.elapsed().as_secs_f64();
+    q.external_start_time = Some(map_res.start_time.clone());
     let res = quantify_rad(&q, &rad_path).context("deterministic requant pass failed")?;
     let pct2 = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
@@ -1205,12 +1212,15 @@ fn run_deterministic(
 /// BAM `AS` tag); the online alignment error model is not used in this mode.
 // The same two-pass split for alignment input: BAM to RAD, then quantify.
 fn run_deterministic_align(
-    opts: AlignQuantOptions,
+    mut opts: AlignQuantOptions,
     rad_out: Option<PathBuf>,
     keep_rad: bool,
     gene_map: Option<&GeneMapOpts>,
     codec: ChunkCodec,
 ) -> Result<()> {
+    // Both phases count toward the reported run time (see run_deterministic).
+    let run_start = std::time::Instant::now();
+    let start_time = salmon_align::asctime_now();
     let out_dir = opts.output_dir.clone();
     // An explicit `--writeRad PATH` is honoured and kept; otherwise a temp under
     // the output dir, removed on success unless `--keepRad` (or `--skipQuant`,
@@ -1237,6 +1247,8 @@ fn run_deterministic_align(
     );
 
     // Phase 2 — quantify from the fully-baked RAD (single pass, order-independent).
+    opts.prior_seconds = run_start.elapsed().as_secs_f64();
+    opts.external_start_time = Some(start_time);
     let res = quantify_rad(&opts, &rad_path).context("deterministic requant pass failed")?;
     let pct2 = if res.num_processed > 0 {
         100.0 * res.num_mapped as f64 / res.num_processed as f64
@@ -1298,6 +1310,9 @@ fn run_genome_project(
     keep_rad: bool,
     gene_map: Option<&GeneMapOpts>,
 ) -> Result<()> {
+    // Both phases count toward the reported run time (see run_deterministic).
+    let run_start = std::time::Instant::now();
+    let start_time = salmon_align::asctime_now();
     let out_dir = q.output_dir.clone();
     let explicit = rad_out.is_some();
     let rad_path = rad_out.unwrap_or_else(|| out_dir.join("genome_projected.rad"));
@@ -1325,6 +1340,8 @@ fn run_genome_project(
     if q.ref_seqs.is_none() {
         q.ref_seqs = art.ref_seqs;
     }
+    q.prior_seconds = run_start.elapsed().as_secs_f64();
+    q.external_start_time = Some(start_time);
     let res = quantify_rad(&q, &rad_path).context("genome-projected quantification failed")?;
     tracing::info!(
         "{} fragments from projected RAD, {} quantified; {} equivalence classes",

--- a/crates/salmon-core/Cargo.toml
+++ b/crates/salmon-core/Cargo.toml
@@ -18,6 +18,12 @@ tracing = { workspace = true }
 # transparent decompression of compressed --geneMap annotations
 niffler = { workspace = true }
 
+# statvfs, for the free-disk-space probe behind the RAD-intermediate
+# preflight/low-space checks (unix only; the probe reports None elsewhere)
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+
 [lints]
 workspace = true
 

--- a/crates/salmon-core/src/diagnostics.rs
+++ b/crates/salmon-core/src/diagnostics.rs
@@ -220,6 +220,10 @@ pub fn free_disk_bytes(path: &std::path::Path) -> Option<u64> {
         // SAFETY: `c` is a valid NUL-terminated path and `st` a valid out
         // pointer for the duration of the call.
         if unsafe { libc::statvfs(c.as_ptr(), &mut st) } == 0 {
+            // The field widths differ per platform (u64 on Linux, narrower on
+            // macOS), so the casts are required on some targets and "identity"
+            // on others — hence the allow rather than removing them.
+            #[allow(clippy::unnecessary_cast)]
             Some(st.f_bavail as u64 * st.f_frsize as u64)
         } else {
             None

--- a/crates/salmon-core/src/diagnostics.rs
+++ b/crates/salmon-core/src/diagnostics.rs
@@ -195,3 +195,60 @@ impl MissingMetaField {
         }
     }
 }
+
+/// Free bytes available to unprivileged writes on the filesystem holding
+/// `path` (`statvfs`: `f_bavail * f_frsize`), or `None` where the answer is
+/// unavailable — a non-Unix platform, or a path `statvfs` rejects. Callers
+/// treat `None` as "cannot check", never as "no space".
+///
+/// Behind the deterministic-intermediate disk checks (#1140): the RAD writer
+/// probes this periodically so a filling disk fails in seconds with an
+/// actionable message instead of at the end of the mapping pass, and the
+/// two-phase drivers probe it up front to warn before minutes of work.
+// The only unsafe in the crate: `statvfs` has no std or pure-Rust equivalent,
+// and the two blocks below are the minimal FFI surface for it — a zeroed
+// plain-old-data out-parameter and one libc call that fills it.
+#[allow(unsafe_code)]
+pub fn free_disk_bytes(path: &std::path::Path) -> Option<u64> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        let c = std::ffi::CString::new(path.as_os_str().as_bytes()).ok()?;
+        // SAFETY: `statvfs` is plain old data; the all-zero bit pattern is a
+        // valid (if meaningless) value, and the call below overwrites it.
+        let mut st: libc::statvfs = unsafe { std::mem::zeroed() };
+        // SAFETY: `c` is a valid NUL-terminated path and `st` a valid out
+        // pointer for the duration of the call.
+        if unsafe { libc::statvfs(c.as_ptr(), &mut st) } == 0 {
+            Some(st.f_bavail as u64 * st.f_frsize as u64)
+        } else {
+            None
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+#[cfg(test)]
+mod fs_tests {
+    /// On Unix the probe must answer for an existing, writable directory; the
+    /// value itself is machine-dependent, so only its presence is asserted.
+    #[test]
+    #[cfg(unix)]
+    fn free_disk_bytes_answers_for_tmp() {
+        let d = std::env::temp_dir();
+        assert!(super::free_disk_bytes(&d).is_some());
+    }
+
+    /// A nonexistent path is "cannot check", not a panic.
+    #[test]
+    fn free_disk_bytes_none_for_missing_path() {
+        assert!(
+            super::free_disk_bytes(std::path::Path::new("/definitely/not/a/real/path/xyz"))
+                .is_none()
+        );
+    }
+}

--- a/crates/salmon-core/src/lib.rs
+++ b/crates/salmon-core/src/lib.rs
@@ -50,7 +50,7 @@ pub mod transcript;
 // modules later without breaking every caller.
 pub use atomic::AtomicF64;
 pub use diagnostics::{
-    input_diagnostics, peak_rss_kb, Diagnostic, MetaFieldSource, MissingMetaField,
+    free_disk_bytes, input_diagnostics, peak_rss_kb, Diagnostic, MetaFieldSource, MissingMetaField,
 };
 pub use libtype::{
     compatible_paired, compatible_single, is_compatible, observed_paired_format,

--- a/crates/salmon-quant/src/output.rs
+++ b/crates/salmon-quant/src/output.rs
@@ -363,6 +363,12 @@ struct MetaInfo {
     em_converged: bool,
     /// library format observed by the auto-detector (null if not observed)
     detected_library_type: Option<String>,
+    /// which inference path produced these results: `online` (the one-pass
+    /// streaming quant), or `none` for a mapping-only `--skipQuant` pass (a
+    /// `--deterministic` run's phase 2 rewrites this file with
+    /// `deterministic`). Makes the online-to-deterministic transition
+    /// auditable from existing output (#1140).
+    inference_path: &'static str,
     /// total wall-clock seconds and peak resident set size (KiB, Linux)
     total_time_seconds: f64,
     peak_rss_kb: u64,
@@ -461,6 +467,7 @@ fn write_meta_info(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Resul
         num_em_iterations: res.em_iters,
         em_converged: res.em_converged,
         detected_library_type: res.detected_library_type.clone(),
+        inference_path: if opts.skip_quant { "none" } else { "online" },
         total_time_seconds: res.total_seconds,
         peak_rss_kb: res.peak_rss_kb,
         diagnostics: res.diagnostics.clone(),

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -189,6 +189,14 @@ fn selective_alignment_quantification_tracks_truth() {
     assert!(out.join("quant.sf").exists());
     assert!(out.join("aux_info").join("meta_info.json").exists());
 
+    // The one-pass path labels itself in meta_info (#1140), so the
+    // online-to-deterministic transition is auditable from existing output.
+    let meta: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(meta["inference_path"].as_str().unwrap(), "online");
+
     // quant.sf has a header + one row per transcript.
     let sf = std::fs::read_to_string(out.join("quant.sf")).unwrap();
     assert!(sf.starts_with("Name\tLength\tEffectiveLength\tTPM\tNumReads\n"));

--- a/crates/salmon-rad/src/writer.rs
+++ b/crates/salmon-rad/src/writer.rs
@@ -71,7 +71,22 @@ pub struct RadOutputWriter {
     has_index_prov: bool,
     /// chunk compression codec applied by worker buffers (advertised in the header).
     codec: ChunkCodec,
+    /// Bytes appended since the last free-disk-space probe (all workers).
+    ///
+    /// A filling disk should fail in seconds with an actionable message, not
+    /// at the end of a mapping pass measured in minutes (#1140): every
+    /// [`SPACE_CHECK_INTERVAL`] bytes, the writer probes the target
+    /// filesystem and errors out early when free space falls under
+    /// [`LOW_SPACE_BYTES`]. The counter reset races benignly between workers —
+    /// it paces the probe, it does not gate correctness.
+    bytes_since_space_check: std::sync::atomic::AtomicU64,
 }
+
+/// Probe the target filesystem's free space every this many appended bytes.
+const SPACE_CHECK_INTERVAL: u64 = 256 * 1024 * 1024;
+/// Fail the run when the target filesystem's free space falls below this while
+/// chunks are still being appended.
+const LOW_SPACE_BYTES: u64 = 512 * 1024 * 1024;
 
 /// The sibling path a RAD file is written to before it is finalized.
 ///
@@ -141,6 +156,7 @@ impl RadOutputWriter {
             pending_counters: None,
             has_index_prov: provenance.index.is_some(),
             codec,
+            bytes_since_space_check: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -202,7 +218,33 @@ impl RadOutputWriter {
                  the incomplete file has been left there; it is NOT usable as `--rad` input",
                 self.partial_path.display()
             )
-        })
+        })?;
+        use std::sync::atomic::Ordering;
+        let since = self
+            .bytes_since_space_check
+            .fetch_add(bytes.len() as u64, Ordering::Relaxed)
+            + bytes.len() as u64;
+        if since >= SPACE_CHECK_INTERVAL {
+            self.bytes_since_space_check.store(0, Ordering::Relaxed);
+            let dir = self
+                .partial_path
+                .parent()
+                .unwrap_or(std::path::Path::new("."));
+            if let Some(free) = salmon_core::free_disk_bytes(dir) {
+                if free < LOW_SPACE_BYTES {
+                    anyhow::bail!(
+                        "running out of disk space while writing {} ({} MiB free in {}); \
+                         stopping now rather than at the end of the pass. \
+                         Consider `--radScratchDir <dir>` to place the intermediate on a \
+                         larger/faster volume, or `--radCompress zstd` (~30% smaller).",
+                        self.partial_path.display(),
+                        free / (1024 * 1024),
+                        dir.display()
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Backpatch any baked FLD / abundances + the `baked_flags` marker, then flush

--- a/website/src/content/docs/guides/rad-and-determinism.mdx
+++ b/website/src/content/docs/guides/rad-and-determinism.mdx
@@ -196,6 +196,31 @@ does in ordinary alignment mode) — you also supply it to reconstruct reference
 sequences for bias correction. The error model is enabled only by `--errorModel`.
 :::
 
+## Disk use of the `--deterministic` intermediate
+
+The two-phase flow writes an intermediate RAD, quantifies from it, and deletes
+it on success. Budget roughly the size of your **compressed input** for it
+(measured ~110 MB per 1M read pairs on GENCODE v49 under the default lz4);
+the exact size grows with the multimapping rate, not just the read count, so
+no fixed per-fragment constant is reliable. Salmon warns at startup when the
+target volume's free space is below the total input size, and the writer
+checks free space periodically during the pass so a filling disk fails within
+seconds — with the partial file removed — rather than silently at the end of
+the mapping pass.
+
+Two knobs when space or I/O speed is a concern:
+
+- `--radScratchDir <dir>` places the intermediate on a different volume —
+  node-local scratch, or memory-backed storage such as `/dev/shm`, which
+  removes the round-trip from slow or networked filesystems entirely. The
+  file is pid-suffixed there, so concurrent runs can share one scratch
+  directory.
+- `--radCompress zstd` shrinks the intermediate a further ~30% over the lz4
+  default for ~11% extra wall time.
+
+An explicit `--writeRad PATH` always wins over `--radScratchDir`, and files at
+user-named paths are never cleaned up by salmon — they are yours.
+
 ## Compressing RAD output (`--radCompress`)
 
 RAD chunks can be compressed, on by default for both `--writeRad` and the

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -133,6 +133,7 @@ See the [RAD I/O & deterministic quantification](../../guides/rad-and-determinis
 | `--skipQuant` | Skip quantification (EM, Gibbs/bootstrap, `quant.sf`); still map, build equivalence classes, detect library type, write metadata. |
 | `--deterministic` | Reproducible reads-mode quantification: map once to an intermediate RAD, then quantify from it with a fixed fragment-length distribution. Byte-identical across runs and thread counts. |
 | `--keepRad` | Keep the `--deterministic` intermediate RAD (deleted by default). |
+| `--radScratchDir <DIR>` | Directory for the `--deterministic` intermediate RAD (default: the output directory). Point at node-local or memory-backed storage (e.g. `/dev/shm`) when the output volume is slow, networked, or space-constrained. Ignored with an explicit `--writeRad`. |
 | `--radCompress <CODEC>` | RAD chunk compression for `--writeRad` / `--deterministic`: `lz4` (default), `zstd` (smaller), or `none`. |
 | `--noCompressRad` | Write uncompressed RAD chunks (overrides `--radCompress`). |
 


### PR DESCRIPTION
Second maintainer-side item from #1140 — the "disk: yes, it needs more than documentation" section of @BenjaminDEMAILLE's review, ahead of the default flip.

- **`--radScratchDir <dir>`** — place the salmon-owned intermediate on node-local scratch or memory-backed storage (`/dev/shm`), pid-suffixed so concurrent runs can share a scratch volume. On Linux this is also our answer to the in-memory RAD store: OS-managed memory placement with graceful spill and no new I/O machinery. Explicit `--writeRad` wins, with a warning if both are given.
- **Startup preflight** — warn when the target volume has less free space than the total compressed input. Deliberately a warning against a proxy rather than an error against a constant: Ben measured 14.6 vs 57.6 bytes/fragment between fixtures of the same read count, so per-fragment estimates aren't safe to hard-fail on.
- **Fast ENOSPC** — the RAD writer probes free space every 256 MiB appended and errors (naming the path, the free space, and the two mitigations) once free space drops under 512 MiB, instead of failing at the end of the mapping pass.
- **Failure cleanup** — when salmon owns the intermediate path: failed phase 1 removes the `.partial-*` leftover, failed phase 2 removes the finalized intermediate (previously leaked). User-named `--writeRad` paths are never cleaned.

All three two-phase drivers (reads `--deterministic`, `-a --deterministic`, genome projection) get identical treatment. `free_disk_bytes` (statvfs) is the workspace's only `unsafe`, documented and confined to `salmon-core` (reports `None` off-Unix, and callers treat `None` as "cannot check", never "no space").

Verified end-to-end: intermediate lands pid-suffixed in the scratch dir, `quant.sf` byte-identical with and without it. Unit tests cover placement, pid-suffixing, and cleanup semantics. Workspace suite 293/0; clippy/fmt clean. Docs updated (CLI reference + the RAD/determinism guide gains a "disk use" section with the measured sizing guidance).

Stacked on #1143 (shares the `run_deterministic` edits); the diff below includes it until that merges.

Refs #1140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs