### PR TITLE
Restore the output contract on every RAD-based path (pre-2.6.0 audit, batch A)

### DIFF
--- a/crates/salmon-align/src/genome_project.rs
+++ b/crates/salmon-align/src/genome_project.rs
@@ -220,6 +220,17 @@ pub fn project_genome_bam_to_rad(
         let em = salmon_infer::optimize(&collapsed, num_refs, &ro, Some(&eff_lengths));
         writer.set_initial_abundances(&em.alphas);
     }
+    // Bake the pass counters so the requant's meta_info.json reports this
+    // run's true num_processed / mapping rate instead of a placeholder
+    // (#1140). Projection has no dovetail/score-filter/decoy notions; those
+    // stay 0.
+    writer.set_map_counters(salmon_rad::MapCounters {
+        num_processed,
+        num_dovetail: 0,
+        num_filtered_vm: 0,
+        num_below_threshold_vm: 0,
+        num_decoy_fragments: 0,
+    });
     writer.finalize()?;
 
     Ok(ProjectionArtifacts {

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -198,6 +198,15 @@ pub struct AlignQuantOptions {
     /// start time (asctime) of that earlier phase; when set, reported as the
     /// run's `start_time` instead of this pass's own
     pub external_start_time: Option<String>,
+    /// keep the `cmd_info.json` an earlier phase already wrote instead of
+    /// overwriting it: reads-mode `--deterministic` phase 1 records the real
+    /// invocation (index, read files, threads); phase 2's own record would
+    /// replace it with a RAD-centric one and lose all of that (#1140)
+    pub preserve_cmd_info: bool,
+    /// the read files behind this RAD, when the driver knows them (reads-mode
+    /// `--deterministic`), for `lib_format_counts.json`'s `read_files` — which
+    /// otherwise reports `[]` because a RAD does not name its reads (#1140)
+    pub read_files: Vec<String>,
     /// `--dumpEq`: write `aux_info/eq_classes.txt.gz`, the equivalence classes
     /// the EM consumed, collapsed by transcript set.
     pub dump_eq: bool,
@@ -283,6 +292,8 @@ impl AlignQuantOptions {
             init_uniform: false,
             prior_seconds: 0.0,
             external_start_time: None,
+            preserve_cmd_info: false,
+            read_files: Vec::new(),
             dump_eq: false,
             dump_eq_weights: false,
             no_length_correction: false,
@@ -2545,13 +2556,34 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
     let dir = &opts.output_dir;
     std::fs::create_dir_all(dir.join("aux_info")).context("creating output dirs")?;
 
+    // Which references get output rows: everything except the RAD-recorded
+    // decoy block. A reads-mode RAD's header must carry every reference —
+    // records index into it — so the writer, not the header, is where decoys
+    // are excluded, exactly as reads mode excludes them (#1140). A RAD without
+    // the recorded boundary (piscem, BAM-derived, or written before the
+    // boundary tags existed) has no decoys to exclude and emits every row, as
+    // before.
+    let (first_decoy, num_decoys) = res
+        .provenance
+        .index
+        .as_ref()
+        .map(|ix| {
+            (
+                ix.first_decoy_index.map(|v| v as usize),
+                ix.num_decoys.unwrap_or(0) as usize,
+            )
+        })
+        .unwrap_or((None, 0));
+    let rows: Vec<usize> =
+        salmon_core::quant_row_indices(res.names.len(), first_decoy, num_decoys).collect();
+
     // quant.sf (EffectiveLength + NumReads at --sigDigits decimals; TPM at 6).
     // Skipped under --skipQuant (no abundances), like salmon.
     if !opts.skip_quant {
         let sd = opts.sig_digits as usize;
         let mut w = std::io::BufWriter::new(std::fs::File::create(dir.join("quant.sf"))?);
         writeln!(w, "Name\tLength\tEffectiveLength\tTPM\tNumReads")?;
-        for i in 0..res.names.len() {
+        for &i in &rows {
             writeln!(
                 w,
                 "{}\t{}\t{:.*}\t{:.6}\t{:.*}",
@@ -2698,7 +2730,17 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
     }
     let meta = MetaInfo {
         salmon_version: SALMON_VERSION.to_string(),
-        samp_type: "none".to_string(),
+        // What kind of posterior samples were actually produced, so tximport
+        // (which keys off this together with num_bootstraps) loads them
+        // (#1140; previously hardcoded "none").
+        samp_type: if res.bootstraps.is_empty() {
+            "none"
+        } else if opts.num_bootstraps > 0 {
+            "bootstrap"
+        } else {
+            "gibbs"
+        }
+        .to_string(),
         opt_type: if opts.em.use_vbem { "vb" } else { "em" }.to_string(),
         quant_errors: vec![],
         num_libraries: 1,
@@ -2736,10 +2778,10 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         index_name_hash512: index_prov.name_hash512,
         index_decoy_seq_hash: index_prov.decoy_seq_hash,
         index_decoy_name_hash: index_prov.decoy_name_hash,
-        num_valid_targets: res.names.len(),
+        num_valid_targets: rows.len(),
         num_decoy_targets: 0,
         num_eq_classes: res.num_eq_classes,
-        serialized_eq_classes: false,
+        serialized_eq_classes: opts.dump_eq || opts.dump_eq_weights,
         eq_class_properties,
         length_classes: res.length_classes.clone(),
         num_processed: res.num_processed,
@@ -2749,7 +2791,10 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         num_alignments_below_threshold_for_mapped_fragments_vm: counters
             .map_or(0, |c| c.num_below_threshold_vm),
         percent_mapped: pct,
-        num_decoy_fragments: 0,
+        // From the RAD-baked mapping counters, like its three siblings above;
+        // 0 when the producing pass predates the counter (#1140; previously
+        // hardcoded 0 while the loaded value sat unused).
+        num_decoy_fragments: res.provenance.counters.map_or(0, |c| c.num_decoy_fragments),
         inference_truncated_mass: res.inference_truncated_mass,
         num_bootstraps: res.bootstraps.len() as u32,
         num_orphan: res.num_orphan,
@@ -2800,9 +2845,9 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
                 .unwrap_or_else(|_| opts.lib_type.clone())
         };
         let counts = salmon_core::LibFormatCountsFile::new(
-            // The BAM / RAD is the input; the reads that produced it are not
-            // known here.
-            vec![],
+            // The reads behind the RAD when the driver knows them (reads-mode
+            // --deterministic); a standalone --rad/-a input has none to name.
+            opts.read_files.clone(),
             expected,
             res.num_mapped,
             res.num_compatible_fragments,
@@ -2829,11 +2874,11 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
 
         let f = std::fs::File::create(bdir.join("names.tsv.gz"))?;
         let mut enc = GzEncoder::new(f, Compression::new(6));
-        for (i, name) in res.names.iter().enumerate() {
-            if i > 0 {
+        for (j, &i) in rows.iter().enumerate() {
+            if j > 0 {
                 enc.write_all(b"\t")?;
             }
-            enc.write_all(name.as_bytes())?;
+            enc.write_all(res.names[i].as_bytes())?;
         }
         enc.write_all(b"\n")?;
         enc.finish()?;
@@ -2841,8 +2886,10 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         let f = std::fs::File::create(bdir.join("bootstraps.gz"))?;
         let mut enc = GzEncoder::new(f, Compression::new(6));
         for sample in &res.bootstraps {
-            for v in sample {
-                enc.write_all(&v.to_le_bytes())?;
+            // Restricted to the same rows as quant.sf so the two stay aligned
+            // positionally, which is what tximport assumes.
+            for &i in &rows {
+                enc.write_all(&sample[i].to_le_bytes())?;
             }
         }
         enc.finish()?;
@@ -2881,14 +2928,15 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
     std::fs::write(dir.join("logs").join("salmon_quant.log"), log)
         .context("writing salmon_quant.log")?;
 
-    // aux_info/ambig_info.tsv
+    // aux_info/ambig_info.tsv — same row set as quant.sf (decoys excluded), so
+    // the two stay row-aligned as the format spec promises.
     {
         let (uniq, ambig) = &res.ambig;
         let mut w = std::io::BufWriter::new(std::fs::File::create(
             dir.join("aux_info").join("ambig_info.tsv"),
         )?);
         writeln!(w, "UniqueCount\tAmbigCount")?;
-        for i in 0..uniq.len() {
+        for &i in &rows {
             writeln!(w, "{}\t{}", uniq[i], ambig[i])?;
         }
         w.flush()?;
@@ -2918,10 +2966,14 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         output: opts.output_dir.display().to_string(),
         aux_dir: "aux_info".to_string(),
     };
-    std::fs::write(
-        dir.join("cmd_info.json"),
-        serde_json::to_string_pretty(&cmd)?,
-    )?;
+    // Phase 2 of a two-phase driver keeps phase 1's record of the real
+    // invocation rather than replacing it with a RAD-centric one (#1140).
+    if !opts.preserve_cmd_info {
+        std::fs::write(
+            dir.join("cmd_info.json"),
+            serde_json::to_string_pretty(&cmd)?,
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -959,6 +959,14 @@ fn load_provenance(file_tag_map: &TagMap) -> RadProvenance {
             Some(TagValue::U8(v)) => Some(*v == 1),
             _ => None,
         },
+        first_decoy_index: match file_tag_map.get(salmon_rad::FIRST_DECOY_INDEX_TAG) {
+            Some(TagValue::U64(v)) => Some(*v),
+            _ => None,
+        },
+        num_decoys: match file_tag_map.get(salmon_rad::NUM_DECOYS_TAG) {
+            Some(TagValue::U64(v)) => Some(*v),
+            _ => None,
+        },
     });
     // Split back into the lines they were joined from; an aligner's command line
     // may contain anything except a newline, so this round-trips.

--- a/crates/salmon-align/tests/output_contract.rs
+++ b/crates/salmon-align/tests/output_contract.rs
@@ -1,0 +1,199 @@
+//! The requant writer's output contract (#1140): decoy references stay out of
+//! `quant.sf` and the files positionally aligned with it, and `meta_info.json`
+//! reports what the run actually did (`samp_type`, `serialized_eq_classes`,
+//! `num_decoy_fragments`) instead of hardcoded placeholders.
+//!
+//! A reads-mode RAD's header must carry every reference — records index into
+//! it — so the *writer* is where decoys are excluded, exactly as reads mode
+//! excludes them. Before #1140's audit, every `quantify_rad` path (including
+//! the deterministic default) emitted decoy rows the docs promise are absent.
+
+use std::path::Path;
+
+use salmon_align::{quantify_rad, AlignQuantOptions};
+use salmon_rad::{frag_map_type, FragmentChunkBuf, RadHit, RadOutputWriter, RadProfile};
+
+/// A RAD whose reference table is `[t0, t1, dA]` with `dA` marked as the decoy
+/// block via the baked index provenance, plus baked mapping counters. Proper
+/// pairs land only on the real transcripts, as the mapper guarantees.
+fn write_decoy_rad(path: &Path) {
+    let prov = salmon_rad::WriterProvenance {
+        mapping_type: salmon_rad::MappingType::Mapping,
+        index: Some(salmon_rad::IndexProvenance {
+            seq_hash: "sh".into(),
+            name_hash: "nh".into(),
+            seq_hash512: String::new(),
+            name_hash512: String::new(),
+            decoy_seq_hash: "dsh".into(),
+            decoy_name_hash: "dnh".into(),
+            keep_duplicates: Some(false),
+            first_decoy_index: Some(2),
+            num_decoys: Some(1),
+        }),
+        source_programs: vec![],
+    };
+    let mut w = RadOutputWriter::create(
+        path,
+        &["t0", "t1", "dA"],
+        &[4000u32, 4000, 4000],
+        true,
+        RadProfile::Sketch,
+        1024,
+        salmon_rad::ChunkCodec::None,
+        &prov,
+    )
+    .unwrap();
+    let ctx: salmon_rad::SalmonBulkContext = *w.context();
+    let mut cb = FragmentChunkBuf::with_capacity_codec(4096, salmon_rad::ChunkCodec::None);
+    for (tid, n) in [(0u32, 30), (1u32, 20)] {
+        for _ in 0..n {
+            let hit = RadHit {
+                tid,
+                is_fw: true,
+                mate_fw: false,
+                pos: 0,
+                frag_len: 200,
+                score: 0,
+            };
+            let rec = salmon_rad::SalmonBulkRecord::new(frag_map_type::MAPPED_PAIR, vec![hit]);
+            cb.write(&rec, &ctx).unwrap();
+        }
+    }
+    w.append_chunk_bytes(&cb.take_bytes().unwrap()).unwrap();
+    w.set_map_counters(salmon_rad::MapCounters {
+        num_processed: 60,
+        num_dovetail: 0,
+        num_filtered_vm: 0,
+        num_below_threshold_vm: 0,
+        num_decoy_fragments: 7,
+    });
+    w.finalize().unwrap();
+}
+
+#[test]
+fn requant_outputs_honor_the_contract() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("decoy.rad");
+    write_decoy_rad(&rad);
+
+    let out = tmp.path().join("out");
+    let mut o = AlignQuantOptions::new(rad.clone(), out.clone());
+    o.lib_type = "IU".to_string();
+    o.fld_mean = 200.0;
+    o.fld_sd = 20.0;
+    o.num_bootstraps = 2;
+    o.dump_eq = true;
+    let res = quantify_rad(&o, &rad).expect("quantify_rad");
+    assert_eq!(res.num_mapped, 50);
+
+    // quant.sf: the decoy block is excluded, exactly as reads mode excludes it.
+    let sf = std::fs::read_to_string(out.join("quant.sf")).unwrap();
+    let names: Vec<&str> = sf
+        .lines()
+        .skip(1)
+        .map(|l| l.split('\t').next().unwrap())
+        .collect();
+    assert_eq!(names, ["t0", "t1"], "decoy dA must not be a quant.sf row");
+
+    // ambig_info.tsv stays row-aligned with quant.sf.
+    let ambig = std::fs::read_to_string(out.join("aux_info").join("ambig_info.tsv")).unwrap();
+    assert_eq!(
+        ambig.lines().count(),
+        1 + 2,
+        "header + one row per quant row"
+    );
+
+    // Bootstrap files carry the same row set, positionally aligned.
+    {
+        use std::io::Read as _;
+        let f = std::fs::File::open(out.join("aux_info").join("bootstrap").join("names.tsv.gz"))
+            .unwrap();
+        let mut txt = String::new();
+        flate2::read::GzDecoder::new(f)
+            .read_to_string(&mut txt)
+            .unwrap();
+        assert_eq!(txt.trim_end(), "t0\tt1");
+
+        let f = std::fs::File::open(out.join("aux_info").join("bootstrap").join("bootstraps.gz"))
+            .unwrap();
+        let mut bytes = Vec::new();
+        flate2::read::GzDecoder::new(f)
+            .read_to_end(&mut bytes)
+            .unwrap();
+        assert_eq!(
+            bytes.len(),
+            2 * 2 * 8,
+            "2 samples x 2 quant rows x 8 bytes; decoy columns would make it 2 x 3 x 8"
+        );
+    }
+
+    // meta_info.json reports what the run did, not placeholders.
+    let meta: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(meta["num_valid_targets"], 2);
+    assert_eq!(
+        meta["samp_type"], "bootstrap",
+        "bootstraps ran and were written; tximport keys off this"
+    );
+    assert_eq!(
+        meta["serialized_eq_classes"], true,
+        "the eq-class dump was requested and written"
+    );
+    assert_eq!(
+        meta["num_decoy_fragments"], 7,
+        "from the RAD-baked mapping counters, like its siblings"
+    );
+    assert_eq!(meta["num_processed"], 60);
+    assert!(out.join("aux_info").join("eq_classes.txt.gz").is_file());
+}
+
+/// A RAD without the decoy boundary (piscem, BAM-derived, or pre-boundary
+/// salmon) behaves exactly as before: every header reference is a row.
+#[test]
+fn rad_without_decoy_boundary_emits_every_reference() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("plain.rad");
+    let prov = salmon_rad::WriterProvenance {
+        mapping_type: salmon_rad::MappingType::Mapping,
+        index: None,
+        source_programs: vec![],
+    };
+    let w = RadOutputWriter::create(
+        &rad,
+        &["t0", "t1"],
+        &[4000u32, 4000],
+        true,
+        RadProfile::Sketch,
+        1024,
+        salmon_rad::ChunkCodec::None,
+        &prov,
+    )
+    .unwrap();
+    let ctx: salmon_rad::SalmonBulkContext = *w.context();
+    let mut cb = FragmentChunkBuf::with_capacity_codec(4096, salmon_rad::ChunkCodec::None);
+    for _ in 0..10 {
+        let hit = RadHit {
+            tid: 0,
+            is_fw: true,
+            mate_fw: false,
+            pos: 0,
+            frag_len: 200,
+            score: 0,
+        };
+        let rec = salmon_rad::SalmonBulkRecord::new(frag_map_type::MAPPED_PAIR, vec![hit]);
+        cb.write(&rec, &ctx).unwrap();
+    }
+    w.append_chunk_bytes(&cb.take_bytes().unwrap()).unwrap();
+    w.finalize().unwrap();
+
+    let out = tmp.path().join("out");
+    let mut o = AlignQuantOptions::new(rad.clone(), out.clone());
+    o.lib_type = "IU".to_string();
+    o.fld_mean = 200.0;
+    o.fld_sd = 20.0;
+    quantify_rad(&o, &rad).expect("quantify_rad");
+    let sf = std::fs::read_to_string(out.join("quant.sf")).unwrap();
+    assert_eq!(sf.lines().count(), 1 + 2);
+}

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -377,7 +377,14 @@ struct QuantArgs {
     )]
     index: Option<PathBuf>,
     /// Alignment-based mode: a BAM of reads aligned to the transcriptome.
-    #[arg(short = 'a', long = "alignments")]
+    /// Mutually exclusive with the read inputs (-1/-2/-r): quantifying a BAM
+    /// while silently dropping supplied FASTQs was the "wrong mode chosen
+    /// silently" failure the mode dispatch exists to prevent (#1140).
+    #[arg(
+        short = 'a',
+        long = "alignments",
+        conflicts_with_all = ["mates1", "mates2", "unmated"]
+    )]
     alignments: Option<PathBuf>,
     /// RAD-input mode: a RAD file of mappings (from `salmon quant --writeRad` or
     /// `piscem map-bulk`) to quantify directly, in parallel.
@@ -1399,6 +1406,17 @@ fn run_deterministic(
     }
     q.prior_seconds = run_start.elapsed().as_secs_f64();
     q.external_start_time = Some(map_res.start_time.clone());
+    // Phase 1 wrote the true invocation record and named the read files; keep
+    // both instead of letting the requant's RAD-centric view replace them
+    // (#1140).
+    q.preserve_cmd_info = true;
+    q.read_files = map_opts
+        .mates1
+        .iter()
+        .chain(map_opts.mates2.iter())
+        .chain(map_opts.unmated.iter())
+        .map(|p| p.display().to_string())
+        .collect();
     let res = match quantify_rad(&q, &rad_path) {
         Ok(r) => r,
         Err(e) => {
@@ -2403,6 +2421,27 @@ mod tests {
     /// Parse a `quant` command line and return just the two mapping-output paths.
     fn write_flags(extra: &[&str]) -> Result<(Option<PathBuf>, Option<PathBuf>), clap::Error> {
         quant_args(extra).map(|args| (args.write_mappings, args.write_bam))
+    }
+
+    /// `-a` with read inputs must be a parse error, not a silent choice of the
+    /// BAM: the pre-#1140 behavior quantified the alignments and dropped the
+    /// FASTQs without a word.
+    #[test]
+    fn alignments_conflict_with_read_inputs() {
+        for reads in [vec!["-1", "r1.fq", "-2", "r2.fq"], vec!["-r", "r.fq"]] {
+            let mut argv = vec!["salmon", "quant", "-l", "A", "-o", "out", "-a", "aln.bam"];
+            argv.extend(reads.iter());
+            let err = match Cli::try_parse_from(&argv) {
+                Err(e) => e,
+                Ok(_) => panic!("-a plus reads must not parse: {argv:?}"),
+            };
+            assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
+        // ...and -a alone still parses.
+        assert!(
+            Cli::try_parse_from(["salmon", "quant", "-l", "A", "-o", "out", "-a", "aln.bam"])
+                .is_ok()
+        );
     }
 
     /// Parse a minimal `salmon quant` invocation plus `extra`.

--- a/crates/salmon-cli/tests/output_contract.rs
+++ b/crates/salmon-cli/tests/output_contract.rs
@@ -1,0 +1,166 @@
+//! End-to-end output-contract checks for the deterministic flow (#1140):
+//! decoy exclusion survives the full index → RAD → requant round trip,
+//! phase 2 preserves phase 1's invocation record, and single-end provenance
+//! tells the truth about where the FLD came from.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SALMON: &str = env!("CARGO_BIN_EXE_salmon");
+
+fn sequence(mut seed: u64, len: usize) -> String {
+    (0..len)
+        .map(|_| {
+            seed = seed
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            "ACGT".as_bytes()[(seed >> 33) as usize & 3] as char
+        })
+        .collect()
+}
+
+/// A gentrome-style fixture: two transcripts plus one decoy sequence (listed
+/// in decoys.txt, appended last as `salmon index -d` expects), and inward
+/// paired reads drawn from the transcripts only.
+fn fixture(dir: &Path) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let a = sequence(5, 3000);
+    let b = sequence(19, 3000);
+    let decoy = sequence(101, 4000);
+    let fasta = dir.join("gentrome.fa");
+    std::fs::write(&fasta, format!(">txA\n{a}\n>txB\n{b}\n>decoy1\n{decoy}\n")).unwrap();
+    let decoys = dir.join("decoys.txt");
+    std::fs::write(&decoys, "decoy1\n").unwrap();
+
+    let (mut r1, mut r2) = (String::new(), String::new());
+    let qual = "I".repeat(100);
+    for i in 0..200 {
+        let source = if i % 2 == 0 { &a } else { &b };
+        let start = (i * 13) % (source.len() - 300);
+        let mate1 = &source[start..start + 100];
+        let mate2: String = source[start + 200..start + 300]
+            .chars()
+            .rev()
+            .map(|c| match c {
+                'A' => 'T',
+                'C' => 'G',
+                'G' => 'C',
+                _ => 'A',
+            })
+            .collect();
+        r1.push_str(&format!("@f{i}\n{mate1}\n+\n{qual}\n"));
+        r2.push_str(&format!("@f{i}\n{mate2}\n+\n{qual}\n"));
+    }
+    let (p1, p2) = (dir.join("r1.fq"), dir.join("r2.fq"));
+    std::fs::write(&p1, r1).unwrap();
+    std::fs::write(&p2, r2).unwrap();
+    (fasta, decoys, p1, p2)
+}
+
+fn quant_names(out: &Path) -> Vec<String> {
+    std::fs::read_to_string(out.join("quant.sf"))
+        .unwrap()
+        .lines()
+        .skip(1)
+        .map(|l| l.split('\t').next().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn deterministic_flow_honors_the_output_contract_with_decoys() {
+    let dir = tempfile::tempdir().unwrap();
+    let (fasta, decoys, r1, r2) = fixture(dir.path());
+    let index = dir.path().join("idx");
+    assert!(Command::new(SALMON)
+        .args(["index", "-t"])
+        .arg(&fasta)
+        .args(["-d"])
+        .arg(&decoys)
+        .arg("-i")
+        .arg(&index)
+        .args(["-p", "2"])
+        .status()
+        .unwrap()
+        .success());
+
+    let run = |tag: &str, extra: &[&str]| -> PathBuf {
+        let out = dir.path().join(tag);
+        let mut cmd = Command::new(SALMON);
+        cmd.args(["quant", "-i"])
+            .arg(&index)
+            .args(["-l", "IU", "-1"])
+            .arg(&r1)
+            .arg("-2")
+            .arg(&r2)
+            .args(["-p", "2", "-o"])
+            .arg(&out)
+            .args(extra);
+        assert!(cmd.status().unwrap().success(), "{tag} run failed");
+        out
+    };
+
+    // The decoy round trip: phase 1 bakes the boundary into the RAD, phase 2
+    // excludes the block — so the deterministic flow's quant.sf carries the
+    // same row set as the one-pass path's, decoy-free.
+    let det = run("det", &["--deterministic"]);
+    let online = run("online", &[]);
+    let det_names = quant_names(&det);
+    assert!(
+        !det_names.iter().any(|n| n == "decoy1"),
+        "decoy row leaked into deterministic quant.sf: {det_names:?}"
+    );
+    assert_eq!(
+        det_names,
+        quant_names(&online),
+        "deterministic and one-pass runs must emit the same quant.sf row set"
+    );
+
+    // Phase 2 keeps phase 1's invocation record: the index and the read files
+    // stay in cmd_info.json instead of being clobbered by a RAD-centric one.
+    let cmd_info = std::fs::read_to_string(det.join("cmd_info.json")).unwrap();
+    assert!(
+        cmd_info.contains("\"index\"") && cmd_info.contains("r1.fq"),
+        "cmd_info.json must record the real invocation: {cmd_info}"
+    );
+    // ...and lib_format_counts.json names the reads rather than [].
+    let lfc = std::fs::read_to_string(det.join("lib_format_counts.json")).unwrap();
+    assert!(
+        lfc.contains("r1.fq"),
+        "lib_format_counts.json read_files must name the inputs: {lfc}"
+    );
+}
+
+#[test]
+fn single_end_frag_length_source_is_the_prior() {
+    let dir = tempfile::tempdir().unwrap();
+    let (fasta, _decoys, r1, _r2) = fixture(dir.path());
+    let index = dir.path().join("idx");
+    assert!(Command::new(SALMON)
+        .args(["index", "-t"])
+        .arg(&fasta)
+        .arg("-i")
+        .arg(&index)
+        .args(["-p", "2"])
+        .status()
+        .unwrap()
+        .success());
+
+    // Single-end (one-pass, where the field was wrong): no fragment lengths
+    // exist to observe, so the FLD is the --fldMean/--fldSD prior and
+    // meta_info.json must say so.
+    let out = dir.path().join("se");
+    assert!(Command::new(SALMON)
+        .args(["quant", "-i"])
+        .arg(&index)
+        .args(["-l", "U", "-r"])
+        .arg(&r1)
+        .args(["-p", "2", "-o"])
+        .arg(&out)
+        .status()
+        .unwrap()
+        .success());
+    let meta = std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap();
+    assert!(
+        meta.contains("\"frag_length_source\": \"prior\""),
+        "a single-end run's FLD is the prior, and provenance must say so: {meta}"
+    );
+}

--- a/crates/salmon-core/src/lib.rs
+++ b/crates/salmon-core/src/lib.rs
@@ -66,6 +66,29 @@ pub use libtype::{LibraryFormat, ReadOrientation, ReadStrandedness, ReadType};
 pub use mate::MateStatus;
 pub use transcript::Transcript;
 
+/// The output-row indices for a reference table laid out as
+/// `[transcripts][decoys][shorts]`: quantified transcripts `[0, first_decoy)`,
+/// the decoy block skipped, and sub-`k` "short" transcripts (reported with zero
+/// counts) after it. `first_decoy_index == None` means no decoys — every
+/// reference is a row.
+///
+/// Shared by the reads-mode writer and the RAD-requant writer so `quant.sf`
+/// (and the files positionally aligned with it) contain the same row set in
+/// every mode (#1140): decoys are references the index carries for mapping
+/// specificity, never quantification targets.
+pub fn quant_row_indices(
+    total: usize,
+    first_decoy_index: Option<usize>,
+    num_decoys: usize,
+) -> impl Iterator<Item = usize> {
+    let fdi = first_decoy_index.unwrap_or(total).min(total);
+    let decoy_end = match first_decoy_index {
+        Some(_) if num_decoys > 0 => (fdi + num_decoys).min(total),
+        _ => total,
+    };
+    (0..fdi).chain(decoy_end..total)
+}
+
 /// A set of reference sequences held as one contiguous buffer plus endpoint
 /// offsets, handing out `&[u8]` views.
 ///

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -526,6 +526,14 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
                             // recorded; the RAD then omits the tag, so a
                             // requant reports it unknown rather than `false`.
                             keep_duplicates: salmon.info().keep_duplicates,
+                            // The decoy boundary, so a requant can exclude the
+                            // decoy block from quant.sf as this mode does
+                            // (#1140). The header must carry every reference
+                            // (records index into it), so the boundary is the
+                            // only way a reader can tell decoys apart.
+                            first_decoy_index: salmon.info().first_decoy_index.map(|i| i as u64),
+                            num_decoys: (salmon.info().num_decoys > 0)
+                                .then_some(salmon.info().num_decoys as u64),
                         }),
                         // No BAM behind reads; nothing an aligner said to carry.
                         source_programs: Vec::new(),
@@ -1360,7 +1368,14 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         num_fragments_filtered_vm: num_frags_filtered_vm.load(Ordering::Relaxed),
         num_alignments_below_threshold_for_mapped_fragments_vm: num_below_threshold_vm
             .load(Ordering::Relaxed),
-        frag_len_source: salmon_model::FragLengthSource::Reads,
+        // A single-end library has no fragment lengths to observe: the FLD is
+        // the --fldMean/--fldSD prior, and saying "reads" would be a
+        // provenance lie in the field that exists for provenance (#1140).
+        frag_len_source: if opts.is_paired() {
+            salmon_model::FragLengthSource::Reads
+        } else {
+            salmon_model::FragLengthSource::Prior
+        },
         frag_len_mean: fld.mean(),
         frag_len_sd: fld.sd(),
         length_classes: salmon_model::compute_length_quantiles(

--- a/crates/salmon-quant/src/output.rs
+++ b/crates/salmon-quant/src/output.rs
@@ -133,7 +133,8 @@ fn write_bootstraps(dir: &Path, res: &QuantResult) -> Result<()> {
     std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
 
     let row_indices: Vec<usize> =
-        quant_row_indices(res.names.len(), res.first_decoy_index, res.num_decoys).collect();
+        salmon_core::quant_row_indices(res.names.len(), res.first_decoy_index, res.num_decoys)
+            .collect();
 
     let f = std::fs::File::create(dir.join("names.tsv.gz"))?;
     let mut enc = GzEncoder::new(f, Compression::new(6));
@@ -172,32 +173,6 @@ fn select_sample_bytes(sample: &[f64], row_indices: &[usize]) -> Vec<u8> {
     out
 }
 
-/// Reference indices to emit in `quant.sf`, in order, given the decoy layout.
-///
-/// The index numbering is `[transcripts][decoys][short transcripts]`: transcripts
-/// occupy `[0, first_decoy_index)`, the decoy block `[first_decoy_index,
-/// first_decoy_index + num_decoys)` is skipped, and sub-`k` "short" transcripts
-/// (no k-mers, never seeded, always 0 reads) occupy the tail
-/// `[first_decoy_index + num_decoys, total)` and are still reported.
-///
-/// `first_decoy_index == None` means no decoys (emit everything). A legacy index
-/// that recorded decoys but not `num_decoys` (== 0) keeps the old behavior:
-/// everything from `first_decoy_index` on is treated as decoy and dropped. The
-/// build guarantees decoys are one contiguous block, so the emitted set is simply
-/// the two non-decoy ranges below.
-fn quant_row_indices(
-    total: usize,
-    first_decoy_index: Option<usize>,
-    num_decoys: usize,
-) -> impl Iterator<Item = usize> {
-    let fdi = first_decoy_index.unwrap_or(total).min(total);
-    let decoy_end = match first_decoy_index {
-        Some(_) if num_decoys > 0 => (fdi + num_decoys).min(total),
-        _ => total,
-    };
-    (0..fdi).chain(decoy_end..total)
-}
-
 /// `quant.sf`: `Name  Length  EffectiveLength  TPM  NumReads`.
 ///
 /// The four numbers per transcript: its annotated length, the effective length
@@ -218,7 +193,8 @@ fn write_quant_sf(path: &Path, res: &QuantResult, sig_digits: usize) -> Result<(
     // `quant.sf` lists every input transcript.
     // salmon writes EffectiveLength and NumReads with `--sigDigits` decimals
     // (default 3) and TPM with the fixed `{:f}` (6-decimal) format.
-    for i in quant_row_indices(res.names.len(), res.first_decoy_index, res.num_decoys) {
+    for i in salmon_core::quant_row_indices(res.names.len(), res.first_decoy_index, res.num_decoys)
+    {
         writeln!(
             w,
             "{}\t{}\t{:.*}\t{:.6}\t{:.*}",
@@ -488,11 +464,11 @@ fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{quant_row_indices, select_names_tsv, select_sample_bytes};
+    use super::{select_names_tsv, select_sample_bytes};
 
     /// Collect the emitted row indices for a given reference layout.
     fn rows(total: usize, fdi: Option<usize>, nd: usize) -> Vec<usize> {
-        quant_row_indices(total, fdi, nd).collect()
+        salmon_core::quant_row_indices(total, fdi, nd).collect()
     }
 
     /// The ordinary case: no decoys, so every reference is reported.
@@ -548,7 +524,8 @@ mod tests {
             .map(|s| s.to_string())
             .collect();
         let sample = vec![10.0_f64, 20.0, 30.0, 7.0, 9.0, 0.0];
-        let row_indices: Vec<usize> = quant_row_indices(names.len(), Some(3), 2).collect();
+        let row_indices: Vec<usize> =
+            salmon_core::quant_row_indices(names.len(), Some(3), 2).collect();
         assert_eq!(row_indices, vec![0, 1, 2, 5]);
 
         let names_tsv = select_names_tsv(&names, &row_indices);

--- a/crates/salmon-rad/src/lib.rs
+++ b/crates/salmon-rad/src/lib.rs
@@ -242,6 +242,19 @@ pub const INDEX_DECOY_NAME_HASH_TAG: &str = "index_decoy_name_hash";
 /// Written only when the index actually recorded it; absent means unknown,
 /// which a reader must not collapse to `false`.
 pub const KEEP_DUPLICATES_TAG: &str = "keep_duplicates";
+/// File-tag name: index of the first decoy reference in the header's reference
+/// table. Written only for an index that has decoys; absent means either "no
+/// decoys" or "written before this was recorded" — a reader that needs the
+/// distinction pairs it with [`NUM_DECOYS_TAG`].
+///
+/// This is what lets a requant exclude the decoy block from `quant.sf` the way
+/// reads mode does: the RAD header must carry every reference (records point
+/// into it), so without the boundary a reader cannot tell decoys apart
+/// (#1140).
+pub const FIRST_DECOY_INDEX_TAG: &str = "first_decoy_index";
+/// File-tag name: number of decoy references starting at
+/// [`FIRST_DECOY_INDEX_TAG`].
+pub const NUM_DECOYS_TAG: &str = "num_decoys";
 /// Whether `value` can be written under `tag_type` without being shortened.
 ///
 /// A thin pass-through to [`libradicl::rad_types::TagValue::fits`], re-exported
@@ -343,6 +356,11 @@ pub struct IndexProvenance {
     /// whether the index was built with `--keepDuplicates`; `None` when the
     /// index predates recording it, which must not be reported as `false`
     pub keep_duplicates: Option<bool>,
+    /// index of the first decoy reference in the reference table; `None` when
+    /// the index has no decoys (or predates recording it)
+    pub first_decoy_index: Option<u64>,
+    /// decoy count starting at `first_decoy_index`
+    pub num_decoys: Option<u64>,
 }
 
 /// Counters describing what a mapping pass *saw*, as opposed to what it wrote.

--- a/crates/salmon-rad/src/schema.rs
+++ b/crates/salmon-rad/src/schema.rs
@@ -133,6 +133,12 @@ pub fn build_prelude(
         if let Some(keep) = prov.keep_duplicates {
             file_tag_values.push((crate::KEEP_DUPLICATES_TAG, TagValue::U8(keep as u8)));
         }
+        // The decoy boundary, when the index has one: what lets a requant
+        // exclude the decoy block from quant.sf as reads mode does (#1140).
+        if let (Some(fdi), Some(nd)) = (prov.first_decoy_index, prov.num_decoys) {
+            file_tag_values.push((crate::FIRST_DECOY_INDEX_TAG, TagValue::U64(fdi)));
+            file_tag_values.push((crate::NUM_DECOYS_TAG, TagValue::U64(nd)));
+        }
     }
     if !provenance.source_programs.is_empty() {
         file_tag_values.push((

--- a/crates/salmon-rad/tests/roundtrip.rs
+++ b/crates/salmon-rad/tests/roundtrip.rs
@@ -23,6 +23,8 @@ fn test_prov() -> salmon_rad::WriterProvenance {
             name_hash512: "namehash512".into(),
             decoy_seq_hash: String::new(),
             decoy_name_hash: String::new(),
+            first_decoy_index: None,
+            num_decoys: None,
             keep_duplicates: Some(false),
         }),
         source_programs: vec![],

--- a/website/src/content/docs/guides/rad-and-determinism.mdx
+++ b/website/src/content/docs/guides/rad-and-determinism.mdx
@@ -32,8 +32,10 @@ salmon quant -i salmon_index -l A -1 r1.fq.gz -2 r2.fq.gz -p 16 \
 
 The file is **piscem `map-bulk`-compatible** and can be re-quantified with
 `--rad`. salmon additionally bakes an order-independent fragment-length
-distribution, initial abundances, and the resolved library format into the RAD
-header, so re-quantifying it is a single pass (see *Determinism* below).
+distribution, initial abundances, the resolved library format, and — for a
+decoy-aware index — the decoy boundary into the RAD header, so re-quantifying
+it is a single pass (see *Determinism* below) and the requant's `quant.sf`
+excludes the decoy block exactly as a direct run does.
 
 ## Quantifying a RAD (`--rad`)
 


### PR DESCRIPTION
The release-blocking batch from the #1140 behavior audit — the six output-contract defects on the deterministic default plus the `-a`/reads mode-dispatch hole, all hand-verified before fixing. This gates #1150 (the flip): the default path cannot ship emitting decoy rows.

- **Decoy exclusion, end to end.** Phase 1 bakes the decoy boundary into the RAD header (`first_decoy_index`/`num_decoys` tags on `IndexProvenance`); the requant writer excludes the block from `quant.sf`, bootstrap `names.tsv.gz`/`bootstraps.gz`, `ambig_info.tsv`, and `num_valid_targets`, via `quant_row_indices` hoisted to `salmon-core` and shared with reads mode. Boundary-less RADs (piscem, BAM-derived, older salmon) are unchanged. E2E test drives the real binary: decoy-aware index → `--deterministic` → same decoy-free row set as one-pass.
- **`cmd_info.json` preserved** (phase 2 keeps phase 1's true invocation record) and **`lib_format_counts.json` names the read files** instead of `[]`.
- **`meta_info.json` placeholders fixed**: `samp_type` derived (`bootstrap`/`gibbs`/`none` — tximport keys off it), `serialized_eq_classes` from the dump flags, `num_decoy_fragments` from the baked counter.
- **Genome projection bakes `MapCounters`** — real `num_processed` in its requant's metadata.
- **Single-end `frag_length_source` reports `"prior"`** — the FLD never observed a fragment length.
- **`-a` conflicts with `-1/-2/-r`** at the parser instead of silently quantifying the BAM and dropping the FASTQs.

Tests at three levels: parser (clap conflict), RAD (decoy/meta contract with baked provenance + counters, plus the boundary-less compatibility case), and full-binary e2e (decoy round trip, cmd_info/read_files preservation, SE provenance). Workspace suite **312 passed / 0 failed**; clippy/fmt clean.

Sequencing: merges before #1150; the flip rebases on top (trivial — different regions except `AlignQuantOptions`, both-additive).

Refs #1140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs