### PR TITLE
fix: strand-judge --recoverOrphans pairs in one-pass mode

### DIFF
--- a/crates/salmon-map/src/mapper.rs
+++ b/crates/salmon-map/src/mapper.rs
@@ -596,7 +596,18 @@ fn push_orphan_or_recovered<R: RefProvider>(
                 } else {
                     anchor.chain.ref_start()
                 },
-                format: None, // recovered pair: orientation not re-derived
+                // The recovered pair's orientation IS observed: the anchor's
+                // strand is real evidence and the rescued mate is opposite by
+                // construction (the rescue searches inward geometry). Filling
+                // it lets the one-pass strand filter judge recovered pairs the
+                // way the deterministic path always has — the RAD stores both
+                // strand bits, so a requant judged these while one-pass waved
+                // them through on `format: None` (#1140, the #1136 pattern
+                // surviving on this one site).
+                format: Some(salmon_core::observed_paired_format(
+                    anchor.is_fw,
+                    !anchor.is_fw,
+                )),
                 // SAM: the partner's leftmost is estimated from the fragment length.
                 r1_pos: if anchor_is_left {
                     anchor.chain.ref_start()

--- a/crates/salmon-quant/tests/quant_end_to_end.rs
+++ b/crates/salmon-quant/tests/quant_end_to_end.rs
@@ -1206,3 +1206,98 @@ fn pseudoalignment_strand_filter_respects_library_type() {
         auto.num_mapped
     );
 }
+
+/// `--recoverOrphans` pairs must be strand-judged like every other proper pair
+/// (#1140): the rescue site knows both mates' strands (the anchor's is
+/// observed; the rescued mate's is opposite by construction) but left
+/// `format: None`, which the one-pass filter accepts unseen — so a wrong-`-l`
+/// run kept and counted recovered wrong-strand pairs that the deterministic
+/// path (judging the RAD's stored strand bits) dropped. The #1136 pattern,
+/// surviving on this one site.
+///
+/// The fixture makes rescue necessary: mate 2 carries a substitution every
+/// 10 bases, so no clean 31-mer survives for seeding (the mate is unmappable
+/// alone) while banded DP still aligns it well above the score floor.
+#[test]
+fn recovered_pairs_are_strand_judged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2, truth) = simulate(tmp.path());
+    let total_truth: u64 = truth.values().sum();
+
+    // Corrupt every mate-2 read: substitute positions 5, 15, ..., killing all
+    // 31-mer seeds while keeping the read alignable by DP.
+    let corrupt = |b: u8| match b {
+        b'A' => b'C',
+        b'C' => b'G',
+        b'G' => b'T',
+        _ => b'A',
+    };
+    let r2_bad = tmp.path().join("reads_2_bad.fq");
+    {
+        let text = std::fs::read_to_string(&r2).unwrap();
+        let mut out = String::with_capacity(text.len());
+        for (i, line) in text.lines().enumerate() {
+            if i % 4 == 1 {
+                let mut seq: Vec<u8> = line.bytes().collect();
+                let mut p = 5;
+                while p < seq.len() {
+                    seq[p] = corrupt(seq[p]);
+                    p += 10;
+                }
+                out.push_str(std::str::from_utf8(&seq).unwrap());
+            } else {
+                out.push_str(line);
+            }
+            out.push('\n');
+        }
+        std::fs::write(&r2_bad, out).unwrap();
+    }
+
+    let idx_dir = tmp.path().join("idx");
+    let mut bopts = IndexBuildOptions::new(vec![fasta], idx_dir.clone());
+    bopts.threads = 1;
+    build(&bopts).expect("build index");
+
+    let quant = |lib_type: &str, recover: bool, out: PathBuf| {
+        let mut opts = QuantOptions::new(idx_dir.clone(), out);
+        opts.mates1 = vec![r1.clone()];
+        opts.mates2 = vec![r2_bad.clone()];
+        opts.lib_type = lib_type.to_string();
+        opts.num_threads = 1;
+        opts.map_config.recover_orphans = recover;
+        quantify(&opts).unwrap_or_else(|e| panic!("quantify {lib_type}: {e}"))
+    };
+
+    // Without rescue, the corrupted mates orphan; with it, pairs are recovered
+    // — this is the guard that the fixture actually exercises the rescue path
+    // rather than mapping normally.
+    let plain = quant("ISF", false, tmp.path().join("no_rescue"));
+    let rescued = quant("ISF", true, tmp.path().join("rescue_isf"));
+    assert!(
+        rescued.num_orphan < plain.num_orphan,
+        "rescue must convert orphans ({}) into pairs ({} orphans remain)",
+        plain.num_orphan,
+        rescued.num_orphan
+    );
+    assert!(
+        rescued.num_mapped as f64 >= 0.9 * total_truth as f64,
+        "matching library type keeps the recovered pairs: {} / {total_truth}",
+        rescued.num_mapped
+    );
+
+    // The regression: under the opposite stranded type, recovered pairs are
+    // judged on their observed orientation and dropped — they used to pass the
+    // filter unseen on `format: None` and be counted compatible.
+    let wrong = quant("ISR", true, tmp.path().join("rescue_isr"));
+    assert!(
+        (wrong.num_mapped as f64) <= 0.1 * (rescued.num_mapped as f64),
+        "wrong-strand recovered pairs must be dropped, kept {} of {}",
+        wrong.num_mapped,
+        rescued.num_mapped
+    );
+    assert!(
+        wrong.num_incompatible_fragments as f64 >= 0.8 * total_truth as f64,
+        "…and counted incompatible, not compatible: {} of {total_truth}",
+        wrong.num_incompatible_fragments
+    );
+}


### PR DESCRIPTION
Closes audit finding F16 from the #1140 behavior review (the last confirmed instance of the #1136 pattern).

## The bug

The `--recoverOrphans` rescue site built its `RawMapping` with `format: None`, and the one-pass strand filter accepts a `None` format unconditionally ("accept rather than guess"). Under a stranded `-l`, recovered wrong-strand pairs therefore bypassed the compatibility filter entirely and were counted as compatible mappings. The deterministic path never had this hole — the RAD stores both mates' strand bits and `quantify_rad` judges recovered pairs like any other pair — so this was also a silent one-pass-vs-deterministic divergence.

## The fix

A recovered pair's orientation is genuinely *observed*, not guessed: the anchor's strand is real mapping evidence, and the rescued mate is opposite by construction (the rescue searches inward geometry). So the site now fills `format` via `observed_paired_format(anchor.is_fw, !anchor.is_fw)`, and one-pass judges recovered pairs exactly as deterministic always has. One-line semantic change.

## The test

`recovered_pairs_are_strand_judged` builds a fixture where rescue is *necessary*: mate 2 gets a substitution every 10 bases, so no clean 31-mer survives for seeding (unmappable alone) while banded DP still clears the score floor. It pins three things:

- rescue actually engages — orphan count drops versus a `recover_orphans: false` run of the same reads (guards against the fixture silently mapping normally);
- the matching library type (`ISF`) keeps ≥90% of recovered pairs — no over-filtering;
- the opposite type (`ISR`) now drops them (≤10% mapped) **and counts them incompatible** — this assertion fails on `develop`.

`cargo fmt` clean, clippy clean, full workspace suite 308/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs