### PR TITLE
2.6.0: deterministic quantification is the default; `--online` is the deprecated escape hatch

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -2734,6 +2734,47 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
             ));
         }
     }
+    // lib_format_counts.json — reads mode writes one, so alignment mode and a
+    // RAD requant should too, or a pipeline that reads it breaks on the requant
+    // of its own output. The struct and its C++-matching field semantics live
+    // in `salmon_core::LibFormatCountsFile`, shared with reads mode; the
+    // per-format histogram and the judged compat/incompat tallies are measured
+    // in both input paths here. For phase 2 of `--deterministic` this rewrite
+    // is what puts *measured* values in the final output directory — the
+    // mapping pass's file is overwritten here, so these fields must be real,
+    // not placeholders.
+    let lib_diags: Vec<salmon_core::Diagnostic> = {
+        // The expected format is the one the strand filter actually used: the
+        // detected type only under `-l A` — the RAD derive pass also detects
+        // under an explicit `-l` (for the mismatch diagnostic), and reporting
+        // that instead would mislabel the file.
+        let expected = if LibraryFormat::is_auto(&opts.lib_type) {
+            res.detected_library_type
+                .clone()
+                .unwrap_or_else(|| opts.lib_type.clone())
+        } else {
+            LibraryFormat::parse(&opts.lib_type)
+                .map(|f| f.canonical().to_string())
+                .unwrap_or_else(|_| opts.lib_type.clone())
+        };
+        let counts = salmon_core::LibFormatCountsFile::new(
+            // The BAM / RAD is the input; the reads that produced it are not
+            // known here.
+            vec![],
+            expected,
+            res.num_mapped,
+            res.num_compatible_fragments,
+            res.num_incompatible_fragments,
+            &res.lib_format_counts,
+        );
+        counts.log_warnings();
+        std::fs::write(
+            dir.join("lib_format_counts.json"),
+            serde_json::to_string_pretty(&counts)?,
+        )?;
+        counts.diagnostics()
+    };
+
     let meta = MetaInfo {
         salmon_version: SALMON_VERSION.to_string(),
         // What kind of posterior samples were actually produced, so tximport
@@ -2817,7 +2858,13 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         },
         total_time_seconds: res.total_seconds,
         peak_rss_kb: res.peak_rss_kb,
-        diagnostics: res.diagnostics.clone(),
+        // The run's own diagnostics plus the library-format warnings, so
+        // `meta_info.json` carries every machine-readable concern (#1140).
+        diagnostics: {
+            let mut d = res.diagnostics.clone();
+            d.extend(lib_diags.iter().cloned());
+            d
+        },
         call: "quant".to_string(),
         start_time: res.start_time.clone(),
         end_time: asctime_now(),
@@ -2826,46 +2873,6 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         dir.join("aux_info").join("meta_info.json"),
         serde_json::to_string_pretty(&meta)?,
     )?;
-
-    // lib_format_counts.json — reads mode writes one, so alignment mode and a
-    // RAD requant should too, or a pipeline that reads it breaks on the requant
-    // of its own output. The struct and its C++-matching field semantics live
-    // in `salmon_core::LibFormatCountsFile`, shared with reads mode; the
-    // per-format histogram and the judged compat/incompat tallies are measured
-    // in both input paths here. For phase 2 of `--deterministic` this rewrite
-    // is what puts *measured* values in the final output directory — the
-    // mapping pass's file is overwritten here, so these fields must be real,
-    // not placeholders.
-    {
-        // The expected format is the one the strand filter actually used: the
-        // detected type only under `-l A` — the RAD derive pass also detects
-        // under an explicit `-l` (for the mismatch diagnostic), and reporting
-        // that instead would mislabel the file.
-        let expected = if LibraryFormat::is_auto(&opts.lib_type) {
-            res.detected_library_type
-                .clone()
-                .unwrap_or_else(|| opts.lib_type.clone())
-        } else {
-            LibraryFormat::parse(&opts.lib_type)
-                .map(|f| f.canonical().to_string())
-                .unwrap_or_else(|_| opts.lib_type.clone())
-        };
-        let counts = salmon_core::LibFormatCountsFile::new(
-            // The reads behind the RAD when the driver knows them (reads-mode
-            // --deterministic); a standalone --rad/-a input has none to name.
-            opts.read_files.clone(),
-            expected,
-            res.num_mapped,
-            res.num_compatible_fragments,
-            res.num_incompatible_fragments,
-            &res.lib_format_counts,
-        );
-        counts.log_warnings();
-        std::fs::write(
-            dir.join("lib_format_counts.json"),
-            serde_json::to_string_pretty(&counts)?,
-        )?;
-    }
 
     // aux_info/bootstrap/{names.tsv.gz, bootstraps.gz}: posterior samples in the
     // same layout reads mode uses (gzipped tab-separated names; gzipped raw

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -225,6 +225,11 @@ pub struct AlignQuantOptions {
     /// `--noFragLengthDist`: drop the fragment-length term from a placement's
     /// weight, leaving score and compatibility to decide it.
     pub no_frag_length_dist: bool,
+    /// diagnostics born in an earlier phase the driver ran (e.g. the
+    /// deterministic alignment pass's unusable-`AS` verdict), appended to this
+    /// pass's own in `meta_info.json` — so a pipeline that only keeps the
+    /// output directory sees them, not just whoever read the log (#1140)
+    pub extra_diagnostics: Vec<salmon_core::Diagnostic>,
     /// significant digits for the EffectiveLength and NumReads columns of
     /// `quant.sf` (`--sigDigits`, salmon default 3)
     pub sig_digits: u32,
@@ -298,6 +303,7 @@ impl AlignQuantOptions {
             dump_eq_weights: false,
             no_length_correction: false,
             no_frag_length_dist: false,
+            extra_diagnostics: Vec::new(),
             sig_digits: 3,
             num_error_bins: 4,
             discard_orphans: false,

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -2758,9 +2758,9 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
                 .unwrap_or_else(|_| opts.lib_type.clone())
         };
         let counts = salmon_core::LibFormatCountsFile::new(
-            // The BAM / RAD is the input; the reads that produced it are not
-            // known here.
-            vec![],
+            // The reads behind the RAD when the driver knows them (reads-mode
+            // --deterministic); a standalone --rad/-a input has none to name.
+            opts.read_files.clone(),
             expected,
             res.num_mapped,
             res.num_compatible_fragments,
@@ -2801,7 +2801,23 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         frag_dist_length: res.frag_len_dist.len(),
         frag_length_mean: res.frag_len_mean,
         frag_length_sd: res.frag_len_sd,
-        frag_length_source: res.frag_len_source.as_str(),
+        // In the integrated `--deterministic` flow (`preserve_cmd_info`, like
+        // the invocation record above) provenance describes the user's run,
+        // not the internal RAD handoff: phase 1 of this same run observed the
+        // FLD (paired) or defaulted it (single-end, no lengths to observe);
+        // the intermediate RAD merely carried it. The rad_baked* spellings
+        // stay for standalone `--rad` input, where the RAD really is the
+        // source (#1140).
+        frag_length_source: match (opts.preserve_cmd_info, res.frag_len_source) {
+            (true, salmon_model::FragLengthSource::RadBaked) => {
+                salmon_model::FragLengthSource::Reads
+            }
+            (true, salmon_model::FragLengthSource::RadBakedPrior) => {
+                salmon_model::FragLengthSource::Prior
+            }
+            (_, s) => s,
+        }
+        .as_str(),
         seq_bias_correct: opts.seq_bias,
         gc_bias_correct: opts.gc_bias,
         pos_bias_correct: opts.pos_bias,

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -2237,13 +2237,16 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     let requested_lib = LibraryFormat::parse(&opts.lib_type)
         .map(|f| f.canonical().to_string())
         .unwrap_or_else(|_| opts.lib_type.clone());
-    let diagnostics = salmon_core::input_diagnostics(
+    let mut diagnostics = salmon_core::input_diagnostics(
         num_processed,
         num_mapped,
         auto_detect,
         &requested_lib,
         detected_library_type.as_deref(),
     );
+    // Phase-1 diagnostics the driver handed in, merged before logging so they
+    // are both spoken and recorded like this pass's own.
+    diagnostics.extend(opts.extra_diagnostics.iter().cloned());
     for d in &diagnostics {
         if d.severity == "error" {
             tracing::error!("{}", d.message);

--- a/crates/salmon-align/tests/rad_lib_format_counts.rs
+++ b/crates/salmon-align/tests/rad_lib_format_counts.rs
@@ -136,6 +136,23 @@ fn rad_requant_lib_format_counts_report_incompatible_fragments() {
     let v = lib_counts(&out_isr);
     assert_eq!(u64_field(&v, "num_compatible_fragments"), n_isr as u64);
     assert_eq!(u64_field(&v, "num_incompatible_fragments"), n_isf as u64);
+    // The >5% incompatible warning is not only spoken: it lands in
+    // meta_info.json's machine-readable diagnostics (#1140), so a pipeline
+    // that never sees the log still sees the concern.
+    let meta: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out_isr.join("aux_info").join("meta_info.json")).unwrap(),
+    )
+    .unwrap();
+    let codes: Vec<&str> = meta["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["code"].as_str().unwrap())
+        .collect();
+    assert!(
+        codes.contains(&"high_incompatible_fraction"),
+        "expected high_incompatible_fraction in diagnostics, got {codes:?}"
+    );
 
     // Unstranded: judged like any other type, and everything passes — but the
     // histogram-derived fields still expose the strand split, which is exactly

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -551,16 +551,23 @@ struct QuantArgs {
     /// piscem map-bulk compatible and can be re-quantified with `--rad`.
     #[arg(long = "writeRad")]
     write_rad: Option<PathBuf>,
-    /// Deterministic quantification (reads/FASTQ input): map once to an
-    /// intermediate RAD, then quantify from it with a fixed fragment-length
-    /// distribution, so the result is byte-identical across runs and thread
-    /// counts. Avoids a second mapping pass. The intermediate RAD is written under
+    /// Deterministic quantification: map once to an intermediate RAD, then
+    /// quantify from it with a fixed fragment-length distribution, so the
+    /// result is byte-identical across runs and thread counts. **The default
+    /// since 2.6.0** — the flag is accepted as a no-op; use --online for the
+    /// deprecated one-pass path. The intermediate RAD is written under
     /// the output directory and deleted on success unless --keepRad (or use
     /// --writeRad PATH to choose its location and keep it). With --skipQuant the
     /// run stops after mapping and the RAD is kept as its output, in the output
     /// directory even when --radScratchDir is given.
     #[arg(long = "deterministic")]
     deterministic: bool,
+    /// Quantify with the pre-2.6 online one-pass path instead of the default
+    /// deterministic two-phase flow. Deprecated: results depend on the thread
+    /// count (the default is byte-identical at any -p); scheduled for removal
+    /// in 2.7.0.
+    #[arg(long = "online", conflicts_with = "deterministic")]
+    online: bool,
     /// Keep the intermediate RAD produced by --deterministic (by default it is
     /// deleted once quantification finishes). Ignored without --deterministic.
     #[arg(long = "keepRad")]
@@ -699,9 +706,11 @@ struct QuantArgs {
     /// fragment-length sensitivity analysis actually vary anything.
     #[arg(long = "fldPolicy", value_enum, default_value_t = FldPolicyArg::Baked)]
     fld_policy: FldPolicyArg,
-    /// Online-phase forgetting factor in (0.5, 1.0].
-    #[arg(short = 'f', long = "forgettingFactor", default_value_t = 0.65)]
-    forgetting_factor: f64,
+    /// Online-phase forgetting factor in (0.5, 1.0]; default 0.65. Online-path
+    /// only (--online, deprecated): ignored with a warning under the default
+    /// deterministic mode.
+    #[arg(short = 'f', long = "forgettingFactor")]
+    forgetting_factor: Option<f64>,
     /// Initialize the optimizer uniformly. In reads mode (one-pass and
     /// --deterministic) the optimizer already starts uniform, so this is the
     /// existing behavior; in online alignment mode (-a) it replaces the
@@ -790,9 +799,11 @@ struct QuantArgs {
     #[arg(long = "biasSpeedSamp", default_value_t = 5)]
     bias_speed_samp: usize,
     /// Number of leading fragments used to train the auxiliary models
-    /// (fragment-length / bias / error); they are fixed afterward.
-    #[arg(long = "numAuxModelSamples", default_value_t = 5_000_000)]
-    num_aux_model_samples: u64,
+    /// (fragment-length / bias / error); they are fixed afterward; default
+    /// 5000000. Online-path only (--online, deprecated): ignored with a
+    /// warning under the default deterministic mode.
+    #[arg(long = "numAuxModelSamples")]
+    num_aux_model_samples: Option<u64>,
     /// Disable the lower threshold on how short bias correction may make an
     /// effective length (increases precision, reduces robustness). Experimental.
     #[arg(long = "noBiasLengthThreshold")]
@@ -840,9 +851,11 @@ struct QuantArgs {
     eqclasses: Option<PathBuf>,
     /// Fragments processed before the auxiliary (fragment-length) model is
     /// applied during online inference. (salmon's --numPreAuxModelSamples;
-    /// salmon's default is 1000000, this port's is 5000.)
-    #[arg(long = "numPreAuxModelSamples", default_value_t = 5000)]
-    num_pre_aux_model_samples: u64,
+    /// salmon's default is 1000000, this port's is 5000.) Online-path only
+    /// (--online, deprecated): ignored with a warning under the default
+    /// deterministic mode.
+    #[arg(long = "numPreAuxModelSamples")]
+    num_pre_aux_model_samples: Option<u64>,
     /// [accepted; not yet implemented] disable fragment-length-distribution
     /// concordance in the per-fragment probability.
     #[arg(long = "noFragLengthDist")]
@@ -1275,6 +1288,9 @@ fn run_deterministic(
     bias_targets: Option<PathBuf>,
     gene_map: Option<&GeneMapOpts>,
     out_dir: &std::path::Path,
+    // The live mapping spinner, owned here so it can be stopped the moment
+    // phase 1 finishes (its counters do not advance during the requant).
+    spinner: Option<ProgressGuard>,
 ) -> Result<()> {
     // Wall-clock accounting spans both phases: phase 2 rewrites
     // `meta_info.json` into the final output directory, and its
@@ -1360,6 +1376,7 @@ fn run_deterministic(
             return Err(e).context("deterministic mapping pass failed");
         }
     };
+    drop(spinner); // stop + clear the mapping spinner before phase-2 logging
     let pct = if map_res.num_processed > 0 {
         100.0 * map_res.num_mapped as f64 / map_res.num_processed as f64
     } else {
@@ -1532,6 +1549,16 @@ fn run_deterministic_align(
         summary.num_processed,
         pct
     );
+    // The unusable-`AS` verdict is born here in phase 1, but `meta_info.json`
+    // is written by phase 2 — hand it across so pipelines that only keep the
+    // output directory see it in `diagnostics`, not just the log (#1140).
+    if let Some(w) = &summary.score_tag_warning {
+        opts.extra_diagnostics.push(salmon_core::Diagnostic::new(
+            "bam_score_tags_unusable",
+            "warning",
+            w.clone(),
+        ));
+    }
 
     // Phase 2 — quantify from the fully-baked RAD (single pass, order-independent).
     opts.prior_seconds = run_start.elapsed().as_secs_f64();
@@ -1751,6 +1778,38 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         .build_global();
     let out_dir = args.output.clone();
     let gene_map = load_gene_map(args.gene_map.clone(), args.ignore_tx_version)?;
+
+    // 2.6.0 flips the default to the deterministic two-phase flow; `--online`
+    // selects the pre-2.6 one-pass path for one deprecation cycle. The knobs
+    // that only exist on the online path warn when passed without it, rather
+    // than being silently inert under the new default — silent inertness is
+    // the exact failure mode #1140's audit spent a release hunting down.
+    if args.online {
+        tracing::warn!(
+            "--online selects the deprecated one-pass quantification path (removal planned \
+             for 2.7.0). Its results depend on the thread count; the default deterministic \
+             mode is byte-identical at any -p and was measured as fast or faster."
+        );
+    } else {
+        let mut inert: Vec<&str> = Vec::new();
+        if args.forgetting_factor.is_some() {
+            inert.push("--forgettingFactor");
+        }
+        if args.num_aux_model_samples.is_some() {
+            inert.push("--numAuxModelSamples");
+        }
+        if args.num_pre_aux_model_samples.is_some() {
+            inert.push("--numPreAuxModelSamples");
+        }
+        if !inert.is_empty() {
+            tracing::warn!(
+                "{} configure the online inference path, which the default deterministic \
+                 mode does not run: ignored. Pass --online (deprecated, removal planned \
+                 for 2.7.0) to use them.",
+                inert.join(", ")
+            );
+        }
+    }
     // `--meta` (metagenomic preset) forces plain EM (no VBEM) and disables rich /
     // range-factorized equivalence classes, matching salmon's --meta. salmon's
     // preset also sets initUniform; the Rust offline EM already initializes
@@ -1794,21 +1853,21 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.fld_mean = args.fld_mean.unwrap_or(DEFAULT_FLD_MEAN);
         opts.fld_sd = args.fld_sd.unwrap_or(DEFAULT_FLD_SD);
         opts.fld_max = args.fld_max.unwrap_or(DEFAULT_FLD_MAX);
-        opts.forgetting_factor = args.forgetting_factor;
+        opts.forgetting_factor = args.forgetting_factor.unwrap_or(0.65);
         opts.init_uniform = args.init_uniform;
         opts.dump_eq = args.dump_eq;
         opts.dump_eq_weights = args.dump_eq_weights;
         opts.no_length_correction = args.no_length_correction;
         opts.no_frag_length_dist = args.no_frag_length_dist;
         opts.bias_speed_samp = args.bias_speed_samp;
-        opts.num_aux_model_samples = args.num_aux_model_samples;
+        opts.num_aux_model_samples = args.num_aux_model_samples.unwrap_or(5_000_000);
         opts.no_bias_length_threshold = args.no_bias_length_threshold;
         opts.num_error_bins = args.num_error_bins;
         opts.discard_orphans = args.discard_orphans;
         opts.gc_bins = args.num_gc_bins;
         opts.cond_gc_bins = args.conditional_gc_bins;
         opts.skip_quant = args.skip_quant;
-        opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples;
+        opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples.unwrap_or(5_000);
         opts.num_bootstraps = args.num_bootstraps;
         opts.num_gibbs_samples = args.num_gibbs_samples;
         opts.thinning_factor = args.thinning_factor;
@@ -1822,10 +1881,10 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             // Genome projection is inherently deterministic (RAD-based) and has no
             // error model (bramble exposes no projected CIGAR), so flags that only
             // matter for transcriptomic alignment are accepted but no-ops here.
-            if args.deterministic {
+            if args.online {
                 tracing::warn!(
-                    "--deterministic is redundant in genome-projection mode (--annotation): \
-                     projection is already deterministic; ignoring it"
+                    "--online has no effect in genome-projection mode (--annotation): \
+                     projection is inherently RAD-based and deterministic; ignoring it"
                 );
             }
             if args.error_model {
@@ -1859,11 +1918,14 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             );
         }
 
-        // `--deterministic`: write the BAM's placements to an intermediate RAD
-        // (baking the FLD/library-format + rough abundances) and requantify from
-        // it, for results byte-identical across thread counts. Score-based; no
-        // online error model.
-        if args.deterministic {
+        // Default (2.6.0): deterministic alignment quant — write the BAM's
+        // placements to an intermediate RAD (baking the FLD/library-format +
+        // rough abundances) and requantify from it, for results byte-identical
+        // across thread counts. Score-based (`AS`); `--errorModel` opts into
+        // the order-independent error model. `--online` selects the deprecated
+        // one-pass path below, which is the only place the online error model
+        // still lives.
+        if !args.online {
             let codec = rad_codec_from_args(args.no_compress_rad, &args.rad_compress)?;
             return run_deterministic_align(
                 opts,
@@ -1875,6 +1937,16 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             );
         }
 
+        // The online alignment path never supported these two (C++ did); the
+        // deterministic default honours them, so under `--online` they warn
+        // rather than silently doing nothing (#1140: no parity work for a path
+        // scheduled for removal).
+        if args.no_length_correction || args.no_frag_length_dist {
+            tracing::warn!(
+                "--noLengthCorrection/--noFragLengthDist are not supported on the deprecated \
+                 online alignment path: ignored. The default (deterministic) mode honours them."
+            );
+        }
         // Live progress spinner on an interactive terminal (unless --quiet/--no-progress).
         let progress = Arc::new(ProgressCounters::default());
         let guard = if !quiet && !args.no_progress && std::io::stderr().is_terminal() {
@@ -2090,12 +2162,12 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.map_config.pair.post_merge_chain_sub_thresh = args.post_merge_chain_sub_thresh;
     // model toggles (Tier 2)
     opts.bias_speed_samp = args.bias_speed_samp;
-    opts.num_aux_model_samples = args.num_aux_model_samples;
+    opts.num_aux_model_samples = args.num_aux_model_samples.unwrap_or(5_000_000);
     opts.no_bias_length_threshold = args.no_bias_length_threshold;
     opts.gc_bins = args.num_gc_bins;
     opts.cond_gc_bins = args.conditional_gc_bins;
     opts.skip_quant = args.skip_quant;
-    opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples;
+    opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples.unwrap_or(5_000);
     opts.map_config.seed_mode = seed_mode(args.unimems, args.refmems, args.sparse_seeds);
     // alignment scoring (selective alignment)
     opts.map_config.align.match_score = args.ma as i8;
@@ -2115,13 +2187,26 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.fld_sd = args.fld_sd.unwrap_or(DEFAULT_FLD_SD);
     opts.fld_max = args.fld_max.unwrap_or(DEFAULT_FLD_MAX);
     warn_unsupported_fld_policy(args.fld_policy, "reads mode");
-    opts.forgetting_factor = args.forgetting_factor;
+    opts.forgetting_factor = args.forgetting_factor.unwrap_or(0.65);
     opts.init_uniform = args.init_uniform;
 
-    // Deterministic mode: map once to an intermediate RAD, then quantify from it
-    // with a fixed FLD (byte-identical output, no second mapping pass).
-    if args.deterministic {
+    // Default (2.6.0): deterministic mode — map once to an intermediate RAD,
+    // then quantify from it with a fixed FLD (byte-identical output at any
+    // thread count, no second mapping pass). `--online` selects the deprecated
+    // one-pass path below.
+    if !args.online {
         let rad_out = opts.write_rad.take(); // honour an explicit --writeRad path
+                                             // The phase-1 mapping spinner, wired exactly as the one-pass path wires
+                                             // its own: a default mode cannot be a silent black box for the minutes
+                                             // the mapping pass takes. Handed into the driver so it stops when
+                                             // phase 1 does, rather than spinning frozen through phase 2.
+        let progress = Arc::new(ProgressCounters::default());
+        let spinner = if !quiet && !args.no_progress && std::io::stderr().is_terminal() {
+            opts.progress = Some(progress.clone());
+            Some(ProgressGuard::start(progress))
+        } else {
+            None
+        };
         return run_deterministic(
             opts,
             rad_out,
@@ -2130,6 +2215,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             args.targets.clone(),
             gene_map.as_ref(),
             &out_dir,
+            spinner,
         );
     }
     // `--initUniform` asks for a uniform optimizer start, and in one-pass reads

--- a/crates/salmon-cli/tests/deterministic_default.rs
+++ b/crates/salmon-cli/tests/deterministic_default.rs
@@ -1,0 +1,152 @@
+//! 2.6.0 flips the default quantification path to deterministic (#1140).
+//!
+//! These tests pin the flip's contract at the binary level: a bare run takes
+//! the deterministic two-phase path (auditable via `meta_info.json`'s
+//! `inference_path`), `--online` selects the deprecated one-pass path with a
+//! deprecation warning, `--deterministic` stays accepted as a no-op (it is in
+//! scripts and CI configs already), the contradictory spelling errors out, and
+//! online-only knobs warn instead of being silently inert under the default.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SALMON: &str = env!("CARGO_BIN_EXE_salmon");
+
+fn sequence(mut seed: u64, len: usize) -> String {
+    (0..len)
+        .map(|_| {
+            seed = seed
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            "ACGT".as_bytes()[(seed >> 33) as usize & 3] as char
+        })
+        .collect()
+}
+
+fn fixture(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let a = sequence(3, 3000);
+    let b = sequence(17, 3000);
+    let fasta = dir.join("txp.fa");
+    std::fs::write(&fasta, format!(">txA\n{a}\n>txB\n{b}\n")).unwrap();
+
+    let (mut r1, mut r2) = (String::new(), String::new());
+    let qual = "I".repeat(100);
+    for i in 0..200 {
+        let source = if i % 2 == 0 { &a } else { &b };
+        let start = (i * 13) % (source.len() - 300);
+        let mate1 = &source[start..start + 100];
+        let mate2: String = source[start + 200..start + 300]
+            .chars()
+            .rev()
+            .map(|c| match c {
+                'A' => 'T',
+                'C' => 'G',
+                'G' => 'C',
+                _ => 'A',
+            })
+            .collect();
+        r1.push_str(&format!("@f{i}\n{mate1}\n+\n{qual}\n"));
+        r2.push_str(&format!("@f{i}\n{mate2}\n+\n{qual}\n"));
+    }
+    let (p1, p2) = (dir.join("r1.fq"), dir.join("r2.fq"));
+    std::fs::write(&p1, r1).unwrap();
+    std::fs::write(&p2, r2).unwrap();
+    (fasta, p1, p2)
+}
+
+fn inference_path(out: &Path) -> String {
+    let text = std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap();
+    let key = "\"inference_path\":";
+    let start = text.find(key).unwrap() + key.len();
+    text[start..]
+        .split('"')
+        .nth(1)
+        .expect("inference_path value")
+        .to_string()
+}
+
+#[test]
+fn deterministic_is_the_default_and_online_is_the_deprecated_escape_hatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = fixture(dir.path());
+    let index = dir.path().join("idx");
+    assert!(Command::new(SALMON)
+        .args(["index", "-t"])
+        .arg(&fasta)
+        .arg("-i")
+        .arg(&index)
+        .args(["-p", "2"])
+        .status()
+        .unwrap()
+        .success());
+
+    let run = |tag: &str, extra: &[&str]| -> (PathBuf, std::process::Output) {
+        let out = dir.path().join(tag);
+        let mut cmd = Command::new(SALMON);
+        cmd.args(["quant", "-i"])
+            .arg(&index)
+            .args(["-l", "IU", "-1"])
+            .arg(&r1)
+            .arg("-2")
+            .arg(&r2)
+            .args(["-p", "2", "-o"])
+            .arg(&out)
+            .args(extra);
+        (out.clone(), cmd.output().unwrap())
+    };
+
+    // A bare run is deterministic: the auditable field says so, and the
+    // intermediate RAD was cleaned up on success.
+    let (out, res) = run("bare", &[]);
+    assert!(res.status.success());
+    assert_eq!(inference_path(&out), "deterministic");
+    assert!(
+        !out.join("intermediate_mappings.rad").exists(),
+        "the intermediate is cleaned up on success"
+    );
+    assert!(out.join("quant.sf").is_file());
+
+    // `--deterministic` stays accepted as a no-op: it is in scripts already,
+    // and erroring on it would break exactly the users who adopted early.
+    let (out, res) = run("explicit", &["--deterministic"]);
+    assert!(res.status.success(), "--deterministic must stay accepted");
+    assert_eq!(inference_path(&out), "deterministic");
+
+    // `--online` selects the one-pass path and says it is deprecated.
+    let (out, res) = run("online", &["--online"]);
+    assert!(res.status.success());
+    assert_eq!(inference_path(&out), "online");
+    let err = String::from_utf8_lossy(&res.stderr);
+    assert!(
+        err.contains("deprecated"),
+        "--online must announce its deprecation: {err}"
+    );
+
+    // The contradictory spelling is an error, not a guess.
+    let (_, res) = run("conflict", &["--online", "--deterministic"]);
+    assert!(
+        !res.status.success(),
+        "--online --deterministic must not pick a side silently"
+    );
+
+    // An online-only knob without `--online` warns instead of being silently
+    // inert — the failure mode this whole release cycle existed to eradicate.
+    let (out, res) = run("inert", &["--forgettingFactor", "0.8"]);
+    assert!(res.status.success());
+    assert_eq!(inference_path(&out), "deterministic");
+    let err = String::from_utf8_lossy(&res.stderr);
+    assert!(
+        err.contains("--forgettingFactor"),
+        "an inert online knob must be named in a warning: {err}"
+    );
+
+    // ...and the same knob under `--online` is used without complaint about
+    // inertness (the only warning is the deprecation one).
+    let (_, res) = run("online_knob", &["--online", "--forgettingFactor", "0.8"]);
+    assert!(res.status.success());
+    let err = String::from_utf8_lossy(&res.stderr);
+    assert!(
+        !err.contains("ignored"),
+        "an online knob under --online is not inert: {err}"
+    );
+}

--- a/crates/salmon-core/src/diagnostics.rs
+++ b/crates/salmon-core/src/diagnostics.rs
@@ -31,9 +31,11 @@ pub struct Diagnostic {
 }
 
 impl Diagnostic {
-    /// Private constructor; the codes and severities are all chosen inside this
-    /// module so they stay consistent.
-    fn new(code: &str, severity: &str, message: String) -> Self {
+    /// The codes and severities are normally chosen inside this module so they
+    /// stay consistent; public so a driver can hand a phase-1-born diagnostic
+    /// into a later pass's `meta_info.json` (e.g. the deterministic alignment
+    /// pass's unusable-`AS` verdict, #1140).
+    pub fn new(code: &str, severity: &str, message: String) -> Self {
         Self {
             code: code.to_string(),
             severity: severity.to_string(),

--- a/crates/salmon-core/src/libtype.rs
+++ b/crates/salmon-core/src/libtype.rs
@@ -483,34 +483,60 @@ pub fn summarize_lib_format_counts(
 
 impl LibFormatSummary {
     /// The classic end-of-run library-format warnings (ported from
-    /// `summarizeLibraryTypeCounts`), emitted by every writer of
-    /// `lib_format_counts.json` so the checks behave identically across modes:
-    /// no concordant-consistent mappings at all; a strand bias beyond 1% under
-    /// an unstranded expectation; and more than 5% of judged fragments
-    /// incompatible with the expected format.
-    pub fn log_warnings(&self, expected: LibraryFormat, compatible_fragment_ratio: f64) {
+    /// `summarizeLibraryTypeCounts`) as structured [`crate::Diagnostic`]s, so
+    /// they reach `meta_info.json`'s machine-readable `diagnostics` array and
+    /// not just whoever reads the log (#1140): no concordant-consistent
+    /// mappings at all; a strand bias beyond 1% under an unstranded
+    /// expectation; and more than 5% of judged fragments incompatible with the
+    /// expected format.
+    pub fn diagnostics(
+        &self,
+        expected: LibraryFormat,
+        compatible_fragment_ratio: f64,
+    ) -> Vec<crate::Diagnostic> {
+        let mut out = Vec::new();
         if expected.strandedness == ReadStrandedness::U {
             if self.num_concordant_consistent == 0 {
-                tracing::warn!(
+                out.push(crate::Diagnostic::new(
+                    "no_concordant_mappings",
+                    "warning",
                     "found no concordant and consistent mappings; if this is a \
                      paired-end library, are you sure the reads are properly \
                      paired? See lib_format_counts.json for details"
-                );
+                        .to_string(),
+                ));
             } else if (self.strand_mapping_bias - 0.5).abs() > 0.01 {
-                tracing::warn!(
-                    "detected a *potential* strand bias > 1% in an unstranded \
-                     protocol (strand_mapping_bias = {:.4}); see \
-                     lib_format_counts.json for details",
-                    self.strand_mapping_bias
-                );
+                out.push(crate::Diagnostic::new(
+                    "strand_bias_unstranded",
+                    "warning",
+                    format!(
+                        "detected a *potential* strand bias > 1% in an unstranded \
+                         protocol (strand_mapping_bias = {:.4}); see \
+                         lib_format_counts.json for details",
+                        self.strand_mapping_bias
+                    ),
+                ));
             }
         }
         if 1.0 - compatible_fragment_ratio > 0.05 {
-            tracing::warn!(
-                "greater than 5% of the fragments disagreed with the expected \
-                 library type ({}); see lib_format_counts.json for details",
-                expected.canonical()
-            );
+            out.push(crate::Diagnostic::new(
+                "high_incompatible_fraction",
+                "warning",
+                format!(
+                    "greater than 5% of the fragments disagreed with the expected \
+                     library type ({}); see lib_format_counts.json for details",
+                    expected.canonical()
+                ),
+            ));
+        }
+        out
+    }
+
+    /// Log [`Self::diagnostics`] as warnings — one condition set, spoken and
+    /// recorded from the same source so the two cannot drift.
+    pub fn log_warnings(&self, expected: LibraryFormat, compatible_fragment_ratio: f64) {
+        for d in self.diagnostics(expected, compatible_fragment_ratio) {
+            tracing::warn!("{}", d.message);
         }
     }
 }
@@ -623,21 +649,33 @@ impl LibFormatCountsFile {
         }
     }
 
-    /// Emit the classic end-of-run warnings for this file's contents (see
-    /// [`LibFormatSummary::log_warnings`]). A no-op when the expected format
-    /// never resolved or nothing mapped — an empty run has nothing to warn
-    /// about.
-    pub fn log_warnings(&self) {
-        if self.num_assigned_fragments == 0 {
-            return;
+    /// The classic end-of-run warnings for this file's contents, as structured
+    /// diagnostics (see [`LibFormatSummary::diagnostics`]). Empty when the
+    /// expected format never resolved, or when nothing was assigned *and*
+    /// nothing was judged incompatible — a truly empty run has nothing to warn
+    /// about, but a run whose every fragment was dropped as wrong-strand
+    /// (assigned 0, incompatible many) is exactly the run these warnings exist
+    /// for.
+    pub fn diagnostics(&self) -> Vec<crate::Diagnostic> {
+        if self.num_assigned_fragments == 0 && self.num_incompatible_fragments == 0 {
+            return Vec::new();
         }
-        if let Ok(exp) = LibraryFormat::parse(&self.expected_format) {
-            let summary = LibFormatSummary {
-                num_concordant_consistent: self.num_frags_with_concordant_consistent_mappings,
-                num_inconsistent_or_orphan: self.num_frags_with_inconsistent_or_orphan_mappings,
-                strand_mapping_bias: self.strand_mapping_bias,
-            };
-            summary.log_warnings(exp, self.compatible_fragment_ratio);
+        let Ok(exp) = LibraryFormat::parse(&self.expected_format) else {
+            return Vec::new();
+        };
+        let summary = LibFormatSummary {
+            num_concordant_consistent: self.num_frags_with_concordant_consistent_mappings,
+            num_inconsistent_or_orphan: self.num_frags_with_inconsistent_or_orphan_mappings,
+            strand_mapping_bias: self.strand_mapping_bias,
+        };
+        summary.diagnostics(exp, self.compatible_fragment_ratio)
+    }
+
+    /// Log [`Self::diagnostics`] as warnings; the writers also merge the same
+    /// diagnostics into `meta_info.json`, so the log and the report agree.
+    pub fn log_warnings(&self) {
+        for d in self.diagnostics() {
+            tracing::warn!("{}", d.message);
         }
     }
 }

--- a/crates/salmon-quant/src/output.rs
+++ b/crates/salmon-quant/src/output.rs
@@ -44,8 +44,16 @@ pub fn write_outputs(opts: &QuantOptions, res: &QuantResult) -> Result<()> {
         write_quant_sf(&dir.join("quant.sf"), res, opts.sig_digits as usize)?;
     }
     write_cmd_info(&dir.join("cmd_info.json"), opts)?;
-    write_lib_counts(&dir.join("lib_format_counts.json"), opts, res)?;
-    write_meta_info(&dir.join("aux_info").join("meta_info.json"), opts, res)?;
+    // The library-format warnings are structured diagnostics: written into
+    // `meta_info.json`'s `diagnostics` alongside the run's own, so a pipeline
+    // that only keeps the output directory sees them (#1140).
+    let lib_diags = write_lib_counts(&dir.join("lib_format_counts.json"), opts, res)?;
+    write_meta_info(
+        &dir.join("aux_info").join("meta_info.json"),
+        opts,
+        res,
+        &lib_diags,
+    )?;
     write_ambig_info(&dir.join("aux_info").join("ambig_info.tsv"), res)?;
     std::fs::create_dir_all(dir.join("libParams")).context("creating libParams")?;
     salmon_model::dumps::write_flen_dist(
@@ -257,7 +265,11 @@ fn write_cmd_info(path: &Path, opts: &QuantOptions) -> Result<()> {
 /// when a mapping rate looks wrong. The struct, its C++-matching field
 /// semantics, and its `num_incompatible_fragments` extension (#1130) live in
 /// [`salmon_core::LibFormatCountsFile`], shared with the alignment/RAD writer.
-fn write_lib_counts(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Result<()> {
+fn write_lib_counts(
+    path: &Path,
+    opts: &QuantOptions,
+    res: &QuantResult,
+) -> Result<Vec<crate::Diagnostic>> {
     let mut read_files = paths_to_strings(&opts.mates1);
     read_files.extend(paths_to_strings(&opts.mates2));
     read_files.extend(paths_to_strings(&opts.unmated));
@@ -270,7 +282,8 @@ fn write_lib_counts(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Resu
         &res.lib_format_counts,
     );
     counts.log_warnings();
-    write_json(path, &counts)
+    write_json(path, &counts)?;
+    Ok(counts.diagnostics())
 }
 
 /// `aux_info/meta_info.json`: everything a downstream tool or a human needs to
@@ -355,7 +368,12 @@ struct MetaInfo {
     end_time: String,
 }
 
-fn write_meta_info(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Result<()> {
+fn write_meta_info(
+    path: &Path,
+    opts: &QuantOptions,
+    res: &QuantResult,
+    lib_diags: &[crate::Diagnostic],
+) -> Result<()> {
     // Mapping the reads answers nearly everything directly; what it cannot
     // answer comes from the index, which may predate recording it.
     let mut missing_meta_info_fields = Vec::new();
@@ -446,7 +464,11 @@ fn write_meta_info(path: &Path, opts: &QuantOptions, res: &QuantResult) -> Resul
         inference_path: if opts.skip_quant { "none" } else { "online" },
         total_time_seconds: res.total_seconds,
         peak_rss_kb: res.peak_rss_kb,
-        diagnostics: res.diagnostics.clone(),
+        diagnostics: {
+            let mut d = res.diagnostics.clone();
+            d.extend(lib_diags.iter().cloned());
+            d
+        },
         call: "quant".to_string(),
         start_time: res.start_time.clone(),
         end_time: crate::asctime_now(),

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -378,6 +378,23 @@ fn stranded_lib_format_counts_report_incompatible_fragments() {
         0.0,
         "ISR run: {isr}"
     );
+    // The >5%-incompatible concern is machine-readable too: it lands in
+    // meta_info.json's diagnostics, not only in the log (#1140).
+    let meta: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out_isr.join("aux_info").join("meta_info.json")).unwrap(),
+    )
+    .unwrap();
+    let codes: Vec<&str> = meta["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["code"].as_str().unwrap())
+        .collect();
+    assert!(
+        codes.contains(&"high_incompatible_fraction"),
+        "expected high_incompatible_fraction in diagnostics, got {codes:?}"
+    );
+
     // …and the matching run shows the complementary picture.
     assert_eq!(isf["expected_format"].as_str().unwrap(), "ISF");
     assert!(

--- a/docs/release-notes-2.6.0.md
+++ b/docs/release-notes-2.6.0.md
@@ -1,0 +1,104 @@
+# salmon 2.6.0
+
+The release that makes **deterministic quantification the default**. A plain
+`salmon quant` now maps once to an intermediate RAD and quantifies from it,
+producing `quant.sf` files that are **byte-identical across runs and thread
+counts** — in every input mode: selective alignment, sketch, and alignment
+(`-a`). **No index rebuild is required.**
+
+The decision is evidence-backed rather than aspirational (#1140):
+
+- **Speed**: deterministic is as fast or faster in every measured cell — on 10M
+  real read pairs, sketch is 13% faster wall / 20% less CPU at `-p 16` and 11%
+  faster at `-p 4`; selective alignment ties at `-p 16` and is ~7% faster at
+  `-p 4` — *including* the cost of writing and re-reading the intermediate.
+  Independently replicated on a hostile high-multimapping synthetic fixture.
+- **Accuracy**: statistically indistinguishable from the online path against
+  ground truth (fourth-decimal differences, direction inconsistent, across two
+  simulated samples and two multimapping regimes).
+- **Reproducibility**: `quant.sf` md5-identical at `-p 1/4/16`; the online path
+  produces a different file at every thread count.
+
+## The deprecation path
+
+- `--deterministic` is **accepted as a no-op** (it is in scripts and CI configs
+  already) and will remain so through at least 2.7.
+- `--online` selects the pre-2.6 one-pass path,
+  **deprecated** with removal planned for 2.7.0. It announces its deprecation
+  when used; `--online --deterministic` is an error rather than a guess.
+- Online-only knobs — `--forgettingFactor`, `--numAuxModelSamples`,
+  `--numPreAuxModelSamples` — **warn and are ignored** when passed without
+  `--online`, instead of being silently inert. Under `--online -a`,
+  `--noLengthCorrection`/`--noFragLengthDist` likewise warn (the online
+  alignment path never supported them; the default path honours them).
+- `aux_info/meta_info.json` records which path ran in a new **`inference_path`**
+  field (`deterministic` / `online` / `none` for a mapping-only pass), so the
+  transition is auditable from existing output.
+
+## What changes in behavior (beyond the flip itself)
+
+- **`--skipQuant`** now stops after the mapping pass and keeps the RAD as the
+  run's output (previously, combined with `--deterministic`, it was silently
+  ignored and a full `quant.sf` was written). With `--dumpEq` it warns that no
+  classes exist to dump and points at `--rad --dumpEq` on the kept RAD.
+- **`-l A` accounting**: the deterministic path detects the library type from
+  the *whole run* and filters afterward, so `num_compatible_fragments` covers
+  every judged fragment; the online path never counted the ~50k-fragment
+  detection prefix. `compatible_fragment_ratio` is unchanged in meaning; the
+  counts it is built from are more complete. Threshold-based QC on these fields
+  should expect slightly higher absolute counts.
+- **Alignment mode scores by the BAM `AS` tag by default** (measured at least
+  as accurate as the error model at half the wall time); `--errorModel -t`
+  opts into the order-independent counting error model. A BAM whose `AS` tags
+  are missing, partial, or constant now draws a warning naming the way out —
+  recorded in `meta_info.json`'s `diagnostics` as `bam_score_tags_unusable`,
+  not just the log. The *online* error model exists only behind `--online -a`
+  and leaves with it.
+
+## Disk behavior of the intermediate
+
+The intermediate RAD is lz4-compressed (~110 MB per 1M read pairs on GENCODE
+v49; grows with the multimapping rate) and deleted on success. New in this
+release cycle:
+
+- **`--radScratchDir <dir>`** places it on node-local or memory-backed storage
+  (e.g. `/dev/shm`), pid-suffixed so concurrent runs can share a scratch
+  volume. A `--skipQuant` deliverable always goes to the output directory.
+- A **startup preflight** warns when the target volume has less free space than
+  the total compressed input, and the writer **checks free space during the
+  pass**, so a filling disk fails in seconds with actionable advice
+  (`--radScratchDir`, `--radCompress zstd` for ~30% more shrink at ~11% wall)
+  instead of at the end of mapping. On failure, salmon-owned intermediates
+  (including `.partial-*` files) are cleaned up; explicit `--writeRad` paths
+  are never touched.
+
+## Accounting and correctness fixes in this cycle
+
+- **`lib_format_counts.json` restored to C++ semantics in every mode** (#1131,
+  #1136/#1137, #1138): measured `num_compatible_fragments` /
+  `num_incompatible_fragments` with the ratio over judged fragments; the
+  per-observed-format histogram (`ISF`, `ISR`, …); format-agreement-based
+  concordant/inconsistent counts; a measured `strand_mapping_bias` with the
+  classic warnings. Sketch mode now applies the strand-compatibility filter
+  (#1136) and `-l A` works in every path, including online alignment mode
+  (which detects from the reported alignments — with a warning that an
+  upstream orientation filter cannot be recovered from).
+- **Flags that were accepted and silently dropped under `--deterministic` now
+  work**: `--biasSpeedSamp`, `--noBiasLengthThreshold`, `--initUniform`
+  (forwarded; note that every reads-mode path already starts the optimizer
+  uniformly, so it toggles behavior only in `--online -a`),
+  `--noLengthCorrection` and `--noFragLengthDist` (newly implemented in the
+  RAD path — tagged-end protocols in particular), and `--dumpEq` /
+  `--dumpEqWeights` (previously wrote a well-formed file declaring **zero**
+  classes; now dumps the classes the EM consumed, in every RAD-based mode).
+- **`total_time_seconds` in `meta_info.json` spans the whole run** (it
+  previously covered only the requant pass — reporting ~0.4s for a run whose
+  mapping took minutes).
+- The deterministic mapping pass has a **live progress spinner**, like the
+  one-pass path.
+
+## Also
+
+- The divan-based alignment-kernel benchmark harness (#1128).
+- `master`→`develop` housekeeping; `postponed` label for parked work
+  (#1041, #1123, #1132, #1129 record their dispositions).

--- a/website/src/content/docs/guides/rad-and-determinism.mdx
+++ b/website/src/content/docs/guides/rad-and-determinism.mdx
@@ -105,7 +105,7 @@ piscem map-bulk -i piscem_index -1 r1.fq.gz -2 r2.fq.gz -t 16 -o pi
 salmon quant --rad pi.rad -l A -p 16 -o out_quant
 ```
 
-## Deterministic quantification (`--deterministic`)
+## Deterministic quantification (the default)
 
 RAD-mode quantification is deterministic: repeated runs at `-p 1` are
 **byte-identical**, and across thread counts every value agrees to at least
@@ -115,17 +115,25 @@ count can perturb is the floating-point association order inside the EM's
 parallel reduction; measured across 2–32 threads on a deliberately hard input,
 the largest deviation was 4.5×10⁻¹³. Everything upstream of the EM is
 integer-accumulated and exactly thread-count independent — see below.)
-`--deterministic` brings the same guarantee to FASTQ input directly:
+Since **2.6.0 this is how salmon quantifies by default** — a plain run brings
+the same guarantee to FASTQ input directly:
 
 ```sh
-salmon quant -i salmon_index -l A -1 r1.fq.gz -2 r2.fq.gz -p 16 \
-  --deterministic -o out
+salmon quant -i salmon_index -l A -1 r1.fq.gz -2 r2.fq.gz -p 16 -o out
 ```
 
 It maps the reads once to an intermediate RAD, then quantifies from it with a
 fixed fragment-length distribution — no second mapping pass. The intermediate RAD
 is written under the output directory and removed on success unless you pass
 `--keepRad` (or `--writeRad <PATH>` to choose its location and keep it).
+`--deterministic` is still accepted as a no-op, and `meta_info.json` records
+which path ran in `inference_path`.
+
+The pre-2.6 online one-pass path remains available for one release cycle behind
+`--online` (**deprecated**, removal planned for 2.7.0). Its results depend on
+the thread count, and the online-only knobs — `--forgettingFactor`,
+`--numAuxModelSamples`, `--numPreAuxModelSamples` — warn and are ignored unless
+`--online` is passed.
 
 The determinism comes from making the computation itself order-independent rather
 than sorting records:

--- a/website/src/content/docs/reference/cli.mdx
+++ b/website/src/content/docs/reference/cli.mdx
@@ -131,7 +131,8 @@ See the [RAD I/O & deterministic quantification](../../guides/rad-and-determinis
 | --- | --- |
 | `--writeRad <FILE>` | Write per-fragment mappings to a RAD file (piscem `map-bulk`-compatible). Quantification still runs unless `--skipQuant`. |
 | `--skipQuant` | Skip quantification (EM, Gibbs/bootstrap, `quant.sf`); still map, build equivalence classes, detect library type, write metadata. |
-| `--deterministic` | Reproducible reads-mode quantification: map once to an intermediate RAD, then quantify from it with a fixed fragment-length distribution. Byte-identical across runs and thread counts. |
+| `--deterministic` | **The default since 2.6.0** (accepted as a no-op): map once to an intermediate RAD, then quantify from it with a fixed fragment-length distribution. Byte-identical across runs and thread counts. |
+| `--online` | Quantify with the pre-2.6 online one-pass path instead. **Deprecated** (removal planned for 2.7.0): results depend on the thread count. Online-only knobs (`--forgettingFactor`, `--numAuxModelSamples`, `--numPreAuxModelSamples`) warn and are ignored without it. |
 | `--keepRad` | Keep the `--deterministic` intermediate RAD (deleted by default). |
 | `--radScratchDir <DIR>` | Directory for the `--deterministic` intermediate RAD (default: the output directory). Point at node-local or memory-backed storage (e.g. `/dev/shm`) when the output volume is slow, networked, or space-constrained. Ignored with an explicit `--writeRad`. |
 | `--radCompress <CODEC>` | RAD chunk compression for `--writeRad` / `--deterministic`: `lz4` (default), `zstd` (smaller), or `none`. |

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -136,8 +136,14 @@ scraping the log (the same messages are also written to
 | `very_low_mapping_rate` | warning | < 10% of fragments mapped |
 | `low_mapping_rate` | warning | < 30% of fragments mapped |
 | `library_type_mismatch` | warning | an explicit `-l` disagrees with the observed library format (reads / `--rad`) |
+| `no_concordant_mappings` | warning | no fragment's observed format agreed with an unstranded expected type — for a paired library, check the reads are properly paired |
+| `strand_bias_unstranded` | warning | strand bias > 1% under an unstranded library type (see `strand_mapping_bias` in `lib_format_counts.json`) |
+| `high_incompatible_fraction` | warning | more than 5% of judged fragments were incompatible with the expected library type |
+| `bam_score_tags_unusable` | warning | deterministic alignment mode scored by `AS`, but the BAM's `AS` tags were missing, partial, or constant — placements were weighted uniformly; consider `--errorModel -t` |
 
-An empty array means no red flags were detected.
+An empty array means no red flags were detected. The library-format codes are
+emitted by every mode that writes `lib_format_counts.json`, from the same
+conditions the log warnings use, so the log and the report cannot disagree.
 
 ### `aux_info/ambig_info.tsv` — per-transcript read partition (TSV)
 

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -440,6 +440,27 @@ formats cannot drift apart.
 Both options apply to the read-mapping path only. In alignment mode (`-a`) and
 RAD-input mode (`--rad`) they are accepted but ignored, with a warning.
 
+### The pseudoalignment output contract
+
+This output is a **diagnostic view of salmon's mappings**, not a
+general-purpose aligner output, and several fields are deliberately nominal —
+for brevity, and because the mapping path computes scores without base-level
+alignments (score-only dynamic programming, no traceback) and does not compute
+them just because output was requested:
+
+- **`CIGAR`** is synthesized from the read length (`<readLen>M`, plus a clip at
+  a transcript end). It records *where* the mapping is, not a base-level
+  alignment; indels are not represented, and no `NM`/`MD` accompany it.
+- **`AS`** is the score salmon's mapper assigned to the placement — the same
+  number quantification used — not a score recomputed from the record's own
+  CIGAR. It is comparable across records within one run, not across aligners.
+- **`MAPQ`** reflects only the placement count, not alignment confidence — see
+  below.
+
+Treat the records as positions + pairing + the quantifier's scores. If you need
+true base-level alignments, run a general-purpose aligner; a possible opt-in
+"realized alignment" output mode is under discussion (see #1141).
+
 ### `MAPQ`
 
 SAM's `MAPQ` is a phred-scaled probability that a placement is wrong, and salmon


### PR DESCRIPTION
The flip proposed, measured, reviewed, and prepared in #1140. A bare `salmon quant` now takes the deterministic two-phase path in **every input mode** — selective alignment, sketch, and `-a` — producing byte-identical `quant.sf` at any thread count. The evidence (both our 10M-pair real-data measurements and @BenjaminDEMAILLE's independent replication on a hostile high-multimapping fixture) is summarized in the issue and in the drafted release notes.

## What this PR does

- **Default dispatch flip** in reads mode and alignment mode; genome projection (inherently RAD-based) warns that `--online` has no meaning there.
- **`--online`** selects the pre-2.6 one-pass path for one deprecation cycle (removal planned for 2.7.0), announcing its deprecation when used. `--online --deterministic` is a clap-level conflict error. (No `--onePass` alias — nothing exists to be compatible with, and `--online` is the better name.)
- **`--deterministic` stays accepted as a no-op** — it's in scripts and CI configs already.
- **No silent inertness**: the online-only knobs (`--forgettingFactor`, `--numAuxModelSamples`, `--numPreAuxModelSamples`) are now `Option`-typed so "explicitly passed" is detectable, and warn *by name* when passed without `--online`. `--noLengthCorrection`/`--noFragLengthDist` warn under `--online -a` (the one path that never supported them) instead of doing nothing.
- **Progress spinner for the deterministic mapping pass**, handed into the driver so it stops at the phase-1/phase-2 boundary instead of spinning frozen through the requant.
- **`bam_score_tags_unusable` reaches `meta_info.json`'s `diagnostics`**: new `AlignQuantOptions::extra_diagnostics` handoff carries the phase-1 AS verdict (from #1145) into the phase-2-written metadata, so pipelines that only keep the output directory see it.
- **Docs** (CLI reference + RAD/determinism guide) reframed around the new default; **`docs/release-notes-2.6.0.md`** drafted, covering the flip, the deprecation schedule, the behavior deltas (`--skipQuant` semantics, `-l A` accounting, AS-scored `-a`), the disk story, and the full accounting/correctness cycle behind it.

## Tests

A binary-level e2e pins the contract: bare run → `inference_path: deterministic` with the intermediate cleaned up; `--online` → `online` + deprecation announcement; `--deterministic` accepted; `--online --deterministic` errors; an inert knob warns by name under the default and draws no inertness complaint under `--online`. Full workspace suite: **303 passed / 0 failed**; clippy/fmt clean.

## Sequencing

Lands **after** #1148 and #1147 (expected trivial conflicts in the `run_quant` wiring blocks; I'll rebase as they merge). Remaining from #1140 after this: the two pre-flip validation runs called for on the issue — the 26M-pair full evaluation set and a slow-disk machine — which should gate the actual 2.6.0 tag rather than this merge.

Refs #1140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs