### PR TITLE
feat(align): --noLengthCorrection and --noFragLengthDist in the RAD path (#1140 PR B)

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -198,6 +198,18 @@ pub struct AlignQuantOptions {
     /// start time (asctime) of that earlier phase; when set, reported as the
     /// run's `start_time` instead of this pass's own
     pub external_start_time: Option<String>,
+    /// `--noLengthCorrection`: use the raw reference length as the effective
+    /// length, instead of the fragment-length-derived one.
+    ///
+    /// For protocols where a fragment does not sample a transcript's interior
+    /// uniformly (3' tagged-end libraries above all), the usual correction
+    /// describes something the data never did, and the raw length is the honest
+    /// divisor. Bias correction is disabled with it, for the same reason: its
+    /// whole job is to adjust an effective length this mode is not computing.
+    pub no_length_correction: bool,
+    /// `--noFragLengthDist`: drop the fragment-length term from a placement's
+    /// weight, leaving score and compatibility to decide it.
+    pub no_frag_length_dist: bool,
     /// significant digits for the EffectiveLength and NumReads columns of
     /// `quant.sf` (`--sigDigits`, salmon default 3)
     pub sig_digits: u32,
@@ -265,6 +277,8 @@ impl AlignQuantOptions {
             init_uniform: false,
             prior_seconds: 0.0,
             external_start_time: None,
+            no_length_correction: false,
+            no_frag_length_dist: false,
             sig_digits: 3,
             num_error_bins: 4,
             discard_orphans: false,

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -451,6 +451,8 @@ struct FragCfg<'a> {
     ignore_incompat: bool,
     incompat_prior: f64,
     paired_lib: bool,
+    /// `--noFragLengthDist`: leave the fragment-length term out of the weight.
+    no_frag_length_dist: bool,
     range_factorization_bins: u32,
     eq_builder: &'a EquivalenceClassBuilder,
 }
@@ -521,7 +523,12 @@ fn process_rad_fragment(
         let proper = p.status == MateStatus::PairedEndPaired
             && p.frag_len != salmon_rad::FRAG_LEN_UNPAIRED
             && p.frag_len > 0;
-        let log_frag_prob = if proper {
+        let log_frag_prob = if cfg.no_frag_length_dist {
+            // --noFragLengthDist: neither the proper-pair PMF term nor the
+            // orphan ambiguous-length term, matching what the reads path
+            // suppresses (`processor::frag_log_prob`).
+            0.0
+        } else if proper {
             // length-conditioned proper-pair probability. The fixed PMF is
             // normalized by `log P(L ≤ txpLen)` (the CMF at the transcript length)
             // so short transcripts — where only the left tail of insert sizes can
@@ -1269,6 +1276,9 @@ struct BiasCfg<'a> {
     ignore_incompat: bool,
     incompat_prior: f64,
     paired_lib: bool,
+    /// `--noFragLengthDist`: leave the fragment-length term out of the posterior
+    /// this bias pass weights its observations by, as the eq-class pass does.
+    no_frag_length_dist: bool,
     /// fixed per-reference abundances (baked or first-EM) for the posterior.
     abundances: &'a [f64],
     ref_bytes: &'a salmon_core::RefSeqs,
@@ -1310,7 +1320,9 @@ fn collect_bias_fragment(
             && p.frag_len != salmon_rad::FRAG_LEN_UNPAIRED
             && p.frag_len > 0;
         let flen = (p.frag_len as i32).min(rl.max(1));
-        let log_frag_prob = if proper {
+        let log_frag_prob = if cfg.no_frag_length_dist {
+            0.0
+        } else if proper {
             at(cfg.pmf, flen as usize) - at(cfg.cmf, rl.max(1) as usize)
         } else if cfg.paired_lib {
             let read_len = if p.frag_len != salmon_rad::FRAG_LEN_UNPAIRED {
@@ -1631,7 +1643,10 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     // three over the reference, so `-t` (the transcriptome FASTA) is required for
     // any bias model — as in reads/alignment mode. (Decoy filtering for piscem RAD
     // without `-i` is still a separate follow-up.)
-    let bias_on = opts.seq_bias || opts.gc_bias || opts.pos_bias;
+    // Bias correction adjusts an effective length that --noLengthCorrection is
+    // not computing, so the two cannot both apply; reads mode gates it the same
+    // way (`salmon-quant/src/lib.rs`).
+    let bias_on = (opts.seq_bias || opts.gc_bias || opts.pos_bias) && !opts.no_length_correction;
     anyhow::ensure!(
         !bias_on || opts.ref_seqs.is_some() || opts.transcripts.is_some(),
         "--seqBias/--gcBias/--posBias with --rad require -t/--targets (the transcriptome FASTA)"
@@ -1798,7 +1813,15 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     let cond_means = fld.conditional_means();
     let mut eff_lengths = vec![0f64; num_refs];
     for (tid, &len) in lengths.iter().enumerate() {
-        eff_lengths[tid] = salmon_model::smoothed_effective_length(&cond_means, len as usize);
+        // --noLengthCorrection: the raw reference length is the divisor, as in
+        // reads mode. A 3' tagged-end library does not sample a transcript's
+        // interior uniformly, so the fragment-length-derived length describes
+        // something the data never did.
+        eff_lengths[tid] = if opts.no_length_correction {
+            len as f64
+        } else {
+            salmon_model::smoothed_effective_length(&cond_means, len as usize)
+        };
     }
     // Rough seed abundances from the naive eq-classes gathered during the prepare
     // read (piscem/unbaked + bias) → the up-front abundances that let pass-2 fuse.
@@ -1891,6 +1914,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             ignore_incompat,
             incompat_prior: opts.incompat_prior,
             paired_lib,
+            no_frag_length_dist: opts.no_frag_length_dist,
             range_factorization_bins: opts.range_factorization_bins,
             eq_builder: &eq_builder,
         };
@@ -1907,6 +1931,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                 ignore_incompat,
                 incompat_prior: opts.incompat_prior,
                 paired_lib,
+                no_frag_length_dist: opts.no_frag_length_dist,
                 abundances: abund,
                 ref_bytes: &ref_bytes,
                 gc_store: &gc_store,
@@ -2058,6 +2083,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                 ignore_incompat,
                 incompat_prior: opts.incompat_prior,
                 paired_lib,
+                no_frag_length_dist: opts.no_frag_length_dist,
                 abundances: &bias_abund,
                 ref_bytes: &ref_bytes,
                 gc_store: &gc_store,

--- a/crates/salmon-align/tests/rad_input.rs
+++ b/crates/salmon-align/tests/rad_input.rs
@@ -1172,3 +1172,109 @@ fn measure_thread_count_fp_deviation() {
          (reported precision step: 5e-4 for NumReads, 5e-7 for TPM)"
     );
 }
+
+// ---- --noLengthCorrection / --noFragLengthDist ----------------------------
+
+/// A RAD with two transcripts of different lengths and proper pairs on each, so
+/// both the effective-length divisor and the fragment-length term have something
+/// to act on.
+fn write_length_knob_rad(rad: &Path) {
+    let names = ["short", "long"];
+    let lens = [900u32, 6000];
+    let mut frags: Vec<Vec<(u32, Option<u16>, i32)>> = Vec::new();
+    for (tid, n) in [(0u32, 150), (1, 150)] {
+        for i in 0..n {
+            // Fragment lengths spread around 200, so the FLD term is not constant.
+            frags.push(vec![(tid, Some(150 + (i % 100) as u16), 0)]);
+        }
+    }
+    write_rad(rad, &names, &lens, RadProfile::Sketch, &frags, None);
+}
+
+#[test]
+/// `--noLengthCorrection` has to reach the RAD path: the divisor is the raw
+/// reference length, as it is in reads mode.
+///
+/// Until #1140 the flag was accepted and dropped on the way to the requant, so
+/// `--deterministic --noLengthCorrection` silently corrected lengths anyway.
+/// That matters most to 3' tagged-end protocols, where a fragment does not
+/// sample a transcript's interior uniformly and the corrected length describes
+/// something the data never did.
+fn no_length_correction_uses_raw_lengths() {
+    let dir = tempfile::tempdir().unwrap();
+    let rad = dir.path().join("m.rad");
+    write_length_knob_rad(&rad);
+
+    let out = dir.path().join("corrected");
+    std::fs::create_dir_all(&out).unwrap();
+    let corrected = quantify_rad(&opts_for(&out), &rad).unwrap();
+    assert!(
+        corrected
+            .eff_lengths
+            .iter()
+            .zip(&corrected.lengths)
+            .all(|(&e, &l)| e < l as f64),
+        "the default has to shorten every transcript: {:?} vs {:?}",
+        corrected.eff_lengths,
+        corrected.lengths
+    );
+
+    let out = dir.path().join("raw");
+    std::fs::create_dir_all(&out).unwrap();
+    let mut opts = opts_for(&out);
+    opts.no_length_correction = true;
+    let raw = quantify_rad(&opts, &rad).unwrap();
+    assert_eq!(
+        raw.eff_lengths,
+        raw.lengths.iter().map(|&l| l as f64).collect::<Vec<_>>(),
+        "with --noLengthCorrection the effective length is the reference length"
+    );
+}
+
+#[test]
+/// `--noFragLengthDist` has to reach the RAD path too, and it acts on the
+/// weights rather than on the lengths: the effective lengths are untouched while
+/// the placement weights, and so the estimates, change.
+fn no_frag_length_dist_changes_weights_not_lengths() {
+    let dir = tempfile::tempdir().unwrap();
+    let rad = dir.path().join("m.rad");
+    // Both transcripts are the same length, so their effective lengths are
+    // equal and the split cannot come from the length divisor. Each fragment is
+    // ambiguous between them, and the two placements report different fragment
+    // lengths: 190, right at the FLD's mean, against 700 far out in its tail.
+    // With the fragment-length term the near-mean placement takes almost all the
+    // weight; without it the two placements are indistinguishable and the
+    // fragment splits evenly.
+    let names = ["a", "b"];
+    let lens = [6000u32, 6000];
+    let mut frags: Vec<Vec<(u32, Option<u16>, i32)>> = Vec::new();
+    for _ in 0..300 {
+        frags.push(vec![(0u32, Some(190), 0), (1u32, Some(700), 0)]);
+    }
+    write_rad(&rad, &names, &lens, RadProfile::Sketch, &frags, None);
+
+    let run = |no_fld: bool, tag: &str| {
+        let out = dir.path().join(tag);
+        std::fs::create_dir_all(&out).unwrap();
+        let mut opts = opts_for(&out);
+        opts.no_frag_length_dist = no_fld;
+        quantify_rad(&opts, &rad).unwrap()
+    };
+    let with = run(false, "with_fld");
+    let without = run(true, "without_fld");
+
+    assert_eq!(
+        with.eff_lengths, without.eff_lengths,
+        "the flag is about the weights, not the lengths"
+    );
+    assert!(
+        with.counts[0] > 290.0,
+        "with the term, the near-mean placement should take the fragment: {:?}",
+        with.counts
+    );
+    assert!(
+        (without.counts[0] - without.counts[1]).abs() < 1.0,
+        "without it the two placements are indistinguishable and the mass splits: {:?}",
+        without.counts
+    );
+}

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1156,6 +1156,11 @@ fn requant_options(
     q.bias_speed_samp = map_opts.bias_speed_samp;
     q.no_bias_length_threshold = map_opts.no_bias_length_threshold;
     q.init_uniform = map_opts.init_uniform;
+    // The RAD path gained these two with #1148; before that they existed only in
+    // reads mode, so `--deterministic` accepted them and quantified as though
+    // they had not been passed.
+    q.no_length_correction = map_opts.no_length_correction;
+    q.no_frag_length_dist = map_opts.no_frag_length_dist;
     q
 }
 
@@ -1742,6 +1747,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.fld_max = args.fld_max.unwrap_or(DEFAULT_FLD_MAX);
         opts.forgetting_factor = args.forgetting_factor;
         opts.init_uniform = args.init_uniform;
+        opts.no_length_correction = args.no_length_correction;
+        opts.no_frag_length_dist = args.no_frag_length_dist;
         opts.bias_speed_samp = args.bias_speed_samp;
         opts.num_aux_model_samples = args.num_aux_model_samples;
         opts.no_bias_length_threshold = args.no_bias_length_threshold;
@@ -1917,6 +1924,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             max: args.fld_max.is_some(),
         };
         opts.skip_quant = args.skip_quant;
+        opts.no_length_correction = args.no_length_correction;
+        opts.no_frag_length_dist = args.no_frag_length_dist;
         opts.num_bootstraps = args.num_bootstraps;
         opts.num_gibbs_samples = args.num_gibbs_samples;
         opts.thinning_factor = args.thinning_factor;
@@ -2412,6 +2421,8 @@ mod tests {
         map_opts.bias_speed_samp = 25;
         map_opts.no_bias_length_threshold = true;
         map_opts.init_uniform = true;
+        map_opts.no_length_correction = true;
+        map_opts.no_frag_length_dist = true;
 
         let q = requant_options(
             &map_opts,
@@ -2443,6 +2454,8 @@ mod tests {
         assert_eq!(q.bias_speed_samp, 25);
         assert!(q.no_bias_length_threshold);
         assert!(q.init_uniform);
+        assert!(q.no_length_correction);
+        assert!(q.no_frag_length_dist);
     }
 
     /// The three knobs #1140 found dropped, checked against a default request
@@ -2460,6 +2473,8 @@ mod tests {
             defaults.no_bias_length_threshold
         );
         assert_eq!(q.init_uniform, defaults.init_uniform);
+        assert_eq!(q.no_length_correction, defaults.no_length_correction);
+        assert_eq!(q.no_frag_length_dist, defaults.no_frag_length_dist);
     }
 
     /// `--writeSam` is a spelling of `--writeMappings`, giving SAM output a


### PR DESCRIPTION
PR B of #1140, the feature work. Neither knob existed in the RAD quantifier, so both were accepted and dropped under `--deterministic`: the run corrected effective lengths and weighted by fragment length whatever the user asked for. `--noLengthCorrection` is the one with a constituency, since 3' tagged-end protocols do not sample a transcript's interior uniformly and the corrected length describes something the data never did.

## Mirroring reads mode, not reinventing it

| knob | reads mode | this PR |
|---|---|---|
| `--noLengthCorrection` | effective length is the raw `ref_len`; bias correction disabled (`bias_on && !no_length_correction`) | same, in `quantify_rad`'s eff-length block and its `bias_on` gate |
| `--noFragLengthDist` | `frag_log_prob` returns `LOG_1`, suppressing both the proper-pair PMF term and the orphan/single-end ambiguous term | same, in the eq-class pass and in the bias pass's posterior, the two places reads mode applies it |

Per your warning not to guess on the orphan term: `processor::frag_log_prob` returns early before either branch, so the ambiguous term goes too. I mirrored that rather than only zeroing the proper-pair PMF.

Both flags are wired for `--deterministic`, `-a` and `--rad`, since all three run the same quantifier and none of them had them.

## Measured

3000-transcript fixture, 300k pairs, `quant.sf` rows where `EffectiveLength == Length`:

```
det                                   0 / 2996
det --noLengthCorrection           2996 / 2996      (one-pass --noLengthCorrection: 2996 / 2996)
det --noLengthCorrection --gcBias  2996 / 2996      byte-identical to the line above
det --noFragLengthDist                0 / 2996      lengths untouched, estimates changed
```

The `--gcBias` line is the gate working: bias is disabled rather than silently correcting lengths the run was told not to correct.

## Testing

Two tests in `crates/salmon-align/tests/rad_input.rs`, both at the RAD level so they pin the semantics rather than the CLI wiring:

- `no_length_correction_uses_raw_lengths`: the default shortens every transcript; with the flag, `eff_lengths == lengths` exactly.
- `no_frag_length_dist_changes_weights_not_lengths`: two transcripts of equal length (so the divisor cannot explain anything), each fragment ambiguous between them with placements reporting fragment lengths of 190 (the FLD mean) and 700 (its far tail). With the term, the near-mean placement takes the mass (>290 of 300); without it, the two are indistinguishable and it splits evenly (within 1). Effective lengths identical in both runs.

Worth recording that the obvious fixture does not work: with two long transcripts the proper-pair term is `pmf(flen) - cmf(txpLen)` and `cmf` is 0 for anything much longer than the fragment distribution, so the term cancels between placements and the flag has no visible effect. Making the transcripts short instead makes the effective-length divisor dominate and the EM goes winner-take-all. Equal lengths plus differing per-placement fragment lengths is what isolates the term.

## Left out

The online `-a` path (`quantify_alignments`) still supports neither, which C++ salmon does. Kept out to hold this to the RAD path the default flip needs, as you offered; happy to follow up if you want the parity before 2.6.0.

## Overlap

Touches `run_deterministic` (two forwarded fields) and the `-a` / `--rad` option blocks in `main.rs`, so it overlaps #1146 and my #1144 / #1147 by a few lines each. Trivial rebase whichever order they land in.
