### PR TITLE
fix(quant): derive MAPQ from the placement count instead of a constant 1

### DIFF
--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -165,6 +165,31 @@ pub fn complement(base: u8) -> u8 {
     }
 }
 
+/// The `MAPQ` to report for a fragment with `nh` placements.
+///
+/// SAM's `MAPQ` is a phred-scaled probability that the placement is wrong, and
+/// salmon does not compute one: its whole design is to keep every plausible
+/// placement and let the EM apportion them. What it does know is *how many*
+/// placements a fragment has, which is the same thing STAR reports, so this uses
+/// STAR's mapping: a uniquely placed fragment gets 255 and the value falls off
+/// as the fragment becomes more ambiguous. Matching STAR matters because the
+/// RNA-seq tools downstream of a salmon BAM are the ones already tuned to it: to
+/// all of them `-q 255` means "uniquely placed".
+///
+/// The previous hardcoded `1` made every record look ambiguous, so any such
+/// filter discarded the whole file. It is the one placeholder in this output
+/// that costs nothing to replace: the count is already in hand when the records
+/// are written, so no alignment work is implied (COMBINE-lab/salmon#1140,
+/// #1141).
+pub fn mapping_quality(nh: usize) -> u8 {
+    match nh {
+        0 | 1 => 255,
+        2 => 3,
+        3..=4 => 1,
+        _ => 0,
+    }
+}
+
 /// The CIGAR and clamped position for a read placed at `pos` on a transcript of
 /// length `txp_len`.
 ///
@@ -245,6 +270,7 @@ pub fn emit_fragment_records(
     let name1 = read_name(r1_id);
     let (name2, r2_seq) = r2.map_or((name1, &[][..]), |(id, seq)| (read_name(id), seq));
     let nh = maps.len();
+    let mapq = mapping_quality(nh);
 
     for (index, mapping) in maps.iter().enumerate() {
         // The first placement is primary; the rest are marked secondary so a
@@ -297,7 +323,7 @@ pub fn emit_fragment_records(
                     flags: f1,
                     reference_id: tid,
                     position: p1,
-                    mapping_quality: 1,
+                    mapping_quality: mapq,
                     cigar: c1,
                     mate_reference_id: Some(tid),
                     mate_position: Some(p2),
@@ -314,7 +340,7 @@ pub fn emit_fragment_records(
                     flags: f2,
                     reference_id: tid,
                     position: p2,
-                    mapping_quality: 1,
+                    mapping_quality: mapq,
                     cigar: c2,
                     mate_reference_id: Some(tid),
                     mate_position: Some(p1),
@@ -335,7 +361,7 @@ pub fn emit_fragment_records(
                     flags: secondary | if mapping.is_fw { 0 } else { IS_RC },
                     reference_id: tid,
                     position,
-                    mapping_quality: 1,
+                    mapping_quality: mapq,
                     cigar,
                     mate_reference_id: None,
                     mate_position: None,
@@ -382,7 +408,7 @@ pub fn emit_fragment_records(
                         | if forward { 0 } else { IS_RC },
                     reference_id: tid,
                     position,
-                    mapping_quality: 1,
+                    mapping_quality: mapq,
                     cigar,
                     mate_reference_id: None,
                     mate_position: None,
@@ -398,4 +424,20 @@ pub fn emit_fragment_records(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// MAPQ has to distinguish a uniquely placed fragment from an ambiguous one.
+    #[test]
+    fn mapping_quality_follows_the_star_convention() {
+        assert_eq!(mapping_quality(1), 255);
+        assert_eq!(mapping_quality(2), 3);
+        assert_eq!(mapping_quality(3), 1);
+        assert_eq!(mapping_quality(4), 1);
+        assert_eq!(mapping_quality(5), 0);
+        assert_eq!(mapping_quality(0), 255);
+    }
 }

--- a/docs/cli-flag-status.md
+++ b/docs/cli-flag-status.md
@@ -51,7 +51,7 @@ misbehaves.
 
 | Flag | Status | Notes |
 |------|--------|-------|
-| `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. |
+| `-l/--libType`, `-o/--output`, `-p/--threads`, `-z/--writeMappings`, `--writeBam` | ✅ | `--writeSam` is a visible alias for `--writeMappings`. `--writeMappings`/`--writeSam` and `--writeBam` are mutually exclusive, and are warned-and-ignored in `-a`/`--rad` modes. Records for a fragment are contiguous; no other order is imposed. `MAPQ` is derived from the placement count on STAR's scale (255 unique, 3, 1, 0); other unwritten fields keep salmon's pseudobam conventions. |
 | `--bamCompressThreads` | ✅ | BGZF compression pool for `--writeBam`; defaults to ~1 worker per 3 mapping threads (max 8), balancing measured deflate throughput against record production. Rust-port feature; not in this salmon build. |
 | `--useEM` | ✅ | VBEM is the default; `--useEM` selects plain EM. |
 | `--meta` | ✅ | Metagenomic preset: plain EM, no range-factorized eq-classes, uniform init (the Rust EM already inits uniformly). Overrides `--useEM`/`--rangeFactorizationBins`. |

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -440,6 +440,24 @@ formats cannot drift apart.
 Both options apply to the read-mapping path only. In alignment mode (`-a`) and
 RAD-input mode (`--rad`) they are accepted but ignored, with a warning.
 
+### `MAPQ`
+
+SAM's `MAPQ` is a phred-scaled probability that a placement is wrong, and salmon
+does not compute one: its design is to keep every plausible placement and let the
+EM apportion them. What it does know is how many placements a fragment has, which
+is what STAR reports, so `MAPQ` follows STAR's mapping:
+
+| placements (`NH`) | `MAPQ` |
+|---|---|
+| 1 | 255 |
+| 2 | 3 |
+| 3 or 4 | 1 |
+| 5 or more | 0 |
+
+Matching STAR matters because the tools downstream of a salmon BAM are tuned to
+it: `samtools view -q 255` means "uniquely placed" to all of them. Before this,
+every record carried a constant `1`, so that filter discarded the entire file.
+
 ### Compression threads
 
 `--writeBam` compresses BGZF blocks on a small pool of threads that run


### PR DESCRIPTION
The MAPQ half of #1141, as its own PR per your review, fully decoupled from realization: no re-alignment, no `ambiguous.bin`, no new index artifact. The count of placements is already in hand when the records are written, so this is arithmetic on a value the writer holds.

## What changes

Every record carried `MAPQ 1`, which says "probably wrong" about placements salmon chose to keep. `samtools view -q 255`, the standard "uniquely placed" filter and the one STAR output trains people to use, therefore discarded the whole file.

salmon has no phred-scaled probability to offer, and this does not invent one. It reports what salmon does know, on the scale STAR already established:

| placements (`NH`) | `MAPQ` |
|---|---|
| 1 | 255 |
| 2 | 3 |
| 3 or 4 | 1 |
| 5 or more | 0 |

On a 300k-fragment fixture (890098 records):

```
before   890098 records at MAPQ 1;      -q 255 selects 0
after    433027 at 255, 199088 at 3, 168502 at 1, 89481 at 0;   -q 255 selects 433027
```

## Docs

The output-formats page gains a short `MAPQ` section stating the scale and, more importantly, that a salmon `MAPQ` counts placements rather than estimating a probability. That belongs in the pseudobam contract paragraph you are landing for 2.6.0; treat this as a first draft of that one field's entry and fold it in if it fits better there.

## Scope

Unit test for the scale, including the boundary at four placements and the `nh == 0` case a record built without a placement would hit. Full workspace suite green, clippy and fmt clean. Nothing else from #1141 is here.

I have taken the rest of your review as written: #1141 and #1142 wait for the opt-in design discussion after 2.6.0, and the scoring-path question goes to its own issue with the fixtures, which I am putting together now. I do want to answer one substantive point there rather than here, since it changes what the issue should measure: the anchor pathologies were found by the realization DP, but the reason I think they are worth chasing is that the *positions* they disagree with come from the same chaining that feeds scoring. Whether that disagreement reaches the scores is exactly the open question, and I would rather measure it than assert it.
