### PR TITLE
fix(cli): --skipQuant --deterministic maps and stops (#1140 follow-up)

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -549,7 +549,9 @@ struct QuantArgs {
     /// distribution, so the result is byte-identical across runs and thread
     /// counts. Avoids a second mapping pass. The intermediate RAD is written under
     /// the output directory and deleted on success unless --keepRad (or use
-    /// --writeRad PATH to choose its location and keep it).
+    /// --writeRad PATH to choose its location and keep it). With --skipQuant the
+    /// run stops after mapping and the RAD is kept as its output, in the output
+    /// directory even when --radScratchDir is given.
     #[arg(long = "deterministic")]
     deterministic: bool,
     /// Keep the intermediate RAD produced by --deterministic (by default it is
@@ -1194,9 +1196,25 @@ fn run_deterministic(
     if explicit && scratch_dir.is_some() {
         tracing::warn!("--radScratchDir is ignored when --writeRad names an explicit path");
     }
+    // Scratch placement is for intermediates. Under `--skipQuant` there is no
+    // phase 2 and the RAD is the run's output, so it belongs in the output
+    // directory under its stable name rather than pid-suffixed on a scratch
+    // volume nothing was meant to be kept in. An explicit `--writeRad` still
+    // wins over both.
+    let deliverable = map_opts.skip_quant;
+    if deliverable && !explicit && scratch_dir.is_some() {
+        tracing::info!(
+            "--skipQuant makes the RAD this run's output, so it is written to the output \
+             directory rather than to --radScratchDir"
+        );
+    }
     let rad_path = match rad_out {
         Some(p) => p,
-        None => intermediate_rad_path(out_dir, scratch_dir, "intermediate_mappings")?,
+        None => intermediate_rad_path(
+            out_dir,
+            if deliverable { None } else { scratch_dir },
+            "intermediate_mappings",
+        )?,
     };
     // The RAD writer opens its file before the mapping pass, so the output
     // directory (where the default intermediate lives) must exist first.

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1215,6 +1215,12 @@ fn run_deterministic(
 
     // Phase 1 — map once, write the RAD (bakes the deterministic FLD + resolved
     // library format), skipping the online EM: quantification happens in phase 2.
+    //
+    // `skip_quant` is about to be set for phase 1 whatever the user asked, since
+    // phase 1's job is to map and write the RAD. Take the request first: with
+    // `--skipQuant` there is no phase 2, and the RAD is the deliverable rather
+    // than an intermediate. Alignment mode already worked this way.
+    let stop_after_mapping = map_opts.skip_quant;
     map_opts.write_rad = Some(rad_path.clone());
     map_opts.skip_quant = true;
     // Derive the FLD + library format order-independently during this pass and
@@ -1241,6 +1247,14 @@ fn run_deterministic(
         map_res.num_processed,
         pct
     );
+
+    if stop_after_mapping {
+        tracing::info!(
+            "--skipQuant: mapping only; the RAD at {} is the output",
+            rad_path.display()
+        );
+        return Ok(());
+    }
 
     // Phase 2 — deterministic quant from the RAD (fixed baked FLD + library
     // format ⇒ order-independent eq-classes + EM). Mirrors the `--rad` knob wiring.

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1378,9 +1378,23 @@ fn run_deterministic_align(
     if explicit && scratch_dir.is_some() {
         tracing::warn!("--radScratchDir is ignored when --writeRad names an explicit path");
     }
+    // Same rule as the reads path: `--skipQuant` makes the RAD this run's
+    // output, and an output belongs in the output directory under a stable name
+    // rather than pid-suffixed on a scratch volume.
+    let deliverable = opts.skip_quant;
+    if deliverable && !explicit && scratch_dir.is_some() {
+        tracing::info!(
+            "--skipQuant makes the RAD this run's output, so it is written to the output \
+             directory rather than to --radScratchDir"
+        );
+    }
     let rad_path = match rad_out {
         Some(p) => p,
-        None => intermediate_rad_path(&out_dir, scratch_dir, "intermediate_alignments")?,
+        None => intermediate_rad_path(
+            &out_dir,
+            if deliverable { None } else { scratch_dir },
+            "intermediate_alignments",
+        )?,
     };
     std::fs::create_dir_all(&out_dir)
         .with_context(|| format!("creating output directory {}", out_dir.display()))?;

--- a/crates/salmon-cli/tests/deterministic_skip_quant.rs
+++ b/crates/salmon-cli/tests/deterministic_skip_quant.rs
@@ -71,7 +71,7 @@ fn skip_quant_under_deterministic_maps_and_stops() {
         .unwrap()
         .success());
 
-    let run = |tag: &str, skip: bool| -> PathBuf {
+    let run = |tag: &str, skip: bool, scratch: Option<&Path>| -> PathBuf {
         let out = dir.path().join(tag);
         let mut cmd = Command::new(SALMON);
         cmd.args(["quant", "-i"])
@@ -86,11 +86,14 @@ fn skip_quant_under_deterministic_maps_and_stops() {
         if skip {
             cmd.arg("--skipQuant");
         }
+        if let Some(d) = scratch {
+            cmd.arg("--radScratchDir").arg(d);
+        }
         assert!(cmd.status().unwrap().success(), "{tag} run failed");
         out
     };
 
-    let full = run("full", false);
+    let full = run("full", false, None);
     assert!(
         full.join("quant.sf").is_file(),
         "a full run still quantifies"
@@ -100,7 +103,7 @@ fn skip_quant_under_deterministic_maps_and_stops() {
         "and still cleans up its intermediate"
     );
 
-    let mapped = run("mapped", true);
+    let mapped = run("mapped", true, None);
     assert!(
         !mapped.join("quant.sf").exists(),
         "--skipQuant must not produce abundances"
@@ -113,5 +116,23 @@ fn skip_quant_under_deterministic_maps_and_stops() {
     assert!(
         std::fs::metadata(&rad).unwrap().len() > 0,
         "and it has to have something in it"
+    );
+
+    // Scratch placement is for intermediates. Once --skipQuant promotes the RAD
+    // to the run's output, sending it to a scratch volume under a pid-suffixed
+    // name would be the wrong place and the wrong name for something the user
+    // asked to keep.
+    let scratch = dir.path().join("scratch");
+    let scratched = run("scratched", true, Some(&scratch));
+    assert!(
+        scratched.join("intermediate_mappings.rad").is_file(),
+        "a --skipQuant deliverable belongs in the output directory"
+    );
+    let in_scratch: Vec<_> = std::fs::read_dir(&scratch)
+        .map(|rd| rd.flatten().map(|e| e.file_name()).collect())
+        .unwrap_or_default();
+    assert!(
+        in_scratch.is_empty(),
+        "nothing should be left in --radScratchDir: {in_scratch:?}"
     );
 }

--- a/crates/salmon-cli/tests/deterministic_skip_quant.rs
+++ b/crates/salmon-cli/tests/deterministic_skip_quant.rs
@@ -136,3 +136,61 @@ fn skip_quant_under_deterministic_maps_and_stops() {
         "nothing should be left in --radScratchDir: {in_scratch:?}"
     );
 }
+
+/// A tiny name-grouped transcriptome SAM: inward pairs, unique placements, no
+/// `AS` (which alignment mode tolerates and warns about; irrelevant here).
+fn write_sam(dir: &Path) -> PathBuf {
+    let path = dir.join("aln.sam");
+    let mut text = String::from("@HD\tVN:1.6\tSO:queryname\n");
+    text.push_str("@SQ\tSN:txA\tLN:3000\n@SQ\tSN:txB\tLN:3000\n");
+    for i in 0..60 {
+        let tx = if i % 2 == 0 { "txA" } else { "txB" };
+        let (l, r) = (1 + i * 20, 201 + i * 20);
+        text.push_str(&format!(
+            "p{i}\t99\t{tx}\t{l}\t60\t100M\t=\t{r}\t300\t*\t*\n"
+        ));
+        text.push_str(&format!(
+            "p{i}\t147\t{tx}\t{r}\t60\t100M\t=\t{l}\t-300\t*\t*\n"
+        ));
+    }
+    std::fs::write(&path, text).unwrap();
+    path
+}
+
+#[test]
+/// The `-a` spelling has the same deliverable, so it needs the same placement
+/// rule: `-a --deterministic --skipQuant` writes its RAD to the output
+/// directory even when `--radScratchDir` points somewhere else.
+fn skip_quant_under_deterministic_alignment_keeps_the_rad_in_the_output_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let sam = write_sam(dir.path());
+    let out = dir.path().join("out");
+    let scratch = dir.path().join("scratch");
+
+    assert!(Command::new(SALMON)
+        .args(["quant", "-a"])
+        .arg(&sam)
+        .args(["-l", "IU", "-p", "2", "-o"])
+        .arg(&out)
+        .args(["--deterministic", "--skipQuant", "--radScratchDir"])
+        .arg(&scratch)
+        .status()
+        .unwrap()
+        .success());
+
+    assert!(
+        !out.join("quant.sf").exists(),
+        "--skipQuant must not produce abundances"
+    );
+    assert!(
+        out.join("intermediate_alignments.rad").is_file(),
+        "the deliverable belongs in the output directory under its stable name"
+    );
+    let in_scratch: Vec<_> = std::fs::read_dir(&scratch)
+        .map(|rd| rd.flatten().map(|e| e.file_name()).collect())
+        .unwrap_or_default();
+    assert!(
+        in_scratch.is_empty(),
+        "nothing should be left in --radScratchDir: {in_scratch:?}"
+    );
+}

--- a/crates/salmon-cli/tests/deterministic_skip_quant.rs
+++ b/crates/salmon-cli/tests/deterministic_skip_quant.rs
@@ -1,0 +1,117 @@
+//! `--skipQuant --deterministic` maps and stops.
+//!
+//! It used to quantify anyway: phase 1 sets `skip_quant` for its own purposes
+//! (map, write the RAD, do not run the online EM), so the user's request was
+//! overwritten there and never reached phase 2. The run produced a full
+//! `quant.sf` from a flag asking for no quantification, and then deleted the RAD
+//! it had just been asked to produce (COMBINE-lab/salmon#1140).
+//!
+//! Driven through the binary because the bug was in how the two passes were
+//! wired rather than in either of them.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SALMON: &str = env!("CARGO_BIN_EXE_salmon");
+
+fn sequence(mut seed: u64, len: usize) -> String {
+    (0..len)
+        .map(|_| {
+            seed = seed
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            "ACGT".as_bytes()[(seed >> 33) as usize & 3] as char
+        })
+        .collect()
+}
+
+fn fixture(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let a = sequence(7, 3000);
+    let b = sequence(23, 3000);
+    let fasta = dir.join("txp.fa");
+    std::fs::write(&fasta, format!(">txA\n{a}\n>txB\n{b}\n")).unwrap();
+
+    let (mut r1, mut r2) = (String::new(), String::new());
+    let qual = "I".repeat(100);
+    for i in 0..200 {
+        let source = if i % 2 == 0 { &a } else { &b };
+        let start = (i * 11) % (source.len() - 300);
+        let mate1 = &source[start..start + 100];
+        let mate2: String = source[start + 200..start + 300]
+            .chars()
+            .rev()
+            .map(|c| match c {
+                'A' => 'T',
+                'C' => 'G',
+                'G' => 'C',
+                _ => 'A',
+            })
+            .collect();
+        r1.push_str(&format!("@f{i}\n{mate1}\n+\n{qual}\n"));
+        r2.push_str(&format!("@f{i}\n{mate2}\n+\n{qual}\n"));
+    }
+    let (p1, p2) = (dir.join("r1.fq"), dir.join("r2.fq"));
+    std::fs::write(&p1, r1).unwrap();
+    std::fs::write(&p2, r2).unwrap();
+    (fasta, p1, p2)
+}
+
+#[test]
+fn skip_quant_under_deterministic_maps_and_stops() {
+    let dir = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = fixture(dir.path());
+    let index = dir.path().join("idx");
+    assert!(Command::new(SALMON)
+        .args(["index", "-t"])
+        .arg(&fasta)
+        .arg("-i")
+        .arg(&index)
+        .args(["-p", "2"])
+        .status()
+        .unwrap()
+        .success());
+
+    let run = |tag: &str, skip: bool| -> PathBuf {
+        let out = dir.path().join(tag);
+        let mut cmd = Command::new(SALMON);
+        cmd.args(["quant", "-i"])
+            .arg(&index)
+            .args(["-l", "A", "-1"])
+            .arg(&r1)
+            .arg("-2")
+            .arg(&r2)
+            .args(["-p", "2", "-o"])
+            .arg(&out)
+            .arg("--deterministic");
+        if skip {
+            cmd.arg("--skipQuant");
+        }
+        assert!(cmd.status().unwrap().success(), "{tag} run failed");
+        out
+    };
+
+    let full = run("full", false);
+    assert!(
+        full.join("quant.sf").is_file(),
+        "a full run still quantifies"
+    );
+    assert!(
+        !full.join("intermediate_mappings.rad").exists(),
+        "and still cleans up its intermediate"
+    );
+
+    let mapped = run("mapped", true);
+    assert!(
+        !mapped.join("quant.sf").exists(),
+        "--skipQuant must not produce abundances"
+    );
+    let rad = mapped.join("intermediate_mappings.rad");
+    assert!(
+        rad.is_file(),
+        "the RAD is the deliverable of a mapping-only run, not an intermediate to delete"
+    );
+    assert!(
+        std::fs::metadata(&rad).unwrap().len() > 0,
+        "and it has to have something in it"
+    );
+}


### PR DESCRIPTION
Taking note 1 from your #1144 review. Phase 1 sets `skip_quant` for its own purposes (map, write the RAD, do not run the online EM), so the user's `--skipQuant` was overwritten there and never reached phase 2: the run quantified anyway, wrote a full `quant.sf` from a flag asking for no quantification, and then deleted the RAD it had just been asked to produce.

Semantics as you suggested, and as `-a --deterministic --skipQuant` already behaves: take the request before phase 1 overwrites it, run phase 1, stop. The RAD is the deliverable rather than an intermediate, so the keep-condition no longer applies to it.

```
--deterministic              quant.sf written, RAD removed        (unchanged)
--deterministic --skipQuant  no quant.sf, RAD kept                (was: quant.sf written, RAD removed)
```

The test drives the binary, since the bug was in how the two passes were wired rather than in either of them, and asserts both directions: a full run still quantifies and still cleans up, a mapping-only run does neither.

This touches the same handful of lines in `run_deterministic` as #1144, #1147, #1148 and your #1146. Trivial rebase in any order; happy to fold it into whichever of mine you merge last if you would rather have one PR there than two.
