### PR TITLE
fix: bound bias correction by the decoy boundary, and detect it if the assumption breaks

### DIFF
--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -1949,8 +1949,25 @@ fn coordinate_sorted_unusable(header: &noodles_sam::Header) -> bool {
 /// abundances differs (online posteriors for BAM; fixed baked/derived abundances
 /// for RAD). The caller runs the subsequent re-EM with the corrected lengths.
 #[allow(clippy::too_many_arguments)]
+/// Bias-correct the effective lengths in place.
+///
+/// `num_targets` is the end of the quantification targets: the decoy block,
+/// when there is one, is the contiguous tail `[num_targets, num_refs)`. Every
+/// expected-bias model and the per-reference effective-length sweep stop
+/// there.
+///
+/// Decoys are never expressed, so an abundance guard already skips them in
+/// practice; bounding the range as well is what makes that a *guarantee*
+/// rather than a consequence — [`salmon_model::build_expected`]'s own contract
+/// says as much, and the reads one-pass path has always passed this bound.
+/// Without it, a decoy that picked up any abundance would drag a whole
+/// genome-scale chromosome (up to ~250 Mb) through an O(refLen) sweep, which
+/// single-threads the dominant phase of the run: issue #1019, fixed for
+/// one-pass by PR #1020 and applied here to every RAD-based path — which, as
+/// of 2.6.0, is the default (#1140 follow-up).
 fn apply_bias_correction(
     num_refs: usize,
+    num_targets: usize,
     ref_bytes: &salmon_core::RefSeqs,
     gc_store: &salmon_model::GcStore<'_>,
     lengths: &[u32],
@@ -1983,7 +2000,7 @@ fn apply_bias_correction(
         of.normalize();
         or.normalize();
         let (ef, er) =
-            salmon_model::build_expected(num_refs, refseq_of, alphas, eff_lengths, &fld_cdf);
+            salmon_model::build_expected(num_targets, refseq_of, alphas, eff_lengths, &fld_cdf);
         (of, or, ef, er)
     });
     if let Some((of, or, ef, er)) = seq.as_ref() {
@@ -2003,7 +2020,7 @@ fn apply_bias_correction(
     });
     let gc_ratio_model = if let Some(mut obs) = gc_obs {
         let mut exp = salmon_model::build_expected_gc(
-            num_refs,
+            num_targets,
             refseq_of,
             |t| gc_store.view(t),
             alphas,
@@ -2033,7 +2050,7 @@ fn apply_bias_correction(
             x.finalize();
         }
         let (ef, er) = salmon_model::build_expected_pos(
-            num_refs,
+            num_targets,
             |t| lengths[t] as usize,
             alphas,
             eff_lengths,
@@ -2061,7 +2078,10 @@ fn apply_bias_correction(
         .par_iter_mut()
         .enumerate()
         .for_each(|(tid, eff_length)| {
-            if alphas[tid] < 1e-8 {
+            // Decoys keep their uncorrected effective length: they are never
+            // reported, so the corrected value would be unused, and computing
+            // it is the #1019 stall. Same guard the one-pass path applies.
+            if tid >= num_targets || alphas[tid] < 1e-8 {
                 return;
             }
             let s = &ref_bytes[tid];
@@ -2437,6 +2457,9 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
     if bias_on && !opts.skip_quant {
         bias_dump = apply_bias_correction(
             num_refs,
+            // Alignment input: the @SQ references are the quantification
+            // targets; a BAM carries no decoy block.
+            num_refs,
             &ref_bytes,
             &gc_store,
             &lengths,
@@ -2610,6 +2633,61 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
     Ok(result)
 }
 
+/// Guard the assumption that the references we omit from `quant.sf` hold no
+/// abundance.
+///
+/// Every reference excluded here is a decoy, and decoys are supposed to be
+/// unreachable by the estimator: reads mode drops decoy placements before the
+/// RAD is written, and piscem never indexes decoys as references at all (its
+/// `--decoy-paths` build a poison-k-mer table used to reject reads, so no RAD
+/// record can point at a decoy). Both are *upstream* invariants, enforced by
+/// code this function cannot see.
+///
+/// If either is ever violated, the failure is silent and nasty: TPM is
+/// normalized over every reference and the rows are filtered afterward, so mass
+/// landing on an excluded reference simply disappears — `quant.sf`'s TPM stops
+/// summing to 1e6 and its NumReads stops summing to the mapped count, with
+/// nothing in the output saying why. This exists so that shows up as a loud
+/// warning naming the references, instead of as a quiet discrepancy someone
+/// has to reverse-engineer months later (#1140 follow-up; the reasoning is in
+/// `rad.rs`'s `num_targets`).
+fn warn_mass_on_unreported_refs(res: &AlignQuantResult, rows: &[usize]) {
+    if rows.len() == res.names.len() {
+        return; // nothing excluded
+    }
+    let reported: std::collections::HashSet<usize> = rows.iter().copied().collect();
+    let mut held = 0.0f64;
+    let mut worst: Vec<(String, f64)> = Vec::new();
+    for (i, &c) in res.counts.iter().enumerate() {
+        if reported.contains(&i) || c <= 0.0 {
+            continue;
+        }
+        held += c;
+        if worst.len() < 5 {
+            worst.push((res.names[i].clone(), c));
+        }
+    }
+    // A hair of mass can land on a decoy through floating-point redistribution
+    // without meaning the invariant broke; a whole fragment cannot.
+    if held < 1.0 {
+        return;
+    }
+    let shown = worst
+        .iter()
+        .map(|(n, c)| format!("{n} ({c:.2})"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    tracing::warn!(
+        "{held:.2} fragments of abundance landed on {} reference(s) that are excluded from \
+         quant.sf (decoys), so the reported NumReads and TPM columns do not account for them \
+         (e.g. {shown}). This should be impossible — decoy placements are dropped before the \
+         RAD is written, and piscem does not index decoys as references — so it means an \
+         upstream invariant changed. Please report this, with the command line, at \
+         https://github.com/COMBINE-lab/salmon/issues",
+        res.names.len() - rows.len()
+    );
+}
+
 fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()> {
     let dir = &opts.output_dir;
     std::fs::create_dir_all(dir.join("aux_info")).context("creating output dirs")?;
@@ -2634,6 +2712,7 @@ fn write_outputs(opts: &AlignQuantOptions, res: &AlignQuantResult) -> Result<()>
         .unwrap_or((None, 0));
     let rows: Vec<usize> =
         salmon_core::quant_row_indices(res.names.len(), first_decoy, num_decoys).collect();
+    warn_mass_on_unreported_refs(res, &rows);
 
     // quant.sf (EffectiveLength + NumReads at --sigDigits decimals; TPM at 6).
     // Skipped under --skipQuant (no abundances), like salmon.

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -43,8 +43,10 @@
 //!
 //! v1 scope: no sequence/GC/positional bias correction (RAD carries no read
 //! sequences; bias would need `-t`, the expected-model machinery, and the baked
-//! `initial_abundances`) and no decoy filtering for piscem RAD (salmon RAD already
-//! excludes decoys at write time). These are tracked follow-ups.
+//! `initial_abundances`). Decoys need no filtering here: a salmon RAD excludes
+//! decoy placements at write time *and* names the decoy block in its header, and
+//! a piscem RAD has no decoy references at all (piscem turns decoy sequence into
+//! poison k-mers rather than indexing it). See `num_targets` below.
 
 use std::fs::File;
 use std::io::BufReader;
@@ -1709,6 +1711,26 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
     let names: Vec<String> = prelude.hdr.ref_names.clone();
     let lengths = ref_lengths_from_tags(&prelude, &file_tag_map)?;
     let num_refs = names.len();
+    // End of the quantification targets. A salmon-written RAD names the decoy
+    // block in its header (`FIRST_DECOY_INDEX_TAG`, written since #1140's
+    // output-contract work); anything else — a piscem RAD in particular — has
+    // no decoy references *by construction*, so every reference is a target.
+    //
+    // ASSUMPTION, recorded deliberately: piscem never emits a decoy hit,
+    // because piscem does not index decoys as references at all. Its
+    // `--decoy-paths` feed `build_poison_table`, which turns decoy sequence
+    // into poison k-mers used to *reject* reads; decoy sequences never enter
+    // the reference table, so no RAD record can point at one. If that ever
+    // changes, the symptom will be mass assigned to references that are then
+    // excluded from `quant.sf` — which `warn_mass_on_unreported_refs` in the
+    // shared writer detects and reports, rather than letting it vanish
+    // silently.
+    let num_targets = provenance
+        .index
+        .as_ref()
+        .and_then(|ix| ix.first_decoy_index)
+        .map(|i| (i as usize).min(num_refs))
+        .unwrap_or(num_refs);
     anyhow::ensure!(num_refs > 0, "RAD file has no reference sequences");
     anyhow::ensure!(
         lengths.len() == num_refs,
@@ -2099,6 +2121,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             .expect("fused bias observations imply up-front abundances");
         bias_dump = crate::apply_bias_correction(
             num_refs,
+            num_targets,
             &ref_bytes,
             &gc_store,
             &lengths,
@@ -2176,6 +2199,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
             };
             bias_dump = crate::apply_bias_correction(
                 num_refs,
+                num_targets,
                 &ref_bytes,
                 &gc_store,
                 &lengths,

--- a/crates/salmon-cli/tests/decoy_bias.rs
+++ b/crates/salmon-cli/tests/decoy_bias.rs
@@ -1,0 +1,144 @@
+//! Decoys must be excluded from the reported rows *and* cost no bias-correction
+//! work (#1140 follow-up). Lives in salmon-cli because it drives the real
+//! binary end to end: `CARGO_BIN_EXE_salmon` is only defined for tests in the
+//! crate that builds the binary.
+
+use std::process::Command;
+
+const SALMON: &str = env!("CARGO_BIN_EXE_salmon");
+
+/// The end-to-end guarantee: a decoy-aware index quantified through the
+/// DEFAULT (deterministic) reads path must exclude decoys from `quant.sf`,
+/// conserve mass over the reported rows, and — with bias correction on — must
+/// not spend any work on decoy references.
+///
+/// The mass assertions are the ones that would catch a regression in the bias
+/// bound turning into a silent accounting error: TPM is normalized over every
+/// reference and rows are filtered afterward, so if a decoy ever held
+/// abundance, these sums would drift without anything else complaining.
+#[test]
+fn decoys_are_excluded_and_mass_is_conserved_with_bias() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // gentrome: 3 transcripts + a decoy that CONTAINS a verbatim copy of txA,
+    // the processed-pseudogene case decoys exist for — so the decoy is a
+    // genuine competitor for txA's reads rather than inert filler.
+    let mut s: u64 = 0x2545_F491_4F6C_DD1D;
+    let mut base = || {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        b"ACGT"[(s >> 33) as usize & 3] as char
+    };
+    let mk = |n: usize, f: &mut dyn FnMut() -> char| (0..n).map(|_| f()).collect::<String>();
+    let (txa, txb, txc) = (
+        mk(3000, &mut base),
+        mk(3000, &mut base),
+        mk(2000, &mut base),
+    );
+    let decoy = format!("{}{}{}", mk(20000, &mut base), txa, mk(20000, &mut base));
+    let fasta = dir.path().join("gentrome.fa");
+    std::fs::write(
+        &fasta,
+        format!(">txA\n{txa}\n>txB\n{txb}\n>txC\n{txc}\n>decoy1\n{decoy}\n"),
+    )
+    .unwrap();
+    let decoys = dir.path().join("decoys.txt");
+    std::fs::write(&decoys, "decoy1\n").unwrap();
+
+    let rc = |x: &str| -> String {
+        x.chars()
+            .rev()
+            .map(|c| match c {
+                'A' => 'T',
+                'C' => 'G',
+                'G' => 'C',
+                _ => 'A',
+            })
+            .collect()
+    };
+    let (mut r1, mut r2) = (String::new(), String::new());
+    let q = "I".repeat(100);
+    for i in 0..600 {
+        let src = [&txa, &txb, &txc][i % 3];
+        let st = (i * 11) % (src.len() - 350);
+        r1.push_str(&format!("@f{i}\n{}\n+\n{q}\n", &src[st..st + 100]));
+        r2.push_str(&format!(
+            "@f{i}\n{}\n+\n{q}\n",
+            rc(&src[st + 200..st + 300])
+        ));
+    }
+    let (p1, p2) = (dir.path().join("r1.fq"), dir.path().join("r2.fq"));
+    std::fs::write(&p1, r1).unwrap();
+    std::fs::write(&p2, r2).unwrap();
+
+    let index = dir.path().join("idx");
+    assert!(Command::new(SALMON)
+        .args(["index", "-t"])
+        .arg(&fasta)
+        .arg("-d")
+        .arg(&decoys)
+        .arg("-i")
+        .arg(&index)
+        .args(["-p", "2"])
+        .status()
+        .unwrap()
+        .success());
+
+    let out = dir.path().join("q");
+    let run = Command::new(SALMON)
+        .args(["quant", "-i"])
+        .arg(&index)
+        .args(["-l", "IU", "-1"])
+        .arg(&p1)
+        .arg("-2")
+        .arg(&p2)
+        .args(["--seqBias", "--gcBias", "-p", "2", "-o"])
+        .arg(&out)
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+
+    let sf = std::fs::read_to_string(out.join("quant.sf")).unwrap();
+    let rows: Vec<Vec<&str>> = sf
+        .lines()
+        .skip(1)
+        .map(|l| l.split('\t').collect())
+        .collect();
+    assert_eq!(rows.len(), 3, "decoy must not get a quant.sf row: {sf}");
+    assert!(
+        !sf.contains("decoy"),
+        "no decoy may appear in quant.sf: {sf}"
+    );
+
+    let tpm: f64 = rows.iter().map(|r| r[3].parse::<f64>().unwrap()).sum();
+    assert!(
+        (tpm - 1e6).abs() < 1.0,
+        "TPM over the reported rows must sum to 1e6, got {tpm} — mass on an \
+         excluded decoy is exactly how this drifts"
+    );
+    let reads: f64 = rows.iter().map(|r| r[4].parse::<f64>().unwrap()).sum();
+    let meta = std::fs::read_to_string(out.join("aux_info").join("meta_info.json")).unwrap();
+    let mapped: f64 = meta
+        .lines()
+        .find(|l| l.contains("\"num_mapped\""))
+        .and_then(|l| l.rsplit(':').next())
+        .map(|v| v.trim().trim_end_matches(',').parse().unwrap())
+        .expect("num_mapped in meta_info.json");
+    assert!(
+        (reads - mapped).abs() < 1.0,
+        "NumReads over reported rows ({reads}) must account for every mapped \
+         fragment ({mapped})"
+    );
+
+    // The invariant guard must stay silent on a healthy run.
+    let err = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        !err.contains("excluded from quant.sf"),
+        "the unreported-mass guard must not fire here: {err}"
+    );
+}


### PR DESCRIPTION
Item 1 from your question, plus the assumption you asked to have documented.

## The bound

The one-pass reads path computes `num_targets = first_decoy_index` and passes it to all three expected-bias model builders *and* the per-reference `corrected_effective_length_full` sweep. The shared `apply_bias_correction` — used by deterministic phase 2, deterministic `-a`, `--rad` and genome projection, i.e. **every default path since 2.6.0** — passed `num_refs` to all four, guarding the sweep only on `alphas[tid] < 1e-8`. The boundary was already available there; #1153 bakes it into the RAD header and `rad.rs` loads it. It just was never threaded in.

`build_expected`'s own contract says why this matters: the abundance guard is defense in depth, the range bound is what *guarantees* "no O(refLen) decoy sweep can ever run". Without it a decoy with any abundance drags a genome-scale chromosome (up to ~250 Mb) through a single-threaded sweep of the run's dominant phase — issue #1019, fixed for one-pass by PR #1020.

**Not currently reachable, and I checked rather than assumed.** Reads mode drops decoy placements before the RAD is written, so decoys always end with alpha 0. I built the case that should trigger it — a 28 Mb decoy chromosome containing verbatim copies of 20 of 200 transcripts, the processed-pseudogene scenario decoys exist for — and measured 0.18 s default vs 0.17 s `--online` with `--seqBias --gcBias`. So this restores a guarantee; it does not fix an observed stall.

## The assumption, recorded and made detectable

You said piscem never puts decoy-mapping reads in the RAD. That's right, and by a stronger mechanism than "they're filtered": **piscem does not index decoys as references at all.** `--decoy-paths` feed `build_poison_table` in both `piscem` and `piscem-rs`, turning decoy sequence into poison k-mers used to *reject* reads — so no RAD record can point at a decoy, because decoys aren't in the reference table. `rad.rs`'s module docs claimed decoy filtering for piscem RADs was a "tracked follow-up", implying a gap that cannot exist; corrected.

Both invariants (salmon's write-time filter, piscem's poison design) are enforced upstream and invisible from the bias code, so a comment alone would rot. If either broke, the failure would be silent and nasty: TPM is normalized over every reference and rows are filtered afterward, so mass landing on an excluded reference simply disappears — `quant.sf` stops summing to 1e6 and to the mapped count, with nothing saying why.

`warn_mass_on_unreported_refs` turns that into a loud warning naming the offending references and asking for a report. It's the symptom-level check, so it covers both invariants without depending on either.

## Test

Pins the contract end to end on a decoy-aware index with bias on: three rows, no decoy, TPM exactly 1e6, NumReads accounting for every mapped fragment, and the guard silent on a healthy run.

Suite **317/0**, clippy clean. Independent of #1160 — different files, either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs