### PR TITLE
feat: dump equivalence classes from the RAD path, not before they exist (#1140 PR C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,6 +2734,7 @@ version = "2.5.1"
 dependencies = [
  "anyhow",
  "clap",
+ "flate2",
  "indicatif",
  "mimalloc",
  "piscem-rs",
@@ -2768,7 +2769,9 @@ name = "salmon-eqclass"
 version = "2.5.1"
 dependencies = [
  "dashmap",
+ "flate2",
  "salmon-core",
+ "tempfile",
  "xxhash-rust",
 ]
 

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -198,6 +198,12 @@ pub struct AlignQuantOptions {
     /// start time (asctime) of that earlier phase; when set, reported as the
     /// run's `start_time` instead of this pass's own
     pub external_start_time: Option<String>,
+    /// `--dumpEq`: write `aux_info/eq_classes.txt.gz`, the equivalence classes
+    /// the EM consumed, collapsed by transcript set.
+    pub dump_eq: bool,
+    /// `--dumpEqWeights`: the same file with each class's per-transcript
+    /// combined weights, and without collapsing range-factorized sub-classes.
+    pub dump_eq_weights: bool,
     /// significant digits for the EffectiveLength and NumReads columns of
     /// `quant.sf` (`--sigDigits`, salmon default 3)
     pub sig_digits: u32,
@@ -265,6 +271,8 @@ impl AlignQuantOptions {
             init_uniform: false,
             prior_seconds: 0.0,
             external_start_time: None,
+            dump_eq: false,
+            dump_eq_weights: false,
             sig_digits: 3,
             num_error_bins: 4,
             discard_orphans: false,

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -1974,6 +1974,20 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     // alignment input; analogous to "mapping" in the reads driver).
     timer.mark("rad_read");
 
+    // The classes as the EM will consume them. Written from here rather than
+    // from the mapping pass because this is the only place they exist: a
+    // deterministic run's first pass maps and writes the RAD without ever
+    // assembling a class (COMBINE-lab/salmon#1140).
+    if opts.dump_eq || opts.dump_eq_weights {
+        salmon_eqclass::write_eq_classes(
+            &opts.output_dir,
+            &names,
+            &collapsed,
+            opts.dump_eq_weights,
+        )
+        .context("writing eq_classes.txt.gz")?;
+    }
+
     // Deterministic EM from a uniform start. With a fixed FLD the collapsed
     // classes are independent of fragment/worker order, so the EM fixed point is
     // reproducible; there is no online warm-start (it was proven not to affect the

--- a/crates/salmon-cli/Cargo.toml
+++ b/crates/salmon-cli/Cargo.toml
@@ -33,6 +33,7 @@ sysalloc = []
 
 [dev-dependencies]
 tempfile = { workspace = true }
+flate2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1156,6 +1156,12 @@ fn requant_options(
     q.bias_speed_samp = map_opts.bias_speed_samp;
     q.no_bias_length_threshold = map_opts.no_bias_length_threshold;
     q.init_uniform = map_opts.init_uniform;
+    // Phase 2 is where the equivalence classes exist, so it is where they are
+    // dumped. Phase 1 has none to dump (COMBINE-lab/salmon#1140), which is why
+    // this mapping has to be built from the request as the user made it, before
+    // the driver clears the flags for phase 1.
+    q.dump_eq = map_opts.dump_eq;
+    q.dump_eq_weights = map_opts.dump_eq_weights;
     q
 }
 
@@ -1306,6 +1312,13 @@ fn run_deterministic(
         ),
     );
 
+    // Phase 2's options, built from the request exactly as the user made it and
+    // before phase 1 rewrites parts of it for its own purposes. Everything it
+    // needs (the RAD path, the bias targets) is known by now, and building it
+    // here is what keeps "the phase-2 options" meaning the user's request rather
+    // than whatever phase 1 left behind.
+    let mut q = requant_options(&map_opts, &rad_path, out_dir, bias_targets);
+
     // Phase 1 — map once, write the RAD (bakes the deterministic FLD + resolved
     // library format), skipping the online EM: quantification happens in phase 2.
     //
@@ -1316,6 +1329,12 @@ fn run_deterministic(
     let stop_after_mapping = map_opts.skip_quant;
     map_opts.write_rad = Some(rad_path.clone());
     map_opts.skip_quant = true;
+    // The classes live in phase 2, which already has these flags. Left on here,
+    // phase 1 pays for `build_eq` and then writes a well-formed
+    // `eq_classes.txt.gz` declaring zero classes, which phase 2 never overwrites
+    // (COMBINE-lab/salmon#1140).
+    map_opts.dump_eq = false;
+    map_opts.dump_eq_weights = false;
     // Derive the FLD + library format order-independently during this pass and
     // bake them (see `QuantOptions::deterministic_fld`), so phase 2 is a single
     // pass and the whole result is byte-identical across thread counts.
@@ -1342,6 +1361,19 @@ fn run_deterministic(
     );
 
     if stop_after_mapping {
+        // The classes are built by phase 2, which is exactly the pass
+        // `--skipQuant` asks not to run, so there is nothing to dump. Saying so
+        // beats writing no file and no explanation: one-pass `--skipQuant
+        // --dumpEq` does produce a dump, so the difference would otherwise look
+        // like the flag being dropped.
+        if q.dump_eq || q.dump_eq_weights {
+            tracing::warn!(
+                "--dumpEq/--dumpEqWeights has nothing to write under --skipQuant --deterministic: \
+                 equivalence classes are built by the quantification pass, which --skipQuant \
+                 skips. Quantify the RAD that was kept with `--rad {} --dumpEq` to produce them.",
+                rad_path.display()
+            );
+        }
         tracing::info!(
             "--skipQuant: mapping only; the RAD at {} is the output",
             rad_path.display()
@@ -1351,7 +1383,6 @@ fn run_deterministic(
 
     // Phase 2 — deterministic quant from the RAD (fixed baked FLD + library
     // format ⇒ order-independent eq-classes + EM). Mirrors the `--rad` knob wiring.
-    let mut q = requant_options(&map_opts, &rad_path, out_dir, bias_targets);
     // Bias needs the reference sequence. Prefer the index's own sequences (we
     // already built the index for phase 1), so the user need not pass `-t`; an
     // explicit `-t` is still honoured as a fallback.
@@ -1742,6 +1773,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.fld_max = args.fld_max.unwrap_or(DEFAULT_FLD_MAX);
         opts.forgetting_factor = args.forgetting_factor;
         opts.init_uniform = args.init_uniform;
+        opts.dump_eq = args.dump_eq;
+        opts.dump_eq_weights = args.dump_eq_weights;
         opts.bias_speed_samp = args.bias_speed_samp;
         opts.num_aux_model_samples = args.num_aux_model_samples;
         opts.no_bias_length_threshold = args.no_bias_length_threshold;
@@ -1917,6 +1950,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             max: args.fld_max.is_some(),
         };
         opts.skip_quant = args.skip_quant;
+        opts.dump_eq = args.dump_eq;
+        opts.dump_eq_weights = args.dump_eq_weights;
         opts.num_bootstraps = args.num_bootstraps;
         opts.num_gibbs_samples = args.num_gibbs_samples;
         opts.thinning_factor = args.thinning_factor;
@@ -2412,6 +2447,8 @@ mod tests {
         map_opts.bias_speed_samp = 25;
         map_opts.no_bias_length_threshold = true;
         map_opts.init_uniform = true;
+        map_opts.dump_eq = true;
+        map_opts.dump_eq_weights = true;
 
         let q = requant_options(
             &map_opts,
@@ -2443,6 +2480,8 @@ mod tests {
         assert_eq!(q.bias_speed_samp, 25);
         assert!(q.no_bias_length_threshold);
         assert!(q.init_uniform);
+        assert!(q.dump_eq);
+        assert!(q.dump_eq_weights);
     }
 
     /// The three knobs #1140 found dropped, checked against a default request
@@ -2460,6 +2499,8 @@ mod tests {
             defaults.no_bias_length_threshold
         );
         assert_eq!(q.init_uniform, defaults.init_uniform);
+        assert_eq!(q.dump_eq, defaults.dump_eq);
+        assert_eq!(q.dump_eq_weights, defaults.dump_eq_weights);
     }
 
     /// `--writeSam` is a spelling of `--writeMappings`, giving SAM output a

--- a/crates/salmon-cli/tests/dump_eq_deterministic.rs
+++ b/crates/salmon-cli/tests/dump_eq_deterministic.rs
@@ -1,0 +1,224 @@
+//! `--dumpEq` has to describe the classes the run actually used, in every mode.
+//!
+//! Under `--deterministic` it did not: the mapping pass wrote the file before any
+//! class existed, declaring zero of them, and the quantification pass never
+//! replaced it (COMBINE-lab/salmon#1140). A well-formed file saying "0 classes"
+//! is worse than a missing one, since a reader has no way to tell it is wrong,
+//! which is why this test drives the binary end to end rather than any single
+//! function: the bug lived in how the two passes were wired, not in the writer.
+
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SALMON: &str = env!("CARGO_BIN_EXE_salmon");
+
+/// Deterministic pseudo-random bases, so the fixture is reproducible without a
+/// data file.
+fn sequence(mut seed: u64, len: usize) -> String {
+    (0..len)
+        .map(|_| {
+            seed = seed
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            "ACGT".as_bytes()[(seed >> 33) as usize & 3] as char
+        })
+        .collect()
+}
+
+/// Three transcripts, two of which share a long stretch so some fragments are
+/// ambiguous and the classes are not all singletons.
+fn fixture(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let a = sequence(11, 4000);
+    let b = sequence(29, 4000);
+    let shared = format!("{}{}", &a[..1500], sequence(41, 2500));
+
+    let fasta = dir.join("txp.fa");
+    std::fs::write(&fasta, format!(">txA\n{a}\n>txB\n{b}\n>txC\n{shared}\n")).unwrap();
+
+    let (mut r1, mut r2) = (String::new(), String::new());
+    let qual = "I".repeat(100);
+    for (i, source) in [&a, &b, &shared].iter().cycle().take(300).enumerate() {
+        let start = (i * 37) % (source.len() - 300);
+        let mate1 = &source[start..start + 100];
+        let mate2: String = source[start + 200..start + 300]
+            .chars()
+            .rev()
+            .map(|c| match c {
+                'A' => 'T',
+                'C' => 'G',
+                'G' => 'C',
+                _ => 'A',
+            })
+            .collect();
+        r1.push_str(&format!("@f{i}\n{mate1}\n+\n{qual}\n"));
+        r2.push_str(&format!("@f{i}\n{mate2}\n+\n{qual}\n"));
+    }
+    let (p1, p2) = (dir.join("r1.fq"), dir.join("r2.fq"));
+    std::fs::write(&p1, r1).unwrap();
+    std::fs::write(&p2, r2).unwrap();
+    (fasta, p1, p2)
+}
+
+struct Dump {
+    names: Vec<String>,
+    declared: usize,
+    classes: Vec<(Vec<u32>, u64)>,
+}
+
+fn read_dump(out: &Path) -> Dump {
+    let f = std::fs::File::open(out.join("aux_info").join("eq_classes.txt.gz"))
+        .expect("the dump has to exist");
+    let mut text = String::new();
+    flate2::read::GzDecoder::new(f)
+        .read_to_string(&mut text)
+        .unwrap();
+    let mut lines = text.lines();
+    let num_txps: usize = lines.next().unwrap().parse().unwrap();
+    let declared: usize = lines.next().unwrap().parse().unwrap();
+    let names: Vec<String> = (0..num_txps)
+        .map(|_| lines.next().unwrap().to_string())
+        .collect();
+    let classes = lines
+        .map(|l| {
+            let f: Vec<&str> = l.split('\t').collect();
+            let size: usize = f[0].parse().unwrap();
+            let txps = f[1..=size].iter().map(|t| t.parse().unwrap()).collect();
+            (txps, f[size + 1].parse().unwrap())
+        })
+        .collect();
+    Dump {
+        names,
+        declared,
+        classes,
+    }
+}
+
+fn num_mapped(out: &Path) -> u64 {
+    let text = std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap();
+    let key = "\"num_mapped\":";
+    let start = text.find(key).unwrap() + key.len();
+    text[start..]
+        .trim_start()
+        .split(|c: char| !c.is_ascii_digit())
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+fn quant(index: &Path, r1: &Path, r2: &Path, out: &Path, deterministic: bool) {
+    let mut cmd = Command::new(SALMON);
+    cmd.args(["quant", "-i"])
+        .arg(index)
+        .args(["-l", "A", "-1"])
+        .arg(r1)
+        .arg("-2")
+        .arg(r2)
+        .args(["-p", "2", "-o"])
+        .arg(out)
+        .arg("--dumpEq");
+    if deterministic {
+        cmd.arg("--deterministic");
+    }
+    let status = cmd.status().unwrap();
+    assert!(status.success(), "quantification failed: {status}");
+}
+
+#[test]
+fn dump_eq_describes_the_classes_in_both_modes() {
+    let dir = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = fixture(dir.path());
+    let index = dir.path().join("idx");
+    let status = Command::new(SALMON)
+        .args(["index", "-t"])
+        .arg(&fasta)
+        .arg("-i")
+        .arg(&index)
+        .args(["-p", "2"])
+        .status()
+        .unwrap();
+    assert!(status.success(), "indexing failed");
+
+    let online = dir.path().join("online");
+    let det = dir.path().join("det");
+    quant(&index, &r1, &r2, &online, false);
+    quant(&index, &r1, &r2, &det, true);
+
+    for (label, out) in [("one-pass", &online), ("deterministic", &det)] {
+        let dump = read_dump(out);
+        // The regression: the deterministic dump used to declare zero classes,
+        // written by a pass that had none to declare.
+        assert!(dump.declared > 0, "{label} dump declares no classes at all");
+        assert_eq!(
+            dump.declared,
+            dump.classes.len(),
+            "{label} dump declares {} classes and lists {}",
+            dump.declared,
+            dump.classes.len()
+        );
+        let total: u64 = dump.classes.iter().map(|(_, c)| c).sum();
+        assert_eq!(
+            total,
+            num_mapped(out),
+            "{label} dump has to account for every mapped fragment"
+        );
+        assert_eq!(dump.names, ["txA", "txB", "txC"], "{label} name block");
+    }
+}
+
+#[test]
+/// `--dumpEq` with `--skipQuant --deterministic` has nothing to write, and has
+/// to say so.
+///
+/// The classes are built by the quantification pass, which `--skipQuant` skips,
+/// so no file is possible. One-pass `--skipQuant --dumpEq` does produce a dump,
+/// so silence here would look exactly like the flag being dropped, which is the
+/// failure mode this whole batch exists to remove.
+fn dump_eq_with_skip_quant_says_it_has_nothing_to_dump() {
+    let dir = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = fixture(dir.path());
+    let index = dir.path().join("idx");
+    assert!(Command::new(SALMON)
+        .args(["index", "-t"])
+        .arg(&fasta)
+        .arg("-i")
+        .arg(&index)
+        .args(["-p", "2"])
+        .status()
+        .unwrap()
+        .success());
+
+    let out = dir.path().join("skipped");
+    let result = Command::new(SALMON)
+        .args(["quant", "-i"])
+        .arg(&index)
+        .args(["-l", "A", "-1"])
+        .arg(&r1)
+        .arg("-2")
+        .arg(&r2)
+        .args(["-p", "2", "-o"])
+        .arg(&out)
+        .args(["--deterministic", "--skipQuant", "--dumpEq"])
+        .output()
+        .unwrap();
+    assert!(result.status.success());
+
+    assert!(
+        !out.join("aux_info").join("eq_classes.txt.gz").exists(),
+        "there are no classes to dump, so there must be no file pretending otherwise"
+    );
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("--dumpEq/--dumpEqWeights has nothing to write"),
+        "the run has to say why the file is absent: {stderr}"
+    );
+    assert!(
+        stderr.contains("--rad"),
+        "and point at the way to get the classes from the RAD it kept: {stderr}"
+    );
+    assert!(
+        out.join("intermediate_mappings.rad").is_file(),
+        "the RAD the warning points at has to be there"
+    );
+}

--- a/crates/salmon-eqclass/Cargo.toml
+++ b/crates/salmon-eqclass/Cargo.toml
@@ -10,8 +10,12 @@ description = "Equivalence-class data structures and concurrent builder for the 
 
 [dependencies]
 salmon-core = { workspace = true }
+flate2 = { workspace = true }
 dashmap = { workspace = true }
 xxhash-rust = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/salmon-eqclass/src/lib.rs
+++ b/crates/salmon-eqclass/src/lib.rs
@@ -527,6 +527,75 @@ impl CollapsedEqClasses {
 ///
 /// A sentinel value is used instead of `Option<u8>` because these placements are
 /// stored in the millions and the extra byte per placement would matter.
+/// Write `aux_info/eq_classes.txt.gz` in salmon's format: the transcript count,
+/// the equivalence-class count, all transcript names (one per line, in the index
+/// order the classes reference), then one line per class.
+///
+/// Without `with_weights`, classes are collapsed by transcript set (`groupSize`,
+/// tids, summed count), matching salmon's `--dumpEq`; with `with_weights` each
+/// class is emitted as-is with its per-transcript combined weights before the
+/// count (`--dumpEqWeights`).
+///
+/// This is the intermediate the EM actually consumes, so dumping it is how to
+/// see what salmon inferred *before* the statistics: which transcript sets the
+/// fragments were compatible with, and how many fell into each.
+///
+/// It lives here, beside [`CollapsedEqClasses`], because both the read-mapping
+/// path and the RAD path have to produce the same bytes for the same classes.
+/// When it lived in one of them, the other could not dump at all
+/// (COMBINE-lab/salmon#1140).
+pub fn write_eq_classes(
+    dir: &std::path::Path,
+    names: &[String],
+    collapsed: &CollapsedEqClasses,
+    with_weights: bool,
+) -> std::io::Result<()> {
+    use std::collections::BTreeMap;
+    use std::io::Write as _;
+    let num_txps = names.len();
+    std::fs::create_dir_all(dir.join("aux_info"))?;
+    let f = std::fs::File::create(dir.join("aux_info").join("eq_classes.txt.gz"))?;
+    let mut w = flate2::write::GzEncoder::new(f, flate2::Compression::new(6));
+
+    if with_weights {
+        writeln!(w, "{num_txps}")?;
+        writeln!(w, "{}", collapsed.classes.len())?;
+        for name in names {
+            writeln!(w, "{name}")?;
+        }
+        for (group, value) in &collapsed.classes {
+            write!(w, "{}", group.txps.len())?;
+            for &tid in &group.txps {
+                write!(w, "\t{tid}")?;
+            }
+            for wt in &value.combined_weights {
+                write!(w, "\t{wt}")?;
+            }
+            writeln!(w, "\t{}", value.count)?;
+        }
+    } else {
+        // Collapse range-factorized sub-classes that share a transcript set.
+        let mut merged: BTreeMap<&Vec<u32>, u64> = BTreeMap::new();
+        for (group, value) in &collapsed.classes {
+            *merged.entry(&group.txps).or_insert(0) += value.count;
+        }
+        writeln!(w, "{num_txps}")?;
+        writeln!(w, "{}", merged.len())?;
+        for name in names {
+            writeln!(w, "{name}")?;
+        }
+        for (txps, count) in &merged {
+            write!(w, "{}", txps.len())?;
+            for &tid in *txps {
+                write!(w, "\t{tid}")?;
+            }
+            writeln!(w, "\t{count}")?;
+        }
+    }
+    w.finish()?;
+    Ok(())
+}
+
 pub const NAIVE_NO_FMT: u8 = u8::MAX;
 
 /// One placement of a NAIVE fragment signature: a transcript plus enough
@@ -635,6 +704,76 @@ impl NaiveEqBuilder {
 
 #[cfg(test)]
 mod tests {
+
+    /// The `--dumpEq` file is what a downstream tool reads instead of re-deriving
+    /// the classes, so its two shapes have to stay exactly what salmon promises:
+    /// collapsed by transcript set without weights, verbatim with them.
+    #[test]
+    fn eq_class_dump_collapses_only_without_weights() {
+        let dir = tempfile::tempdir().unwrap();
+        let names = vec!["txA".to_string(), "txB".to_string(), "txC".to_string()];
+        // Two classes over the same transcript set (as range factorization
+        // produces) plus one over another set.
+        let classes = vec![
+            (
+                TranscriptGroup::new(vec![0, 1]),
+                TGValue {
+                    acc: Vec::new(),
+                    weights: vec![0.5, 0.5],
+                    combined_weights: vec![0.25, 0.75],
+                    count: 3,
+                },
+            ),
+            (
+                TranscriptGroup::new(vec![0, 1]),
+                TGValue {
+                    acc: Vec::new(),
+                    weights: vec![0.5, 0.5],
+                    combined_weights: vec![0.6, 0.4],
+                    count: 4,
+                },
+            ),
+            (
+                TranscriptGroup::new(vec![2]),
+                TGValue {
+                    acc: Vec::new(),
+                    weights: vec![1.0],
+                    combined_weights: vec![1.0],
+                    count: 5,
+                },
+            ),
+        ];
+        let collapsed = CollapsedEqClasses {
+            classes,
+            total_count: 12,
+        };
+
+        let read = |with_weights: bool| -> Vec<String> {
+            write_eq_classes(dir.path(), &names, &collapsed, with_weights).unwrap();
+            let f =
+                std::fs::File::open(dir.path().join("aux_info").join("eq_classes.txt.gz")).unwrap();
+            let mut text = String::new();
+            std::io::Read::read_to_string(&mut flate2::read::GzDecoder::new(f), &mut text).unwrap();
+            text.lines().map(str::to_string).collect()
+        };
+
+        let plain = read(false);
+        assert_eq!(plain[0], "3", "transcript count");
+        assert_eq!(
+            plain[1], "2",
+            "the two classes on {{txA,txB}} collapse into one"
+        );
+        assert_eq!(&plain[2..5], &["txA", "txB", "txC"]);
+        // Collapsed: group size, tids, summed count. No weights.
+        assert_eq!(plain[5], "2\t0\t1\t7");
+        assert_eq!(plain[6], "1\t2\t5");
+
+        let weighted = read(true);
+        assert_eq!(weighted[1], "3", "with weights nothing is collapsed");
+        assert_eq!(weighted[5], "2\t0\t1\t0.25\t0.75\t3");
+        assert_eq!(weighted[6], "2\t0\t1\t0.6\t0.4\t4");
+        assert_eq!(weighted[7], "1\t2\t1\t5");
+    }
     use super::*;
 
     /// A group must be order-insensitive and duplicate-insensitive: the same

--- a/crates/salmon-eqclass/src/lib.rs
+++ b/crates/salmon-eqclass/src/lib.rs
@@ -527,6 +527,8 @@ impl CollapsedEqClasses {
 ///
 /// A sentinel value is used instead of `Option<u8>` because these placements are
 /// stored in the millions and the extra byte per placement would matter.
+pub const NAIVE_NO_FMT: u8 = u8::MAX;
+
 /// Write `aux_info/eq_classes.txt.gz` in salmon's format: the transcript count,
 /// the equivalence-class count, all transcript names (one per line, in the index
 /// order the classes reference), then one line per class.
@@ -555,6 +557,9 @@ pub fn write_eq_classes(
     let num_txps = names.len();
     std::fs::create_dir_all(dir.join("aux_info"))?;
     let f = std::fs::File::create(dir.join("aux_info").join("eq_classes.txt.gz"))?;
+    // One `write!` per field per class is a lot of small writes; buffer them
+    // before they reach the encoder.
+    let f = std::io::BufWriter::new(f);
     let mut w = flate2::write::GzEncoder::new(f, flate2::Compression::new(6));
 
     if with_weights {
@@ -595,8 +600,6 @@ pub fn write_eq_classes(
     w.finish()?;
     Ok(())
 }
-
-pub const NAIVE_NO_FMT: u8 = u8::MAX;
 
 /// One placement of a NAIVE fragment signature: a transcript plus enough
 /// orientation/strand info to drop it later if it is library-incompatible.

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -39,7 +39,7 @@ mod output;
 mod processor;
 mod sam;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
@@ -912,8 +912,16 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
     timer.mark("eff_length_collapse");
 
     if opts.dump_eq || opts.dump_eq_weights {
-        dump_eq_classes(&opts.output_dir, &salmon, &collapsed, opts.dump_eq_weights)
-            .context("writing eq_classes.txt.gz")?;
+        let names: Vec<String> = (0..salmon.num_refs())
+            .map(|t| salmon.ref_name(t).to_string())
+            .collect();
+        salmon_eqclass::write_eq_classes(
+            &opts.output_dir,
+            &names,
+            &collapsed,
+            opts.dump_eq_weights,
+        )
+        .context("writing eq_classes.txt.gz")?;
     }
     let bias_on = (opts.seq_bias || opts.gc_bias || opts.pos_bias) && !opts.no_length_correction;
     // salmon runs a *single* offline EM: after a short burn-in (`targetIt = 10`
@@ -1395,69 +1403,4 @@ pub(crate) fn asctime_now() -> String {
     jiff::Zoned::now()
         .strftime("%a %b %e %H:%M:%S %Y")
         .to_string()
-}
-
-/// Write the naive equivalence classes (collapsing any range-factorized
-/// sub-classes back to their transcript set) for comparison/diagnostics.
-/// Write `aux_info/eq_classes.txt.gz` in salmon's format: the transcript count,
-/// the equivalence-class count, all transcript names (one per line, the index
-/// order the classes reference), then one line per class. Without `with_weights`
-/// classes are collapsed by transcript set (`groupSize`, tids…, summed count),
-/// matching salmon's `--dumpEq`; with `with_weights` each class is emitted as-is
-/// with its per-transcript combined weights before the count (`--dumpEqWeights`).
-/// Serialize the equivalence classes for inspection or for a downstream tool.
-///
-/// This is the intermediate the EM actually consumes, so dumping it is the way to
-/// see what salmon inferred *before* the statistics: which transcript sets the
-/// reads were compatible with, and how many reads fell into each.
-fn dump_eq_classes(
-    dir: &Path,
-    salmon: &SalmonIndex,
-    collapsed: &salmon_eqclass::CollapsedEqClasses,
-    with_weights: bool,
-) -> Result<()> {
-    use std::collections::BTreeMap;
-    use std::io::Write as _;
-    let num_txps = salmon.num_refs();
-    std::fs::create_dir_all(dir.join("aux_info"))?;
-    let f = std::fs::File::create(dir.join("aux_info").join("eq_classes.txt.gz"))?;
-    let mut w = flate2::write::GzEncoder::new(f, flate2::Compression::new(6));
-
-    if with_weights {
-        writeln!(w, "{num_txps}")?;
-        writeln!(w, "{}", collapsed.classes.len())?;
-        for t in 0..num_txps {
-            writeln!(w, "{}", salmon.ref_name(t))?;
-        }
-        for (group, value) in &collapsed.classes {
-            write!(w, "{}", group.txps.len())?;
-            for &tid in &group.txps {
-                write!(w, "\t{tid}")?;
-            }
-            for wt in &value.combined_weights {
-                write!(w, "\t{wt}")?;
-            }
-            writeln!(w, "\t{}", value.count)?;
-        }
-    } else {
-        // Collapse range-factorized sub-classes that share a transcript set.
-        let mut merged: BTreeMap<&Vec<u32>, u64> = BTreeMap::new();
-        for (group, value) in &collapsed.classes {
-            *merged.entry(&group.txps).or_insert(0) += value.count;
-        }
-        writeln!(w, "{num_txps}")?;
-        writeln!(w, "{}", merged.len())?;
-        for t in 0..num_txps {
-            writeln!(w, "{}", salmon.ref_name(t))?;
-        }
-        for (txps, count) in &merged {
-            write!(w, "{}", txps.len())?;
-            for &tid in *txps {
-                write!(w, "\t{tid}")?;
-            }
-            writeln!(w, "\t{count}")?;
-        }
-    }
-    w.finish()?;
-    Ok(())
 }


### PR DESCRIPTION
PR C of #1140. `--dumpEq` under `--deterministic` wrote a well-formed `eq_classes.txt.gz` declaring **zero** classes: the mapping pass wrote it, and at that point there are none, because the classes are assembled by the quantification pass from the RAD. Nothing overwrote it afterwards, so the run produced a file whose header says `2996` transcripts and `0` classes beside a `quant.sf` derived from 4469 of them. Worse than a missing file, since nothing about it looks wrong.

## Shape, as you suggested

The serializer moves to `salmon-eqclass` as `write_eq_classes(dir, names: &[String], collapsed, with_weights)`, beside the `CollapsedEqClasses` it writes. It could not be shared before because it took a `SalmonIndex`, which the RAD path does not have; taking the names is all it needed. Both callers are now thin, and the two paths cannot drift into writing different bytes for the same classes. `flate2` as a direct dependency of `salmon-eqclass` rather than routing through `salmon-core::compress`, since the format is line-oriented text straight into a `GzEncoder`.

- `quantify_rad` dumps after collapsing, where the classes the EM consumes exist.
- `run_deterministic` takes the two flags off phase 1 and sets them on phase 2, so phase 1 also stops forcing `build_eq` to fill a builder nothing reads.
- `-a`, `--rad` and genome projection gain `--dumpEq`/`--dumpEqWeights`: same quantifier, the flags were simply never wired to it.

## Measured

Same 300k-fragment input, `--dumpEq`, before and after:

```
before   one-pass  header "2996 4468"      det  header "2996 0"      (5599 bytes of nothing)
after    one-pass  header "2996 4468"      det  header "2996 4469"
```

The one-class difference between the modes is real and not a defect of either: the fixed FLD moves a weight across the acceptance boundary. In both modes the declared count equals the number of class lines, and the per-class counts sum to the mapped-fragment total from `meta_info.json`.

## Testing

Rather than assert the two modes produce identical class sets (they do not, see above), the end-to-end test asserts the invariants that must hold in each mode: the declared count is non-zero, it equals the number of lines, the counts account for every mapped fragment, and the transcript-name block is the index's. It drives the built binary, because the bug was in how the two passes were wired rather than in the writer.

A unit test in `salmon-eqclass` pins the two output shapes: collapsed by transcript set without weights (two range-factorized sub-classes over the same set merging into one line, counts summed), verbatim with them.

## Overlap warning

This touches `run_deterministic` in `crates/salmon-cli/src/main.rs`, which #1146 rewrites substantially. The overlap is four lines (taking `dump_eq`/`dump_eq_weights` off `map_opts`, setting them on the phase-2 options), so whichever lands second is a trivial rebase. Happy to rebase this onto #1146 rather than the other way round, since yours is the larger change there. Same applies to #1144, which extracts the phase-2 option building into a named function.
