### PR TITLE
fix(group 3): detect incompatible flag combinations at invocation

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -400,7 +400,10 @@ struct QuantArgs {
     #[arg(short = 't', long = "targets")]
     targets: Option<PathBuf>,
     /// Disable the alignment error model (alignment mode).
-    #[arg(long = "noErrorModel")]
+    /// Direct opposite of `--errorModel`; passing both was resolved by silent
+    /// precedence (`--noErrorModel` won) and salmon then advised passing
+    /// `--errorModel`, which was already on the command line (#1140).
+    #[arg(long = "noErrorModel", conflicts_with = "error_model")]
     no_error_model: bool,
     /// Opt in to the order-independent alignment error model in deterministic
     /// mode (`-a --deterministic`, requires `-t`). Off by default: deterministic
@@ -414,7 +417,18 @@ struct QuantArgs {
     /// salmon projects the spliced genome alignments into transcriptome
     /// coordinates (via bramble) and quantifies the projected placements. The
     /// transcript set is taken from the annotation.
-    #[arg(long = "annotation", value_name = "GTF|GFF")]
+    /// Genome projection is reachable only through `-a <genome.bam>`, so
+    /// without it the whole request — annotation, genome and junction discount
+    /// — was dropped without a word, and the paths were never even checked for
+    /// existence. `--genome`/`--juncMissDiscount` already required this flag;
+    /// this closes the chain (#1140).
+    ///
+    /// The `requires` below is necessary but not sufficient: clap skips a
+    /// `requires` when the required argument conflicts with one already
+    /// present, and `-1/-2`, `-r` and `--rad` all conflict with `-a` — which is
+    /// precisely how a user gets here. `run_quant` therefore checks it
+    /// explicitly as well.
+    #[arg(long = "annotation", value_name = "GTF|GFF", requires = "alignments")]
     annotation: Option<PathBuf>,
     // `--genome` / `--juncMissDiscount` are read only by the genome-projection
     // branch, which `--annotation` selects; without it they were silently
@@ -632,8 +646,11 @@ struct QuantArgs {
     )]
     num_gibbs_samples: u32,
     /// Gibbs thinning factor.
-    #[arg(long = "thinningFactor", default_value_t = 16)]
-    thinning_factor: u32,
+    /// Option-typed (default 16 at use) so passing it without Gibbs sampling
+    /// can be reported rather than silently doing nothing — the sibling
+    /// `--bamCompressThreads` without `--writeBam` already hard-errors.
+    #[arg(long = "thinningFactor")]
+    thinning_factor: Option<u32>,
     /// (Long reads) Oxford Nanopore model — not supported; use oarfish instead.
     #[arg(long = "ont")]
     ont: bool,
@@ -2043,6 +2060,17 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             args.decoy_threshold.unwrap_or(1.0)
         );
     }
+    // Genome projection lives inside the `-a` branch, so `--annotation` without
+    // it silently discards the entire request. clap's `requires` does not fire
+    // for the cases that matter (see the flag's doc comment), so check here.
+    if args.annotation.is_some() && args.alignments.is_none() {
+        anyhow::bail!(
+            "--annotation selects genome-projection mode, which reads a genome BAM: pass it \
+             together with `-a <genome.bam>`. With FASTQ or --rad input there is nothing to \
+             project, and the annotation would be ignored."
+        );
+    }
+
     // `--noLengthCorrection` and bias correction cannot both apply: every
     // driver computes `bias_on = (seq||gc||pos) && !no_length_correction`, so
     // the bias request was silently discarded — and `meta_info.json` went on
@@ -2242,7 +2270,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.num_pre_aux_model_samples = args.num_pre_aux_model_samples.unwrap_or(5_000);
         opts.num_bootstraps = args.num_bootstraps;
         opts.num_gibbs_samples = args.num_gibbs_samples;
-        opts.thinning_factor = args.thinning_factor;
+        opts.thinning_factor = args.thinning_factor.unwrap_or(16);
         // --scoreExp scales the best-minus-score soft weight, and the RAD
         // quantifier applies it to AS-scored placements exactly as it does to
         // selective-alignment ones — so the deterministic `-a` path honours it.
@@ -2498,7 +2526,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         opts.no_frag_length_dist = args.no_frag_length_dist;
         opts.num_bootstraps = args.num_bootstraps;
         opts.num_gibbs_samples = args.num_gibbs_samples;
-        opts.thinning_factor = args.thinning_factor;
+        opts.thinning_factor = args.thinning_factor.unwrap_or(16);
         let res = quantify_rad(&opts, &rad_path).context("RAD-input quantification failed")?;
         let pct = if res.num_processed > 0 {
             100.0 * res.num_mapped as f64 / res.num_processed as f64
@@ -2590,6 +2618,31 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             ],
         );
     }
+    // Posterior sampling happens inside the quantification pass, so
+    // `--skipQuant` and it cannot both be honoured. The sibling cases
+    // (`--skipQuant --dumpEq`, `--skipQuant -g`) both explain themselves;
+    // these two were discarded in silence (#1140).
+    if args.skip_quant {
+        warn_inert_in_mode(
+            "a --skipQuant run",
+            "posterior sampling happens inside the quantification pass that --skipQuant \
+             skips (quantify the kept RAD with --rad to draw samples from it)",
+            &[
+                ("--numBootstraps", args.num_bootstraps > 0),
+                ("--numGibbsSamples", args.num_gibbs_samples > 0),
+            ],
+        );
+    }
+    // `--thinningFactor` thins a Gibbs chain; with no chain there is nothing to
+    // thin. The analogous `--bamCompressThreads` without `--writeBam` errors,
+    // and this said nothing at all.
+    if args.thinning_factor.is_some() && args.num_gibbs_samples == 0 {
+        warn_inert_in_mode(
+            "a run without Gibbs sampling",
+            "it thins a Gibbs chain, which needs --numGibbsSamples",
+            &[("--thinningFactor", true)],
+        );
+    }
     // Bias sub-knobs tune a model that only exists when bias correction is on.
     if !(args.seq_bias || args.gc_bias || args.pos_bias) {
         warn_inert_in_mode(
@@ -2672,7 +2725,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     };
     opts.num_bootstraps = args.num_bootstraps;
     opts.num_gibbs_samples = args.num_gibbs_samples;
-    opts.thinning_factor = args.thinning_factor;
+    opts.thinning_factor = args.thinning_factor.unwrap_or(16);
     opts.no_length_correction = args.no_length_correction;
     opts.model_single_frag_prob = !args.no_single_frag_prob;
     opts.no_frag_length_dist = args.no_frag_length_dist;

--- a/crates/salmon-cli/tests/input_validation.rs
+++ b/crates/salmon-cli/tests/input_validation.rs
@@ -317,3 +317,175 @@ fn a_truncated_fastq_is_refused_rather_than_partially_quantified() {
         "intact FASTQ must run"
     );
 }
+
+// ---- Group 3: incompatibilities detectable at invocation ------------------
+
+/// Genome projection lives inside the `-a` branch, so `--annotation` with any
+/// other input silently discarded the whole request — annotation, genome and
+/// junction discount — without even checking the paths exist.
+///
+/// clap's `requires` is necessary but not sufficient here, and the test covers
+/// why: clap skips a `requires` when the required argument conflicts with one
+/// already present, and `-1/-2`, `-r` and `--rad` all conflict with `-a`. Those
+/// are exactly the ways a user gets here, so all three are exercised.
+#[test]
+fn annotation_requires_alignment_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let fx = fixture(dir.path());
+    let rad = dir.path().join("m.rad");
+    assert!(Command::new(SALMON)
+        .args(["quant", "-i"])
+        .arg(&fx.index)
+        .args(["-l", "IU", "-1"])
+        .arg(&fx.r1)
+        .arg("-2")
+        .arg(&fx.r2)
+        .args(["-p", "2", "--writeRad"])
+        .arg(&rad)
+        .arg("-o")
+        .arg(dir.path().join("seed"))
+        .status()
+        .unwrap()
+        .success());
+
+    let out = dir.path().join("q");
+    let gtf = dir.path().join("a.gtf");
+    std::fs::write(&gtf, "").unwrap();
+    let inputs: Vec<Vec<&std::ffi::OsStr>> = vec![
+        vec![
+            os("-i"),
+            fx.index.as_os_str(),
+            os("-1"),
+            fx.r1.as_os_str(),
+            os("-2"),
+            fx.r2.as_os_str(),
+        ],
+        vec![os("-i"), fx.index.as_os_str(), os("-r"), fx.se.as_os_str()],
+        vec![os("--rad"), rad.as_os_str()],
+    ];
+    for inp in inputs {
+        let mut v: Vec<&std::ffi::OsStr> = vec![os("quant")];
+        v.extend(inp.iter().copied());
+        v.extend([
+            os("-l"),
+            os("IU"),
+            os("--annotation"),
+            gtf.as_os_str(),
+            os("-p"),
+            os("2"),
+            os("-o"),
+            out.as_os_str(),
+        ]);
+        let o = run(&v);
+        assert!(
+            !o.status.success(),
+            "--annotation without -a must be refused, not silently dropped"
+        );
+        let err = String::from_utf8_lossy(&o.stderr);
+        assert!(
+            err.contains("--annotation") && (err.contains("-a") || err.contains("alignments")),
+            "the error must name both flags:\n{err}"
+        );
+    }
+}
+
+/// `--errorModel` and `--noErrorModel` are direct opposites; passing both was
+/// resolved by silent precedence, after which salmon advised passing
+/// `--errorModel` — already on the command line.
+#[test]
+fn error_model_flags_conflict() {
+    let dir = tempfile::tempdir().unwrap();
+    let fx = fixture(dir.path());
+    let sam = dir.path().join("a.sam");
+    std::fs::write(
+        &sam,
+        "@HD\tVN:1.6\tSO:queryname\n@SQ\tSN:txA\tLN:3000\n\
+         r0\t99\ttxA\t1\t60\t100M\t=\t201\t300\t*\t*\tAS:i:200\n\
+         r0\t147\ttxA\t201\t60\t100M\t=\t1\t-300\t*\t*\tAS:i:200\n",
+    )
+    .unwrap();
+    let _ = &fx;
+    let o = run(&[
+        os("quant"),
+        os("-a"),
+        sam.as_os_str(),
+        os("-l"),
+        os("IU"),
+        os("--errorModel"),
+        os("--noErrorModel"),
+        os("-o"),
+        dir.path().join("q").as_os_str(),
+    ]);
+    assert!(!o.status.success(), "opposite flags must conflict");
+    assert!(
+        String::from_utf8_lossy(&o.stderr).contains("cannot be used with"),
+        "{}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+}
+
+/// Posterior sampling happens inside the pass `--skipQuant` skips, and
+/// `--thinningFactor` thins a Gibbs chain that may not exist. Both were
+/// discarded in silence while their siblings explained themselves.
+#[test]
+fn requests_that_cannot_be_honoured_say_so() {
+    let dir = tempfile::tempdir().unwrap();
+    let fx = fixture(dir.path());
+    let out = dir.path().join("q");
+    let base: Vec<&std::ffi::OsStr> = vec![
+        os("quant"),
+        os("-i"),
+        fx.index.as_os_str(),
+        os("-l"),
+        os("IU"),
+        os("-1"),
+        fx.r1.as_os_str(),
+        os("-2"),
+        fx.r2.as_os_str(),
+        os("-p"),
+        os("2"),
+    ];
+
+    let mut v = base.clone();
+    v.extend([
+        os("--skipQuant"),
+        os("--numBootstraps"),
+        os("4"),
+        os("-o"),
+        out.as_os_str(),
+    ]);
+    let o = run(&v);
+    assert!(o.status.success());
+    let err = String::from_utf8_lossy(&o.stderr);
+    assert!(
+        err.contains("--numBootstraps") && err.contains("--skipQuant run"),
+        "--skipQuant must say it is discarding the posterior request:\n{err}"
+    );
+
+    let mut v = base.clone();
+    v.extend([os("--thinningFactor"), os("8"), os("-o"), out.as_os_str()]);
+    let o = run(&v);
+    assert!(o.status.success());
+    assert!(
+        String::from_utf8_lossy(&o.stderr).contains("--thinningFactor has no effect"),
+        "{}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+
+    // Control: with Gibbs actually running, --thinningFactor is silent.
+    let mut v = base.clone();
+    v.extend([
+        os("--numGibbsSamples"),
+        os("20"),
+        os("--thinningFactor"),
+        os("8"),
+        os("-o"),
+        out.as_os_str(),
+    ]);
+    let o = run(&v);
+    assert!(o.status.success());
+    assert!(
+        !String::from_utf8_lossy(&o.stderr).contains("--thinningFactor has no effect"),
+        "--thinningFactor must not warn when Gibbs sampling runs"
+    );
+}


### PR DESCRIPTION
**Group 3 of 4** (#1140). Each of these is fully known from the command line, and each was previously resolved by silently discarding one side. Stacked on #1164.

| Combination | Was | Now |
|---|---|---|
| `--annotation` without `-a` | Whole genome-projection request dropped silently; paths never even checked for existence | Errors, naming both flags |
| `--errorModel` + `--noErrorModel` | Silent precedence (`--noErrorModel` won) — then salmon advised passing `--errorModel`, already on the command line | clap conflict |
| `--skipQuant` + `--numBootstraps`/`--numGibbsSamples` | Discarded in silence, while sibling `--dumpEq` and `-g` both explain themselves | Warns, naming the recovery (quantify the kept RAD with `--rad`) |
| `--thinningFactor` without `--numGibbsSamples` | Silently inert; the analogous `--bamCompressThreads` without `--writeBam` already errors | Option-typed and warned |

## Worth knowing: `requires` was not enough

My first attempt at `--annotation` used clap's `requires = "alignments"` alone. It doesn't fire for the cases that matter: **clap skips a `requires` when the required argument conflicts with one already present**, and `-1/-2`, `-r` and `--rad` all conflict with `-a`. Those are exactly how a user reaches this mistake, so all three sailed through.

The `requires` is kept (it covers the no-other-input case and chains correctly from `--genome`), but the real enforcement is an explicit check. That check also had to move: my first placement sat inside the reads branch and missed `--rad`, which the test caught — the `--rad` branch dispatches earlier. It now runs before mode dispatch, alongside the other invocation-time validations.

Both facts are recorded in comments at the site, since the next person to add a `requires` in this file will hit the same thing.

Suite **331/0**, clippy clean. Group 4 next; Group 5 tracked in #1162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs