### PR TITLE
audit batch E: the mode×flag applicability sweep

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -230,6 +230,12 @@ pub struct AlignQuantOptions {
     /// pass's own in `meta_info.json` — so a pipeline that only keeps the
     /// output directory sees them, not just whoever read the log (#1140)
     pub extra_diagnostics: Vec<salmon_core::Diagnostic>,
+    /// `--dumpBiasModels` (hidden): write the observed+expected seq/GC/pos
+    /// bias models to `bias_models.txt` for debugging / C++-parity comparison.
+    /// Written by the shared output writer from the pass's [`BiasDump`], so it
+    /// works on every path that runs bias correction (#1140: it used to exist
+    /// only on the deprecated one-pass reads path).
+    pub dump_bias_models: bool,
     /// significant digits for the EffectiveLength and NumReads columns of
     /// `quant.sf` (`--sigDigits`, salmon default 3)
     pub sig_digits: u32,
@@ -304,6 +310,7 @@ impl AlignQuantOptions {
             no_length_correction: false,
             no_frag_length_dist: false,
             extra_diagnostics: Vec::new(),
+            dump_bias_models: false,
             sig_digits: 3,
             num_error_bins: 4,
             discard_orphans: false,
@@ -2953,6 +2960,14 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         .context("writing fld.gz")?;
     salmon_model::dumps::write_aux_bias_dumps(&dir.join("aux_info"), &res.bias_dump)
         .context("writing aux bias dumps")?;
+    // `--dumpBiasModels`: the same dump the one-pass reads path writes, from
+    // this pass's own models — the shared writer makes it work on every
+    // RAD/alignment driver (#1140: it silently vanished when deterministic
+    // became the default, because only salmon-quant had a write site).
+    if opts.dump_bias_models {
+        salmon_model::dumps::dump_bias_models_to_file(&dir.join("bias_models.txt"), &res.bias_dump)
+            .context("writing bias_models.txt")?;
+    }
     std::fs::create_dir_all(dir.join("logs")).context("creating logs")?;
     // In alignment mode the input records are already aligned, so `num_processed`
     // is the count of aligned fragments and `num_mapped` is those with a strand-

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -414,13 +414,16 @@ struct QuantArgs {
     /// transcript set is taken from the annotation.
     #[arg(long = "annotation", value_name = "GTF|GFF")]
     annotation: Option<PathBuf>,
+    // `--genome` / `--juncMissDiscount` are read only by the genome-projection
+    // branch, which `--annotation` selects; without it they were silently
+    // accepted and dead (#1140), so clap now enforces the dependency.
     /// Genome FASTA (genome-alignment mode) — needed only for bias correction, to
     /// reconstruct transcript sequences from the annotation's exons.
-    #[arg(long = "genome", value_name = "FASTA")]
+    #[arg(long = "genome", value_name = "FASTA", requires = "annotation")]
     genome: Option<PathBuf>,
     /// Genome-alignment projection: penalty multiplier per junction mismatch
     /// (bramble `junc_miss_discount`; default 1.0 = no penalty).
-    #[arg(long = "juncMissDiscount", value_name = "F")]
+    #[arg(long = "juncMissDiscount", value_name = "F", requires = "annotation")]
     junc_miss_discount: Option<f64>,
     /// Library type (e.g. IU, ISR, A for auto).
     #[arg(short = 'l', long = "libType", default_value = "A")]
@@ -601,8 +604,10 @@ struct QuantArgs {
     dump_bias_models: bool,
     /// Compression codec for RAD output (`--writeRad` and the `--deterministic`
     /// intermediate): `lz4` (default), `zstd` (better ratio), or `none`.
-    #[arg(long = "radCompress", default_value = "lz4", value_parser = ["lz4", "zstd", "none"])]
-    rad_compress: String,
+    /// Option-typed (default applied at use: `lz4`) so passing it on a path
+    /// that writes no RAD can warn instead of being silently inert (#1140).
+    #[arg(long = "radCompress", value_parser = ["lz4", "zstd", "none"])]
+    rad_compress: Option<String>,
     /// Write uncompressed RAD chunks (overrides --radCompress).
     #[arg(long = "noCompressRad")]
     no_compress_rad: bool,
@@ -630,14 +635,16 @@ struct QuantArgs {
     /// Disable effective-length correction (use raw reference length).
     #[arg(long = "noLengthCorrection")]
     no_length_correction: bool,
-    /// Minimum alignment score as a fraction of the perfect score.
-    #[arg(long = "minScoreFraction", default_value_t = 0.65)]
-    min_score_fraction: f32,
+    /// Minimum alignment score as a fraction of the perfect score (default 0.65).
+    /// Option-typed so passing it under `--sketch` — which computes no alignment
+    /// scores — can warn instead of being silently inert (#1140).
+    #[arg(long = "minScoreFraction")]
+    min_score_fraction: Option<f32>,
     /// Orphan chain sub-optimality threshold (salmon's `orphanChainSubThresh`).
     /// `0.0` (default) aligns every orphan candidate (more sensitive than salmon's
     /// 0.95, which prunes low-chain-coverage orphans before alignment).
-    #[arg(long = "orphanChainSubThresh", default_value_t = 0.0)]
-    orphan_chain_sub_thresh: f32,
+    #[arg(long = "orphanChainSubThresh")]
+    orphan_chain_sub_thresh: Option<f32>,
     /// Score the full read with one DP instead of PuffAligner-style inter-MEM-gap scoring.
     #[arg(long = "fullLengthAlignment")]
     full_length_alignment: bool,
@@ -652,18 +659,18 @@ struct QuantArgs {
     /// default; the flag is accepted for explicitness/back-compat.
     #[arg(long = "uniMEMs", conflicts_with = "refmems")]
     unimems: bool,
-    /// Match score for selective alignment (reads mode).
-    #[arg(long = "ma", default_value_t = 2)]
-    ma: i32,
-    /// Mismatch penalty for selective alignment (reads mode).
-    #[arg(long = "mp", default_value_t = 4)]
-    mp: i32,
-    /// Gap-open penalty for selective alignment (reads mode).
-    #[arg(long = "go", default_value_t = 6)]
-    go: i32,
-    /// Gap-extend penalty for selective alignment (reads mode).
-    #[arg(long = "ge", default_value_t = 2)]
-    ge: i32,
+    /// Match score for selective alignment (reads mode; default 2).
+    #[arg(long = "ma")]
+    ma: Option<i32>,
+    /// Mismatch penalty for selective alignment (reads mode; default 4).
+    #[arg(long = "mp")]
+    mp: Option<i32>,
+    /// Gap-open penalty for selective alignment (reads mode; default 6).
+    #[arg(long = "go")]
+    go: Option<i32>,
+    /// Gap-extend penalty for selective alignment (reads mode; default 2).
+    #[arg(long = "ge")]
+    ge: Option<i32>,
     /// Consensus slack: a target is kept only if its best chain score is at least
     /// `(1 - slack)` of the max chain score for that mate (salmon default 0.35;
     /// `1.0` keeps every target).
@@ -1186,6 +1193,11 @@ fn requant_options(
     // the driver clears the flags for phase 1.
     q.dump_eq = map_opts.dump_eq;
     q.dump_eq_weights = map_opts.dump_eq_weights;
+    // Same shape as the eq dumps: phase 2 owns the run's final bias models
+    // (phase 1's dump site is gated off by skip_quant), so `--dumpBiasModels`
+    // is honoured by the requant's shared writer (#1140: the flag silently
+    // vanished when deterministic became the default).
+    q.dump_bias_models = map_opts.dump_bias_models;
     // The RAD path gained these two with #1148; before that they existed only in
     // reads mode, so `--deterministic` accepted them and quantified as though
     // they had not been passed.
@@ -1465,7 +1477,15 @@ fn run_deterministic(
         pct2,
         res.num_eq_classes
     );
-    if let Some(gm) = gene_map {
+    // `--skipQuant` estimates no abundances; aggregating the zero rows to
+    // gene level would announce success over an empty result (#1140 — the
+    // deterministic reads driver already skipped it, the others wrote
+    // zeros silently).
+    if map_opts.skip_quant && gene_map.is_some() {
+        tracing::info!(
+            "--skipQuant: gene-level aggregation (-g) skipped — no abundances were estimated"
+        );
+    } else if let Some(gm) = gene_map {
         write_gene_level(
             out_dir,
             gm,
@@ -1594,7 +1614,15 @@ fn run_deterministic_align(
         pct2,
         res.num_eq_classes
     );
-    if let Some(gm) = gene_map {
+    // `--skipQuant` estimates no abundances; aggregating the zero rows to
+    // gene level would announce success over an empty result (#1140 — the
+    // deterministic reads driver already skipped it, the others wrote
+    // zeros silently).
+    if opts.skip_quant && gene_map.is_some() {
+        tracing::info!(
+            "--skipQuant: gene-level aggregation (-g) skipped — no abundances were estimated"
+        );
+    } else if let Some(gm) = gene_map {
         write_gene_level(
             &out_dir,
             gm,
@@ -1651,9 +1679,25 @@ fn run_genome_project(
     if explicit && scratch_dir.is_some() {
         tracing::warn!("--radScratchDir is ignored when --writeRad names an explicit path");
     }
+    // Deliverable-vs-intermediate rule, same as the reads/alignment drivers
+    // (#1149/#1140): under `--skipQuant` the projected RAD is the run's only
+    // output, so it belongs in the output directory under its stable name —
+    // not pid-suffixed in scratch, where a "successful" run would leave the
+    // output directory empty.
+    let deliverable = q.skip_quant;
+    if deliverable && scratch_dir.is_some() {
+        tracing::info!(
+            "--skipQuant makes the projected RAD this run's output, so it is written to \
+             the output directory rather than to --radScratchDir"
+        );
+    }
     let rad_path = match rad_out {
         Some(p) => p,
-        None => intermediate_rad_path(&out_dir, scratch_dir, "genome_projected")?,
+        None => intermediate_rad_path(
+            &out_dir,
+            if deliverable { None } else { scratch_dir },
+            "genome_projected",
+        )?,
     };
     std::fs::create_dir_all(&out_dir)
         .with_context(|| format!("creating output directory {}", out_dir.display()))?;
@@ -1705,7 +1749,15 @@ fn run_genome_project(
         res.num_mapped,
         res.num_eq_classes
     );
-    if let Some(gm) = gene_map {
+    // `--skipQuant` estimates no abundances; aggregating the zero rows to
+    // gene level would announce success over an empty result (#1140 — the
+    // deterministic reads driver already skipped it, the others wrote
+    // zeros silently).
+    if q.skip_quant && gene_map.is_some() {
+        tracing::info!(
+            "--skipQuant: gene-level aggregation (-g) skipped — no abundances were estimated"
+        );
+    } else if let Some(gm) = gene_map {
         write_gene_level(
             &out_dir,
             gm,
@@ -1716,7 +1768,7 @@ fn run_genome_project(
             &res.counts,
         )?;
     }
-    if explicit || keep_rad {
+    if explicit || keep_rad || deliverable {
         tracing::info!("kept projected RAD at {}", rad_path.display());
     } else if let Err(e) = std::fs::remove_file(&rad_path) {
         tracing::warn!("could not remove projected RAD {}: {e}", rad_path.display());
@@ -1794,7 +1846,19 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     // that only exist on the online path warn when passed without it, rather
     // than being silently inert under the new default — silent inertness is
     // the exact failure mode #1140's audit spent a release hunting down.
-    if args.online {
+    // In RAD-input mode there is no online path at all — a RAD is always
+    // quantified with the offline estimator — so `--online` there must not
+    // claim the one-pass path will run, and must not suppress the inert-knob
+    // warnings below (`--rad X --online -f 0.9` used to drop `-f` silently
+    // behind a misleading deprecation notice, #1140).
+    let online_path_exists = args.rad.is_none();
+    if args.online && !online_path_exists {
+        tracing::warn!(
+            "--online has no effect in RAD-input mode (--rad): a RAD is always quantified \
+             with the offline (deterministic) estimator"
+        );
+    }
+    if args.online && online_path_exists {
         tracing::warn!(
             "--online selects the deprecated one-pass quantification path (removal planned \
              for 2.7.0). Its results depend on the thread count; the default deterministic \
@@ -1845,6 +1909,14 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
                  quantified directly and the index is never consulted"
             );
         }
+        if args.write_unmapped_names {
+            // Only the reads-mode mapper tracks per-read mapping failures; an
+            // alignment/RAD input carries only the records that aligned.
+            tracing::warn!(
+                "--writeUnmappedNames is ignored in alignment mode (-a): unmapped-read \
+                 tracking exists only in reads mode"
+            );
+        }
         warn_unsupported_mapping_output(
             &args.write_mappings,
             &args.write_bam,
@@ -1875,6 +1947,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.init_uniform = args.init_uniform;
         opts.dump_eq = args.dump_eq;
         opts.dump_eq_weights = args.dump_eq_weights;
+        opts.dump_bias_models = args.dump_bias_models;
         opts.no_length_correction = args.no_length_correction;
         opts.no_frag_length_dist = args.no_frag_length_dist;
         opts.bias_speed_samp = args.bias_speed_samp;
@@ -1911,7 +1984,10 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
                      projection scores by bramble similarity, not an alignment error model"
                 );
             }
-            let codec = rad_codec_from_args(args.no_compress_rad, &args.rad_compress)?;
+            let codec = rad_codec_from_args(
+                args.no_compress_rad,
+                args.rad_compress.as_deref().unwrap_or("lz4"),
+            )?;
             let gp = GenomeProjectOptions {
                 bam: opts.bam.clone(),
                 annotation,
@@ -1944,7 +2020,10 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         // one-pass path below, which is the only place the online error model
         // still lives.
         if !args.online {
-            let codec = rad_codec_from_args(args.no_compress_rad, &args.rad_compress)?;
+            let codec = rad_codec_from_args(
+                args.no_compress_rad,
+                args.rad_compress.as_deref().unwrap_or("lz4"),
+            )?;
             return run_deterministic_align(
                 opts,
                 args.write_rad.clone(),
@@ -1963,6 +2042,26 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             tracing::warn!(
                 "--noLengthCorrection/--noFragLengthDist are not supported on the deprecated \
                  online alignment path: ignored. The default (deterministic) mode honours them."
+            );
+        }
+        // The online alignment path writes no RAD, so the flags that place or
+        // shape one are inert here; the deterministic default honours them
+        // (#1140: a flag that does nothing must say so).
+        let inert_rad: Vec<&str> = [
+            ("--writeRad", args.write_rad.is_some()),
+            ("--keepRad", args.keep_rad),
+            ("--radScratchDir", args.rad_scratch_dir.is_some()),
+            ("--radCompress", args.rad_compress.is_some()),
+            ("--noCompressRad", args.no_compress_rad),
+        ]
+        .iter()
+        .filter_map(|&(name, passed)| passed.then_some(name))
+        .collect();
+        if !inert_rad.is_empty() {
+            tracing::warn!(
+                "{} shape the intermediate RAD, which the deprecated online alignment path \
+                 never writes: ignored. The default (deterministic) mode honours them.",
+                inert_rad.join(", ")
             );
         }
         // Live progress spinner on an interactive terminal (unless --quiet/--no-progress).
@@ -2005,7 +2104,15 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         }
         // The truncated-mass warning now fires in the shared output writer,
         // covering this path and every quantify_rad driver alike (#1140).
-        if let Some(gm) = &gene_map {
+        // `--skipQuant` estimates no abundances; aggregating the zero rows to
+        // gene level would announce success over an empty result (#1140 — the
+        // deterministic reads driver already skipped it, the others wrote
+        // zeros silently).
+        if args.skip_quant && gene_map.is_some() {
+            tracing::info!(
+                "--skipQuant: gene-level aggregation (-g) skipped — no abundances were estimated"
+            );
+        } else if let Some(gm) = &gene_map {
             write_gene_level(
                 &out_dir,
                 gm,
@@ -2026,6 +2133,31 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             tracing::warn!(
                 "-i/--index is ignored in RAD-input mode (--rad): the RAD's own reference \
                  table is used and the index is never consulted"
+            );
+        }
+        if args.write_unmapped_names {
+            tracing::warn!(
+                "--writeUnmappedNames is ignored in RAD-input mode (--rad): a RAD carries \
+                 only the fragments that mapped, and no read names"
+            );
+        }
+        // The input *is* the RAD; the flags that would place or shape a new
+        // one have nothing to act on (#1140).
+        let inert_rad: Vec<&str> = [
+            ("--writeRad", args.write_rad.is_some()),
+            ("--keepRad", args.keep_rad),
+            ("--radScratchDir", args.rad_scratch_dir.is_some()),
+            ("--radCompress", args.rad_compress.is_some()),
+            ("--noCompressRad", args.no_compress_rad),
+        ]
+        .iter()
+        .filter_map(|&(name, passed)| passed.then_some(name))
+        .collect();
+        if !inert_rad.is_empty() {
+            tracing::warn!(
+                "{} shape an intermediate RAD, which RAD-input mode does not write \
+                 (the --rad file is the input): ignored",
+                inert_rad.join(", ")
             );
         }
         warn_unsupported_mapping_output(
@@ -2068,6 +2200,15 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.skip_quant = args.skip_quant;
         opts.dump_eq = args.dump_eq;
         opts.dump_eq_weights = args.dump_eq_weights;
+        opts.dump_bias_models = args.dump_bias_models;
+        // The GC/bias shape knobs quantify_rad honours everywhere else; these
+        // four were the exact requant_options omission recurring in this block
+        // (#1140): --gcBias was wired while its tuning flags silently stayed
+        // at defaults.
+        opts.gc_bins = args.num_gc_bins;
+        opts.cond_gc_bins = args.conditional_gc_bins;
+        opts.bias_speed_samp = args.bias_speed_samp;
+        opts.no_bias_length_threshold = args.no_bias_length_threshold;
         opts.no_length_correction = args.no_length_correction;
         opts.no_frag_length_dist = args.no_frag_length_dist;
         opts.num_bootstraps = args.num_bootstraps;
@@ -2086,7 +2227,15 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             pct,
             res.num_eq_classes
         );
-        if let Some(gm) = &gene_map {
+        // `--skipQuant` estimates no abundances; aggregating the zero rows to
+        // gene level would announce success over an empty result (#1140 — the
+        // deterministic reads driver already skipped it, the others wrote
+        // zeros silently).
+        if args.skip_quant && gene_map.is_some() {
+            tracing::info!(
+                "--skipQuant: gene-level aggregation (-g) skipped — no abundances were estimated"
+            );
+        } else if let Some(gm) = &gene_map {
             write_gene_level(
                 &out_dir,
                 gm,
@@ -2153,7 +2302,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.rad_codec = if args.no_compress_rad {
         ChunkCodec::None
     } else {
-        match args.rad_compress.as_str() {
+        match args.rad_compress.as_deref().unwrap_or("lz4") {
             "none" => ChunkCodec::None,
             "lz4" => ChunkCodec::Lz4,
             "zstd" => ChunkCodec::Zstd,
@@ -2168,8 +2317,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.no_length_correction = args.no_length_correction;
     opts.model_single_frag_prob = !args.no_single_frag_prob;
     opts.no_frag_length_dist = args.no_frag_length_dist;
-    opts.map_config.align.min_score_fraction = args.min_score_fraction;
-    opts.map_config.pair.orphan_chain_sub_thresh = args.orphan_chain_sub_thresh;
+    opts.map_config.align.min_score_fraction = args.min_score_fraction.unwrap_or(0.65);
+    opts.map_config.pair.orphan_chain_sub_thresh = args.orphan_chain_sub_thresh.unwrap_or(0.0);
     opts.map_config.align.full_length_alignment = args.full_length_alignment;
     opts.map_config.align.bandwidth = args.bandwidth;
     opts.map_config.pair.allow_dovetail = args.allow_dovetail;
@@ -2199,10 +2348,55 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples.unwrap_or(5_000);
     opts.map_config.seed_mode = seed_mode(args.unimems, args.refmems, args.sparse_seeds);
     // alignment scoring (selective alignment)
-    opts.map_config.align.match_score = args.ma as i8;
-    opts.map_config.align.mismatch_pen = args.mp as i8;
-    opts.map_config.align.gap_open_pen = args.go as i8;
-    opts.map_config.align.gap_extend_pen = args.ge as i8;
+    opts.map_config.align.match_score = args.ma.unwrap_or(2) as i8;
+    opts.map_config.align.mismatch_pen = args.mp.unwrap_or(4) as i8;
+    opts.map_config.align.gap_open_pen = args.go.unwrap_or(6) as i8;
+    opts.map_config.align.gap_extend_pen = args.ge.unwrap_or(2) as i8;
+
+    // The sketch (pseudoalignment) path computes no alignment scores, uses its
+    // own hardcoded seeding, and governs orphans solely through
+    // `--sketchStrictOrphans` — so every selective-alignment knob below is
+    // inert under `--sketch`. A flag that does nothing must say so (#1140);
+    // this is the mode×flag applicability check for the sketch/SA split.
+    if args.sketch {
+        let inert: Vec<&str> = [
+            ("--ma", args.ma.is_some()),
+            ("--mp", args.mp.is_some()),
+            ("--go", args.go.is_some()),
+            ("--ge", args.ge.is_some()),
+            ("--minScoreFraction", args.min_score_fraction.is_some()),
+            ("--fullLengthAlignment", args.full_length_alignment),
+            (
+                "--orphanChainSubThresh",
+                args.orphan_chain_sub_thresh.is_some(),
+            ),
+            ("--discardOrphansQuasi", args.discard_orphans_quasi),
+            (
+                "--orphansRequireUnmappedMate",
+                args.orphans_require_unmapped_mate,
+            ),
+            ("--sparseSeeds", args.sparse_seeds),
+            ("--refMEMs", args.refmems),
+            ("--uniMEMs", args.unimems),
+        ]
+        .iter()
+        .filter_map(|&(name, passed)| passed.then_some(name))
+        .collect();
+        if !inert.is_empty() {
+            tracing::warn!(
+                "{} {} no effect under --sketch: pseudoalignment computes no alignment \
+                 scores, seeds with its own fixed sketch parameters, and controls orphans \
+                 only via --sketchStrictOrphans",
+                inert.join(", "),
+                if inert.len() == 1 { "has" } else { "have" }
+            );
+        }
+    } else if args.sketch_strict_orphans {
+        tracing::warn!(
+            "--sketchStrictOrphans has no effect without --sketch: selective alignment \
+             governs orphans via --discardOrphansQuasi / --orphansRequireUnmappedMate"
+        );
+    }
     // chaining consensus + repetitive-hit guard
     opts.map_config.collect.consensus_fraction = 1.0 - args.consensus_slack;
     opts.map_config.collect.max_hit_occ = args.max_occs_per_hit;
@@ -2288,7 +2482,15 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             res.inference_truncated_mass
         );
     }
-    if let Some(gm) = &gene_map {
+    // `--skipQuant` estimates no abundances; aggregating the zero rows to
+    // gene level would announce success over an empty result (#1140 — the
+    // deterministic reads driver already skipped it, the others wrote
+    // zeros silently).
+    if args.skip_quant && gene_map.is_some() {
+        tracing::info!(
+            "--skipQuant: gene-level aggregation (-g) skipped — no abundances were estimated"
+        );
+    } else if let Some(gm) = &gene_map {
         write_gene_level(
             &out_dir,
             gm,
@@ -2611,6 +2813,7 @@ mod tests {
         map_opts.init_uniform = true;
         map_opts.dump_eq = true;
         map_opts.dump_eq_weights = true;
+        map_opts.dump_bias_models = true;
         map_opts.no_length_correction = true;
         map_opts.no_frag_length_dist = true;
 
@@ -2646,6 +2849,7 @@ mod tests {
         assert!(q.init_uniform);
         assert!(q.dump_eq);
         assert!(q.dump_eq_weights);
+        assert!(q.dump_bias_models);
         assert!(q.no_length_correction);
         assert!(q.no_frag_length_dist);
     }

--- a/crates/salmon-cli/tests/flag_matrix.rs
+++ b/crates/salmon-cli/tests/flag_matrix.rs
@@ -1,0 +1,241 @@
+//! Mode×flag applicability, end to end (#1140, audit batch E): a flag that
+//! does nothing in the selected mode must say so, and the flags the audit
+//! found silently dropped must now act. One index build feeds every check.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SALMON: &str = env!("CARGO_BIN_EXE_salmon");
+
+fn sequence(mut seed: u64, len: usize) -> String {
+    (0..len)
+        .map(|_| {
+            seed = seed
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            "ACGT".as_bytes()[(seed >> 33) as usize & 3] as char
+        })
+        .collect()
+}
+
+/// Two transcripts and inward paired reads drawn from them.
+fn fixture(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let a = sequence(5, 3000);
+    let b = sequence(19, 3000);
+    let fasta = dir.join("txome.fa");
+    std::fs::write(&fasta, format!(">txA\n{a}\n>txB\n{b}\n")).unwrap();
+    let (mut r1, mut r2) = (String::new(), String::new());
+    let qual = "I".repeat(100);
+    for i in 0..200 {
+        let source = if i % 2 == 0 { &a } else { &b };
+        let start = (i * 13) % (source.len() - 300);
+        let mate1 = &source[start..start + 100];
+        let mate2: String = source[start + 200..start + 300]
+            .chars()
+            .rev()
+            .map(|c| match c {
+                'A' => 'T',
+                'C' => 'G',
+                'G' => 'C',
+                _ => 'A',
+            })
+            .collect();
+        r1.push_str(&format!("@f{i}\n{mate1}\n+\n{qual}\n"));
+        r2.push_str(&format!("@f{i}\n{mate2}\n+\n{qual}\n"));
+    }
+    let (p1, p2) = (dir.join("r1.fq"), dir.join("r2.fq"));
+    std::fs::write(&p1, r1).unwrap();
+    std::fs::write(&p2, r2).unwrap();
+    (fasta, p1, p2)
+}
+
+fn salmon(args: &[&std::ffi::OsStr]) -> Output {
+    Command::new(SALMON).args(args).output().unwrap()
+}
+
+fn os(s: &str) -> &std::ffi::OsStr {
+    std::ffi::OsStr::new(s)
+}
+
+#[test]
+fn mode_flag_matrix_end_to_end() {
+    let dir = tempfile::tempdir().unwrap();
+    let (fasta, r1, r2) = fixture(dir.path());
+    let index = dir.path().join("idx");
+    assert!(Command::new(SALMON)
+        .args(["index", "-t"])
+        .arg(&fasta)
+        .arg("-i")
+        .arg(&index)
+        .args(["-p", "2"])
+        .status()
+        .unwrap()
+        .success());
+    let quant_reads = |extra: &[&std::ffi::OsStr], out: &Path| -> Output {
+        let mut v: Vec<&std::ffi::OsStr> = vec![
+            os("quant"),
+            os("-i"),
+            index.as_os_str(),
+            os("-l"),
+            os("IU"),
+            os("-1"),
+            r1.as_os_str(),
+            os("-2"),
+            r2.as_os_str(),
+            os("-p"),
+            os("2"),
+            os("-o"),
+            out.as_os_str(),
+        ];
+        v.extend_from_slice(extra);
+        salmon(&v)
+    };
+
+    // --dumpBiasModels must produce bias_models.txt on the DEFAULT
+    // (deterministic) path — it silently vanished with the 2.6.0 flip because
+    // only the one-pass writer had a dump site. Also produce the RAD the later
+    // --rad checks quantify.
+    let out = dir.path().join("det");
+    let rad = dir.path().join("mappings.rad");
+    let o = quant_reads(
+        &[
+            os("--gcBias"),
+            os("--dumpBiasModels"),
+            os("--writeRad"),
+            rad.as_os_str(),
+        ],
+        &out,
+    );
+    assert!(o.status.success(), "{}", String::from_utf8_lossy(&o.stderr));
+    assert!(
+        out.join("bias_models.txt").exists(),
+        "--dumpBiasModels must write bias_models.txt under the deterministic default"
+    );
+    assert!(rad.exists());
+
+    // Sketch mode computes no alignment scores: the selective-alignment knobs
+    // must warn by name instead of being silently inert.
+    let o = quant_reads(
+        &[
+            os("--sketch"),
+            os("--ma"),
+            os("3"),
+            os("--minScoreFraction"),
+            os("0.8"),
+            os("--fullLengthAlignment"),
+        ],
+        &dir.path().join("sk_warn"),
+    );
+    assert!(o.status.success(), "{}", String::from_utf8_lossy(&o.stderr));
+    let err = String::from_utf8_lossy(&o.stderr).into_owned();
+    for needle in ["--ma", "--minScoreFraction", "--fullLengthAlignment"] {
+        assert!(
+            err.contains(needle),
+            "sketch run must name inert flag {needle}: {err}"
+        );
+    }
+    assert!(err.contains("no effect under --sketch"), "{err}");
+
+    // Control: a plain sketch run draws no such complaint, and a plain
+    // selective-alignment run does not warn about sketch knobs it honours.
+    let o = quant_reads(&[os("--sketch")], &dir.path().join("sk_plain"));
+    assert!(
+        !String::from_utf8_lossy(&o.stderr).contains("no effect under --sketch"),
+        "a plain --sketch run must not warn"
+    );
+    let o = quant_reads(&[os("--ma"), os("3")], &dir.path().join("sa_ma"));
+    assert!(
+        !String::from_utf8_lossy(&o.stderr).contains("no effect under --sketch"),
+        "--ma is honoured in selective-alignment mode and must not warn"
+    );
+
+    // --sketchStrictOrphans without --sketch is the reverse orphan: warn.
+    let o = quant_reads(&[os("--sketchStrictOrphans")], &dir.path().join("sso"));
+    assert!(
+        String::from_utf8_lossy(&o.stderr).contains("--sketchStrictOrphans has no effect"),
+        "{}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+
+    // RAD-input mode: --online has no online path to select, and it must not
+    // suppress the inert-knob warning for the online knobs it used to mask;
+    // the RAD-shaping flags have nothing to act on either.
+    let o = salmon(&[
+        os("quant"),
+        os("--rad"),
+        rad.as_os_str(),
+        os("-l"),
+        os("IU"),
+        os("--online"),
+        os("--forgettingFactor"),
+        os("0.9"),
+        os("--keepRad"),
+        os("-o"),
+        dir.path().join("rad_online").as_os_str(),
+    ]);
+    assert!(o.status.success(), "{}", String::from_utf8_lossy(&o.stderr));
+    let err = String::from_utf8_lossy(&o.stderr).into_owned();
+    assert!(
+        err.contains("--online has no effect in RAD-input mode"),
+        "{err}"
+    );
+    assert!(
+        err.contains("--forgettingFactor"),
+        "--online must not suppress the inert-knob warning in --rad mode: {err}"
+    );
+    assert!(
+        !err.contains("deprecated one-pass quantification path"),
+        "--rad --online must not claim the one-pass path will run: {err}"
+    );
+    assert!(err.contains("--keepRad"), "{err}");
+
+    // --genome / --juncMissDiscount are genome-projection knobs; without
+    // --annotation clap rejects them up front instead of silently dropping.
+    let o = salmon(&[
+        os("quant"),
+        os("-i"),
+        index.as_os_str(),
+        os("-l"),
+        os("IU"),
+        os("-1"),
+        r1.as_os_str(),
+        os("-2"),
+        r2.as_os_str(),
+        os("--genome"),
+        fasta.as_os_str(),
+        os("-o"),
+        dir.path().join("g").as_os_str(),
+    ]);
+    assert!(
+        !o.status.success(),
+        "--genome without --annotation must be rejected"
+    );
+
+    // -g under --skipQuant: no abundances exist, so no quant.genes.sf full of
+    // zeros — the run says why instead.
+    let gm = dir.path().join("t2g.tsv");
+    std::fs::write(&gm, "txA\tgeneA\ntxB\tgeneB\n").unwrap();
+    let out_sq = dir.path().join("rad_sq");
+    let o = salmon(&[
+        os("quant"),
+        os("--rad"),
+        rad.as_os_str(),
+        os("-l"),
+        os("IU"),
+        os("--skipQuant"),
+        os("-g"),
+        gm.as_os_str(),
+        os("-o"),
+        out_sq.as_os_str(),
+    ]);
+    assert!(o.status.success(), "{}", String::from_utf8_lossy(&o.stderr));
+    assert!(
+        !out_sq.join("quant.genes.sf").exists(),
+        "--skipQuant must not write a zero-filled quant.genes.sf"
+    );
+    assert!(
+        String::from_utf8_lossy(&o.stderr).contains("gene-level aggregation (-g) skipped"),
+        "{}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+}


### PR DESCRIPTION
Stacked on #1155 (GitHub will retarget to `develop` when it merges). The ~20 accepted-but-inert flag×mode combinations from the #1140 audit, resolved under one rule: **a flag that does nothing must say so** — and where the fix was as cheap as the warning, it acts instead.

## Now acting (real fixes)

- **`--dumpBiasModels` works on every RAD/alignment path.** It silently vanished with the 2.6.0 flip: only the one-pass reads writer had a dump site, gated off by phase 1's `skip_quant`. The dump now lives in the shared output writer, fed by each pass's own `BiasDump` (which `quantify_rad` and `quantify_alignments` already build); forwarded via `requant_options` (field test extended), the `-a` branch, and the `--rad` block.
- **`--rad` forwards `--numGCBins`/`--conditionalGCBins`/`--biasSpeedSamp`/`--noBiasLengthThreshold`** — the same omission class `requant_options` was built to end, recurring in the `--rad` block while `--gcBias` itself was wired.
- **`--genome`/`--juncMissDiscount` without `--annotation` are clap errors** (`requires`), not silently dead flags.
- **Genome-projection `--skipQuant` applies the deliverable rule (#1149):** the projected RAD is the run's only output, so it lands in the output directory under its stable name and is kept — previously a "successful" run deleted it and left the output directory empty.
- **`-g` under `--skipQuant` no longer writes a zero-filled `quant.genes.sf`** (while announcing success) on the alignment/RAD/online paths; it logs why it skipped, matching the deterministic reads driver. All six drivers now behave identically.

## Now saying so (warn-by-name)

- **Sketch mode names every selective-alignment knob it ignores**: `--ma/--mp/--go/--ge`, `--minScoreFraction`, `--fullLengthAlignment`, `--orphanChainSubThresh`, `--discardOrphansQuasi`, `--orphansRequireUnmappedMate`, `--sparseSeeds`/`--refMEMs`/`--uniMEMs`. The valued knobs are Option-typed (defaults applied at wiring) so "explicitly passed" is detectable — the #1150 pattern. `--sketchStrictOrphans` without `--sketch` warns in reverse.
- **`--online` in `--rad` mode tells the truth**: it says a RAD is always quantified offline instead of promising the one-pass path, and it no longer suppresses the online-knob inertness warning — `--rad X --online -f 0.9` used to drop `-f` silently behind a misleading deprecation notice.
- **RAD-shaping flags** (`--writeRad`/`--keepRad`/`--radScratchDir`/`--radCompress`/`--noCompressRad`) warn on the two paths that write no RAD (online `-a`, `--rad` input); `--radCompress` is Option-typed for it.
- **`--writeUnmappedNames`** warns in `-a` and `--rad` modes — only the reads mapper tracks per-read mapping failures.

## Verified stale (no change needed)

`--dumpEq`/`--dumpEqWeights` in `-a`/`--rad` and the `--skipQuant --dumpEq` warning were already fixed by the #1147 follow-ons; the audit entries predate them.

## Tests

`flag_matrix.rs` drives one index through every row end-to-end: `bias_models.txt` exists on the default path (fails on develop), sketch warns by name with two non-warning controls, `--rad --online` surfaces both truths and the un-suppressed knob warning, clap rejects orphaned `--genome`, and `--skipQuant -g` skips with its reason and no gene file. Full workspace suite 318/0, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs