### PR TITLE
docs: measured 2.6.0 figures, EM architecture briefing, and strong types for the init/eff-lens footgun

### DIFF
--- a/crates/salmon-align/src/bam_rad.rs
+++ b/crates/salmon-align/src/bam_rad.rs
@@ -256,7 +256,12 @@ pub fn write_alignment_rad(
         ro.min_iter = opts.bias_seed_em_iters;
         ro.max_iter = opts.bias_seed_em_iters;
         ro.min_alpha = 0.0;
-        let em = salmon_infer::optimize(&collapsed, num_refs, &ro, Some(&eff_lengths));
+        let em = salmon_infer::optimize(
+            &collapsed,
+            num_refs,
+            &ro,
+            salmon_infer::EffLens::new(&eff_lengths),
+        );
         writer.set_initial_abundances(&em.alphas);
     }
 

--- a/crates/salmon-align/src/genome_project.rs
+++ b/crates/salmon-align/src/genome_project.rs
@@ -226,7 +226,12 @@ pub fn project_genome_bam_to_rad(
         ro.min_iter = opts.bias_seed_em_iters;
         ro.max_iter = opts.bias_seed_em_iters;
         ro.min_alpha = 0.0;
-        let em = salmon_infer::optimize(&collapsed, num_refs, &ro, Some(&eff_lengths));
+        let em = salmon_infer::optimize(
+            &collapsed,
+            num_refs,
+            &ro,
+            salmon_infer::EffLens::new(&eff_lengths),
+        );
         writer.set_initial_abundances(&em.alphas);
     }
     // Bake the pass counters so the requant's meta_info.json reports this

--- a/crates/salmon-align/src/lib.rs
+++ b/crates/salmon-align/src/lib.rs
@@ -2458,14 +2458,23 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             dropped_mass: 0.0,
         }
     } else if opts.init_uniform {
-        salmon_infer::optimize_packed_with_init(&packed, &opts.em, true, None, Some(&eff_lengths))
+        salmon_infer::optimize_packed_with_init(
+            &packed,
+            &opts.em,
+            true,
+            salmon_infer::InitAlphas::NONE,
+            salmon_infer::EffLens::new(&eff_lengths),
+        )
     } else {
         salmon_infer::optimize_packed_with_init(
             &packed,
             &opts.em,
             true,
-            init_alphas.as_deref(),
-            Some(&eff_lengths),
+            init_alphas.as_deref().map_or(
+                salmon_infer::InitAlphas::NONE,
+                salmon_infer::InitAlphas::new,
+            ),
+            salmon_infer::EffLens::new(&eff_lengths),
         )
     };
 
@@ -2501,8 +2510,8 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
             &packed,
             &opts.em,
             true,
-            None,
-            Some(&eff_lengths),
+            salmon_infer::InitAlphas::NONE,
+            salmon_infer::EffLens::new(&eff_lengths),
         );
     }
     let inference_truncated_mass = em.dropped_mass;
@@ -2583,7 +2592,7 @@ pub fn quantify_alignments(opts: &AlignQuantOptions) -> Result<AlignQuantResult>
         salmon_infer::bootstrap(
             &packed,
             &opts.em,
-            Some(&eff_lengths),
+            salmon_infer::EffLens::new(&eff_lengths),
             opts.num_bootstraps,
             0x5A13_0000,
         )

--- a/crates/salmon-align/src/rad.rs
+++ b/crates/salmon-align/src/rad.rs
@@ -1968,7 +1968,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         ro.min_iter = opts.bias_seed_em_iters;
         ro.max_iter = opts.bias_seed_em_iters;
         ro.min_alpha = 0.0;
-        salmon_infer::optimize(&c, num_refs, &ro, Some(&eff_lengths)).alphas
+        salmon_infer::optimize(&c, num_refs, &ro, salmon_infer::EffLens::new(&eff_lengths)).alphas
     });
 
     // Reference-derived inputs for bias correction (built only when a bias model
@@ -2211,14 +2211,20 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         );
         collapsed.update_eff_lengths(&eff_lengths);
         packed.refresh_combined(&collapsed);
-        salmon_infer::optimize_packed_with_init(&packed, &opts.em, true, None, Some(&eff_lengths))
+        salmon_infer::optimize_packed_with_init(
+            &packed,
+            &opts.em,
+            true,
+            salmon_infer::InitAlphas::NONE,
+            salmon_infer::EffLens::new(&eff_lengths),
+        )
     } else {
         let mut em = salmon_infer::optimize_packed_with_init(
             &packed,
             &opts.em,
             true,
-            None,
-            Some(&eff_lengths),
+            salmon_infer::InitAlphas::NONE,
+            salmon_infer::EffLens::new(&eff_lengths),
         );
         if bias_on {
             // Abundances weighting bias collection: baked prior if present, else
@@ -2295,8 +2301,8 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
                 &packed,
                 &opts.em,
                 true,
-                None,
-                Some(&eff_lengths),
+                salmon_infer::InitAlphas::NONE,
+                salmon_infer::EffLens::new(&eff_lengths),
             );
         }
         em
@@ -2338,7 +2344,7 @@ pub fn quantify_rad(opts: &AlignQuantOptions, rad_path: &Path) -> Result<AlignQu
         salmon_infer::bootstrap(
             &packed,
             &opts.em,
-            Some(&eff_lengths),
+            salmon_infer::EffLens::new(&eff_lengths),
             opts.num_bootstraps,
             0x5A13_0000,
         )

--- a/crates/salmon-infer/src/lib.rs
+++ b/crates/salmon-infer/src/lib.rs
@@ -66,6 +66,87 @@ pub enum EmAccel {
     Daarem,
 }
 
+/// Effective lengths, one per transcript, or their absence.
+///
+/// A newtype rather than a bare `Option<&[f64]>` because it sits directly beside
+/// [`InitAlphas`] in several signatures and the two are structurally identical:
+/// swapping them type-checks and compiles silently. That is not hypothetical —
+/// it shipped. The bootstrap path passed effective lengths into the
+/// `init_alphas` slot, which left `--perNucleotidePrior` inert inside every
+/// replicate (the prior stayed flat) *and* warm-started each replicate from the
+/// effective-length vector, which no caller intended. Reported spread was then
+/// drawn under a different prior than the point estimate it quantified.
+///
+/// Distinct types make that mistake a compile error. Zero-overhead: a newtype
+/// over `Option<&[f64]>` has identical layout and the accessor inlines away.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EffLens<'a>(Option<&'a [f64]>);
+
+impl<'a> EffLens<'a> {
+    /// No effective lengths supplied — priors stay flat, weights are used as-is.
+    pub const NONE: Self = Self(None);
+
+    pub fn new(v: &'a [f64]) -> Self {
+        Self(Some(v))
+    }
+
+    /// Borrow the slice, if any. Deliberately not `Deref`/`Into<Option<..>>`:
+    /// an implicit conversion back to the bare type would reopen the hole.
+    pub(crate) fn get(self) -> Option<&'a [f64]> {
+        self.0
+    }
+}
+
+impl<'a> From<&'a [f64]> for EffLens<'a> {
+    fn from(v: &'a [f64]) -> Self {
+        Self::new(v)
+    }
+}
+
+/// An initial abundance vector to warm-start the optimizer from, or its absence
+/// (in which case the optimizer starts uniform).
+///
+/// See [`EffLens`] for why this is a newtype. The swap that motivated it no
+/// longer compiles:
+///
+/// ```compile_fail
+/// use salmon_infer::{EffLens, InitAlphas};
+/// fn takes(_init: InitAlphas<'_>, _eff: EffLens<'_>) {}
+/// let v = [1.0f64, 2.0];
+/// // Arguments in the wrong order — a type error now, silent before.
+/// takes(EffLens::new(&v), InitAlphas::new(&v));
+/// ```
+#[derive(Clone, Copy, Debug, Default)]
+pub struct InitAlphas<'a>(Option<&'a [f64]>);
+
+impl<'a> InitAlphas<'a> {
+    /// Start uniform — the least presumptuous initialization, and the default
+    /// on every reads-mode path.
+    pub const NONE: Self = Self(None);
+
+    pub fn new(v: &'a [f64]) -> Self {
+        Self(Some(v))
+    }
+
+    pub(crate) fn get(self) -> Option<&'a [f64]> {
+        self.0
+    }
+}
+
+impl<'a> From<&'a [f64]> for InitAlphas<'a> {
+    fn from(v: &'a [f64]) -> Self {
+        Self::new(v)
+    }
+}
+
+// The "zero-overhead" in the two types above is a claim, so it is checked: a
+// newtype over `Option<&[f64]>` must have identical layout, or the wrappers are
+// costing something at every call.
+const _: () = assert!(
+    core::mem::size_of::<EffLens<'_>>() == core::mem::size_of::<Option<&[f64]>>()
+        && core::mem::size_of::<InitAlphas<'_>>() == core::mem::size_of::<Option<&[f64]>>()
+);
+
 /// Optimizer configuration. Defaults mirror salmon's command-line defaults.
 #[derive(Debug, Clone)]
 pub struct EmOptions {
@@ -164,10 +245,10 @@ pub fn optimize(
     eq: &CollapsedEqClasses,
     num_txps: usize,
     opts: &EmOptions,
-    eff_lens: Option<&[f64]>,
+    eff_lens: EffLens<'_>,
 ) -> EmResult {
     let packed = PackedEqClasses::from_collapsed(eq, num_txps);
-    optimize_packed_with_init(&packed, opts, true, None, eff_lens)
+    optimize_packed_with_init(&packed, opts, true, InitAlphas::NONE, eff_lens)
 }
 
 /// As [`optimize`], but warm-starts the abundances from `init_alphas` (per
@@ -181,8 +262,8 @@ pub fn optimize_with_init(
     eq: &CollapsedEqClasses,
     num_txps: usize,
     opts: &EmOptions,
-    init_alphas: Option<&[f64]>,
-    eff_lens: Option<&[f64]>,
+    init_alphas: InitAlphas<'_>,
+    eff_lens: EffLens<'_>,
 ) -> EmResult {
     let packed = PackedEqClasses::from_collapsed(eq, num_txps);
     optimize_packed_with_init(&packed, opts, true, init_alphas, eff_lens)
@@ -197,7 +278,7 @@ pub fn optimize_with_init(
 /// Parallelizing at only one level is deliberate: nesting a parallel M-step
 /// inside parallel replicates would oversubscribe the machine and slow both down.
 pub fn optimize_packed(p: &PackedEqClasses, opts: &EmOptions, parallel: bool) -> EmResult {
-    optimize_packed_with_init(p, opts, parallel, None, None)
+    optimize_packed_with_init(p, opts, parallel, InitAlphas::NONE, EffLens::NONE)
 }
 
 /// As [`optimize_packed`], but seeds the abundances from `init_alphas` (a warm
@@ -207,8 +288,8 @@ pub fn optimize_packed_with_init(
     p: &PackedEqClasses,
     opts: &EmOptions,
     parallel: bool,
-    init_alphas: Option<&[f64]>,
-    eff_lens: Option<&[f64]>,
+    init_alphas: InitAlphas<'_>,
+    eff_lens: EffLens<'_>,
 ) -> EmResult {
     let (alphas, iters, converged) = run_em_counts(
         p,
@@ -240,10 +321,10 @@ pub fn optimize_packed_with_init(
 /// transcript offers, so a flat prior does not dominate short transcripts.
 pub(crate) fn prior_alphas_vec(
     opts: &EmOptions,
-    eff_lens: Option<&[f64]>,
+    eff_lens: EffLens<'_>,
     num_txps: usize,
 ) -> Vec<f64> {
-    match (opts.per_nucleotide_prior, eff_lens) {
+    match (opts.per_nucleotide_prior, eff_lens.get()) {
         // Only usable when effective lengths were supplied and line up; the
         // catch-all arm below falls back to the flat prior otherwise.
         (true, Some(el)) if el.len() == num_txps => {
@@ -263,7 +344,7 @@ pub(crate) fn finalize_truncate_redistribute(
     counts: &[u64],
     alphas: Vec<f64>,
     opts: &EmOptions,
-    eff_lens: Option<&[f64]>,
+    eff_lens: EffLens<'_>,
 ) -> (Vec<f64>, f64) {
     if opts.min_alpha <= 0.0 {
         return (alphas, 0.0);
@@ -282,8 +363,8 @@ pub(crate) fn run_em_counts(
     opts: &EmOptions,
     parallel: bool,
     min_iter: u32,
-    init_alphas: Option<&[f64]>,
-    eff_lens: Option<&[f64]>,
+    init_alphas: InitAlphas<'_>,
+    eff_lens: EffLens<'_>,
 ) -> (Vec<f64>, u32, bool) {
     let num_txps = p.num_txps;
     let total: u64 = counts.iter().sum();
@@ -297,7 +378,7 @@ pub(crate) fn run_em_counts(
     // Warm start from a supplied initialization (e.g. the online-phase abundance
     // estimates blended with uniform, matching salmon's count-blended init) when
     // its length matches; otherwise start uniform over the total fragment count.
-    let mut alphas = match init_alphas {
+    let mut alphas = match init_alphas.get() {
         Some(a) if a.len() == num_txps => a.to_vec(),
         _ => vec![init; num_txps],
     };
@@ -559,7 +640,7 @@ mod tests {
     fn unique_classes_recover_exact_counts() {
         // Two transcripts, only unique evidence: EM must return those counts.
         let eq = build(&[(vec![0], 30), (vec![1], 70)], 2);
-        let res = optimize(&eq, 2, &EmOptions::default(), None);
+        let res = optimize(&eq, 2, &EmOptions::default(), EffLens::NONE);
         assert!((res.alphas[0] - 30.0).abs() < 1e-6);
         assert!((res.alphas[1] - 70.0).abs() < 1e-6);
     }
@@ -573,7 +654,7 @@ mod tests {
         // current abundances; with equal eff lengths the stable split tracks
         // the unique ratio, so totals converge to 0.1*200=20 and 0.9*200=180.
         let eq = build(&[(vec![0], 10), (vec![1], 90), (vec![0, 1], 100)], 2);
-        let res = optimize(&eq, 2, &EmOptions::default(), None);
+        let res = optimize(&eq, 2, &EmOptions::default(), EffLens::NONE);
         let total = res.alphas[0] + res.alphas[1];
         assert!((total - 200.0).abs() < 1e-6, "total={total}");
         assert!((res.alphas[0] - 20.0).abs() < 1e-2, "a0={}", res.alphas[0]);
@@ -585,7 +666,7 @@ mod tests {
     #[test]
     fn conserves_total_count() {
         let eq = build(&[(vec![0, 1, 2], 50), (vec![1, 2], 30), (vec![2], 20)], 3);
-        let res = optimize(&eq, 3, &EmOptions::default(), None);
+        let res = optimize(&eq, 3, &EmOptions::default(), EffLens::NONE);
         let total: f64 = res.alphas.iter().sum();
         assert!((total - 100.0).abs() < 1e-6, "total={total}");
     }
@@ -599,7 +680,7 @@ mod tests {
             use_vbem: true,
             ..Default::default()
         };
-        let res = optimize(&eq, 2, &opts, None);
+        let res = optimize(&eq, 2, &opts, EffLens::NONE);
         let total: f64 = res.alphas.iter().sum();
         // VBEM with a tiny prior stays very close to the EM total.
         assert!((total - 200.0).abs() < 1.0, "total={total}");
@@ -629,7 +710,7 @@ mod tests {
     #[test]
     fn squarem_matches_plain_em_fixpoint() {
         let eq = ambiguous();
-        let plain = optimize(&eq, 3, &EmOptions::default(), None);
+        let plain = optimize(&eq, 3, &EmOptions::default(), EffLens::NONE);
         let sq = optimize(
             &eq,
             3,
@@ -637,7 +718,7 @@ mod tests {
                 accel: EmAccel::Squarem,
                 ..Default::default()
             },
-            None,
+            EffLens::NONE,
         );
         for t in 0..3 {
             let rel = (sq.alphas[t] - plain.alphas[t]).abs() / plain.alphas[t].max(1.0);
@@ -668,7 +749,7 @@ mod tests {
             use_vbem: true,
             ..Default::default()
         };
-        let plain = optimize(&eq, 3, &base, None);
+        let plain = optimize(&eq, 3, &base, EffLens::NONE);
         let sq = optimize(
             &eq,
             3,
@@ -676,7 +757,7 @@ mod tests {
                 accel: EmAccel::Squarem,
                 ..base.clone()
             },
-            None,
+            EffLens::NONE,
         );
         for t in 0..3 {
             let rel = (sq.alphas[t] - plain.alphas[t]).abs() / plain.alphas[t].max(1.0);
@@ -701,7 +782,7 @@ mod tests {
                 accel: EmAccel::Squarem,
                 ..Default::default()
             },
-            None,
+            EffLens::NONE,
         );
         let total: f64 = res.alphas.iter().sum();
         // total input count = 40+35+25+300+260+180+500 = 1340
@@ -725,7 +806,7 @@ mod tests {
             alpha_check_cutoff: 1e-8,
             ..Default::default()
         };
-        let plain = optimize(&eq, ntxp, &tight, None);
+        let plain = optimize(&eq, ntxp, &tight, EffLens::NONE);
         let sq = optimize(
             &eq,
             ntxp,
@@ -733,7 +814,7 @@ mod tests {
                 accel: EmAccel::Squarem,
                 ..tight.clone()
             },
-            None,
+            EffLens::NONE,
         );
         println!(
             "squarem_reduces_iters: plain M-steps={} (converged={}) squarem M-steps={} (converged={})",
@@ -760,7 +841,7 @@ mod tests {
     #[test]
     fn daarem_matches_plain_em_fixpoint() {
         let eq = ambiguous();
-        let plain = optimize(&eq, 3, &EmOptions::default(), None);
+        let plain = optimize(&eq, 3, &EmOptions::default(), EffLens::NONE);
         let da = optimize(
             &eq,
             3,
@@ -768,7 +849,7 @@ mod tests {
                 accel: EmAccel::Daarem,
                 ..Default::default()
             },
-            None,
+            EffLens::NONE,
         );
         for t in 0..3 {
             let rel = (da.alphas[t] - plain.alphas[t]).abs() / plain.alphas[t].max(1.0);
@@ -798,7 +879,7 @@ mod tests {
             use_vbem: true,
             ..Default::default()
         };
-        let plain = optimize(&eq, 3, &base, None);
+        let plain = optimize(&eq, 3, &base, EffLens::NONE);
         let da = optimize(
             &eq,
             3,
@@ -806,7 +887,7 @@ mod tests {
                 accel: EmAccel::Daarem,
                 ..base.clone()
             },
-            None,
+            EffLens::NONE,
         );
         for t in 0..3 {
             let rel = (da.alphas[t] - plain.alphas[t]).abs() / plain.alphas[t].max(1.0);
@@ -830,7 +911,7 @@ mod tests {
                 accel: EmAccel::Daarem,
                 ..Default::default()
             },
-            None,
+            EffLens::NONE,
         );
         let total: f64 = res.alphas.iter().sum();
         assert!((total - 1340.0).abs() < 1e-6, "total={total}");
@@ -850,7 +931,7 @@ mod tests {
             alpha_check_cutoff: 1e-8,
             ..Default::default()
         };
-        let plain = optimize(&eq, ntxp, &tight, None);
+        let plain = optimize(&eq, ntxp, &tight, EffLens::NONE);
         let da = optimize(
             &eq,
             ntxp,
@@ -858,7 +939,7 @@ mod tests {
                 accel: EmAccel::Daarem,
                 ..tight.clone()
             },
-            None,
+            EffLens::NONE,
         );
         println!(
             "daarem_reduces_iters: plain M-steps={} (converged={}) daarem M-steps={} (converged={})",
@@ -886,7 +967,7 @@ mod tests {
         b.add_group(TranscriptGroup::new(vec![0, 1]), vec![1.0, 1.0], 100);
         let mut eq = b.finish();
         eq.update_eff_lengths(&[300.0, 100.0]);
-        let res = optimize(&eq, 2, &EmOptions::default(), None);
+        let res = optimize(&eq, 2, &EmOptions::default(), EffLens::NONE);
         assert!(res.alphas[1] > res.alphas[0], "{:?}", res.alphas);
     }
 }

--- a/crates/salmon-infer/src/packed.rs
+++ b/crates/salmon-infer/src/packed.rs
@@ -841,7 +841,14 @@ mod shard_plan_determinism {
                     .build()
                     .expect("thread pool");
                 pool.install(|| {
-                    crate::optimize_packed_with_init(&packed, &opts, true, None, Some(&eff)).alphas
+                    crate::optimize_packed_with_init(
+                        &packed,
+                        &opts,
+                        true,
+                        crate::InitAlphas::NONE,
+                        crate::EffLens::new(&eff),
+                    )
+                    .alphas
                 })
             };
 

--- a/crates/salmon-infer/src/uncertainty.rs
+++ b/crates/salmon-infer/src/uncertainty.rs
@@ -37,7 +37,7 @@ use rand_pcg::Pcg64Mcg;
 use rayon::prelude::*;
 
 use crate::packed::PackedEqClasses;
-use crate::{run_em_counts, EmOptions};
+use crate::{run_em_counts, EffLens, EmOptions, InitAlphas};
 
 /// Smallest class denominator below which mass is redistributed evenly (Gibbs).
 const MIN_EQ_CLASS_WEIGHT: f64 = f64::MIN_POSITIVE;
@@ -108,7 +108,7 @@ fn multinomial(total: u64, weights: &[f64], rng: &mut impl Rng) -> Vec<u64> {
 pub fn bootstrap(
     p: &PackedEqClasses,
     opts: &EmOptions,
-    eff_lens: Option<&[f64]>,
+    eff_lens: EffLens<'_>,
     num_bootstraps: u32,
     seed: u64,
 ) -> Vec<Vec<f64>> {
@@ -133,7 +133,8 @@ pub fn bootstrap(
             // first attempt at this fix did exactly that — the prior stayed
             // flat AND every replicate warm-started from the effective-length
             // vector. Keep `None` explicit for the uniform start.
-            let (alphas, _, _) = run_em_counts(p, &resampled, opts, false, 50, None, eff_lens);
+            let (alphas, _, _) =
+                run_em_counts(p, &resampled, opts, false, 50, InitAlphas::NONE, eff_lens);
             // Finalize like the point estimate: truncate the negligible
             // abundances, then redistribute that mass to eq-class co-members via a
             // masked final M-step over the *resampled* counts (no rescale-up). The
@@ -466,7 +467,7 @@ mod tests {
     fn bootstrap_mean_near_point_estimate() {
         // unique evidence -> every bootstrap recovers ~the same counts
         let p = packed(&[(vec![0], 300), (vec![1], 700)], 2);
-        let bs = bootstrap(&p, &EmOptions::default(), None, 50, 12345);
+        let bs = bootstrap(&p, &EmOptions::default(), EffLens::NONE, 50, 12345);
         assert_eq!(bs.len(), 50);
         let m0: f64 = bs.iter().map(|b| b[0]).sum::<f64>() / 50.0;
         let m1: f64 = bs.iter().map(|b| b[1]).sum::<f64>() / 50.0;
@@ -483,7 +484,7 @@ mod tests {
     fn bootstrap_variance_grows_with_ambiguity() {
         // a fully shared class has higher per-transcript bootstrap variance
         let p = packed(&[(vec![0], 10), (vec![1], 10), (vec![0, 1], 980)], 2);
-        let bs = bootstrap(&p, &EmOptions::default(), None, 100, 7);
+        let bs = bootstrap(&p, &EmOptions::default(), EffLens::NONE, 100, 7);
         let m0: f64 = bs.iter().map(|b| b[0]).sum::<f64>() / 100.0;
         let var0: f64 = bs.iter().map(|b| (b[0] - m0).powi(2)).sum::<f64>() / 100.0;
         assert!(
@@ -561,9 +562,9 @@ mod per_nucleotide_prior_reaches_replicates {
         };
 
         opts.per_nucleotide_prior = false;
-        let flat = bootstrap(&packed, &opts, Some(&eff_lens), 16, 0xC0FFEE);
+        let flat = bootstrap(&packed, &opts, EffLens::new(&eff_lens), 16, 0xC0FFEE);
         opts.per_nucleotide_prior = true;
-        let per_nt = bootstrap(&packed, &opts, Some(&eff_lens), 16, 0xC0FFEE);
+        let per_nt = bootstrap(&packed, &opts, EffLens::new(&eff_lens), 16, 0xC0FFEE);
 
         assert_eq!(flat.len(), 16);
         assert_eq!(per_nt.len(), 16);

--- a/crates/salmon-quant/src/lib.rs
+++ b/crates/salmon-quant/src/lib.rs
@@ -1017,7 +1017,12 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         ro.min_iter = opts.bias_seed_em_iters;
         ro.max_iter = opts.bias_seed_em_iters;
         ro.min_alpha = 0.0;
-        salmon_infer::optimize(&naive_collapsed, num_refs, &ro, Some(&eff_lengths))
+        salmon_infer::optimize(
+            &naive_collapsed,
+            num_refs,
+            &ro,
+            salmon_infer::EffLens::new(&eff_lengths),
+        )
     } else if opts.skip_quant {
         // `--skipQuant`: emit equivalence classes + library type + metadata but
         // skip the optimizer (and Gibbs/bootstrap below, and quant.sf). Leave
@@ -1036,9 +1041,21 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         // EM, and a zeroed alpha can never recover under the multiplicative
         // update (salmon keeps one continuous, untruncated vector).
         pre.min_alpha = 0.0;
-        optimize_packed_with_init(&packed, &pre, true, None, Some(&eff_lengths))
+        optimize_packed_with_init(
+            &packed,
+            &pre,
+            true,
+            salmon_infer::InitAlphas::NONE,
+            salmon_infer::EffLens::new(&eff_lengths),
+        )
     } else {
-        optimize_packed_with_init(&packed, &opts.em, true, None, Some(&eff_lengths))
+        optimize_packed_with_init(
+            &packed,
+            &opts.em,
+            true,
+            salmon_infer::InitAlphas::NONE,
+            salmon_infer::EffLens::new(&eff_lengths),
+        )
     };
 
     // ---- bias correction: re-estimate effective lengths --------------------
@@ -1246,7 +1263,13 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         // Warm-start the single full convergence from the burn-in alphas, as
         // salmon continues the same vector after its in-loop correction.
         let warm = std::mem::take(&mut em.alphas);
-        em = optimize_packed_with_init(&packed, &opts.em, true, Some(&warm), Some(&eff_lengths));
+        em = optimize_packed_with_init(
+            &packed,
+            &opts.em,
+            true,
+            salmon_infer::InitAlphas::new(&warm),
+            salmon_infer::EffLens::new(&eff_lengths),
+        );
     }
     // The min-alpha truncation is applied inside the EM as a mass-preserving
     // redistribution (see `redistribute_truncated`): the truncated mass flows to
@@ -1310,7 +1333,7 @@ pub fn quantify(opts: &QuantOptions) -> Result<QuantResult> {
         salmon_infer::PosteriorMethod::Bootstrap { replicates } => salmon_infer::bootstrap(
             &packed,
             &opts.em,
-            Some(&eff_lengths),
+            salmon_infer::EffLens::new(&eff_lengths),
             replicates,
             0x5A13_0000,
         ),

--- a/docs/em-architecture-and-optimization.md
+++ b/docs/em-architecture-and-optimization.md
@@ -1,0 +1,405 @@
+# The EM/VBEM phase: architecture, optimizations to date, and where to look next
+
+Written as a briefing for someone evaluating further optimization of the
+inference phase. It describes what is there now, what has already been tried
+and measured, and which specific things are known to still be on the table —
+so that effort goes somewhere new rather than re-deriving what is here.
+
+All line references are against `develop` at the time of writing plus
+`fix/em-determinism-and-scaling` (#1167); check them, they drift.
+
+---
+
+## 1. Why this phase matters
+
+On a 26.1M-fragment sketch run against GENCODE v49 (238,442 transcripts), the
+wall time splits roughly:
+
+| phase | time | share |
+|---|---|---|
+| phase 1 — mapping (includes writing the intermediate RAD) | 30.5 s | 45% |
+| phase 2 — **EM inference** | 31.9 s → **15.2 s after #1167** | 47% → ~31% |
+| phase 2 — RAD read | 3.9 s | 6% |
+| index load, eff-length collapse, posterior, output | ~1.5 s | 2% |
+
+Before #1167 the EM was as expensive as all of mapping. It is now roughly half
+that, and it is still the second-largest cost and the one that scales worst.
+
+Measured on `newton` (Xeon E5-2699 v4, 88 cores); see §7 for the data.
+
+---
+
+## 2. Where the EM sits
+
+Two entry points, both in `crates/salmon-infer/src/lib.rs`:
+
+- `optimize(...)` — builds a `PackedEqClasses` from a `CollapsedEqClasses` and
+  runs to convergence.
+- `optimize_packed_with_init(p, opts, parallel, init_alphas, eff_lens)` — the
+  one production actually calls, with `parallel = true` everywhere (reads mode
+  `salmon-quant/src/lib.rs:1039,1041,1249`; RAD/alignment
+  `salmon-align/src/rad.rs:2214,2216,2294` and `salmon-align/src/lib.rs:2461,2463,2500`).
+
+Both funnel into **`run_em_counts(p, counts, opts, parallel, min_iter, init_alphas, eff_lens)`**
+(`lib.rs:279`), which owns the buffers, builds the shard plan, selects the
+M-step kernel, and drives one of three convergence loops.
+
+Note the argument order: `init_alphas` precedes `eff_lens` and both are
+`Option<&[f64]>`, so swapping them type-checks silently. That has bitten us
+once already (the bootstrap path passed effective lengths as the initial
+abundance vector; `uncertainty.rs:136` now has a comment about it).
+
+### Callers with different needs
+
+- **Point estimate** — `parallel = true`, full iteration budget.
+- **Bias seed EM** (`salmon-quant/src/lib.rs:1039`) — a deliberately
+  under-converged short run (`min_iter = max_iter = bias_seed_em_iters`,
+  `min_alpha = 0.0`) whose output seeds the bias model.
+- **Bootstrap replicates** (`uncertainty.rs:136`) — `parallel = false`, because
+  the *replicates* are the parallel dimension; each replicate runs a sequential
+  EM inside a `par_iter` over replicates. Optimizing the sequential kernel
+  therefore matters as much as the parallel one for `--numBootstraps` runs.
+- **Gibbs** (`uncertainty.rs`) — separate sampler, shares `PackedEqClasses`
+  and the `weights` array rather than `combined`.
+
+---
+
+## 3. The data structure: `PackedEqClasses` (CSR)
+
+`crates/salmon-infer/src/packed.rs`. Flat CSR, built once per run:
+
+```
+labels:   Vec<u32>   flat transcript ids; class i spans labels[starts[i]..starts[i+1]]
+starts:   Vec<u64>   CSR offsets, len = num_classes + 1
+combined: Vec<f64>   weight/effLen per (class, transcript) incidence — EM reads this
+weights:  Vec<f64>   raw conditional weights, same layout — Gibbs reads this
+counts:   Vec<u64>   per-class fragment count
+num_txps: usize
+```
+
+`starts` is `u64` deliberately: these are cumulative *incidence* counts, and a
+`u32` wrapped silently past 4G incidences and handed the optimizer slices
+belonging to other classes (#1097). Costs ~3.5% of the structure.
+
+Scale on the reference dataset: **536,311 classes, 238,442 transcripts**, mean
+class size ~2.5, so ~1.3M incidences. Each M-step reads every incidence twice
+(denominator, then distribution) — call it ~2.6M f64 reads of `combined` plus
+the same number of scattered reads of `alpha_in` and scattered writes to an
+accumulator.
+
+`weights` is populated only when a posterior method needs it
+(`PosteriorMethod::needs_raw_weights`); a point-estimate run does not pay for
+it.
+
+---
+
+## 4. The M-step kernels
+
+Four, dispatched by `(use_vbem, parallel)` in the closure at `lib.rs:~300`:
+
+| | sequential | parallel |
+|---|---|---|
+| EM | `em_step_seq` | `em_step_par` |
+| VBEM | `vbem_step_seq` | `vbem_step_par` |
+
+**Plain EM**, per class `ci` with `count` fragments and members `(tid, w)`:
+
+```
+denom = Σ alpha_in[tid] * w
+if denom > MIN_EQ_CLASS_WEIGHT:
+    inv = count / denom
+    for each (tid, w): acc[tid] += alpha_in[tid] * w * inv
+```
+
+Single-member classes short-circuit to `acc[tid] += count`. The inner product
+is recomputed rather than cached in scratch — the multiply was measured cheaper
+than the extra memory traffic inside the parallel closure.
+
+**VBEM** substitutes `exp_theta` for `alpha`:
+`exp_theta[i] = exp(digamma(alpha_i + prior_i) − digamma(Σ_j alpha_j + prior_j))`,
+computed by `fill_exp_theta` **once per M-step, sequentially**, because it
+depends on a global sum over all transcripts. That is an `O(num_txps)` serial
+prologue on every iteration, including `num_txps` `digamma` calls — worth
+measuring, see §6.
+
+Priors come from `prior_alphas_vec` (`lib.rs:241`): flat `vb_prior` per
+transcript, or `vb_prior * max(1, effLen)` under `--perNucleotidePrior`.
+
+**VBEM is the production default** (`opt_type: "vb"`; the CLI sets
+`use_vbem = !args.use_em && !args.meta`). `EmOptions::default()` has
+`use_vbem: false`, so any benchmark or test built on the default is exercising
+the *non*-default kernel. This mattered: the original determinism test did
+exactly that.
+
+---
+
+## 5. Parallelism: `ShardPlan` (this is what #1167 changed)
+
+### What it was
+
+```rust
+let nshards = rayon::current_num_threads().clamp(1, 64);
+// per shard, per iteration:
+buf.iter_mut().for_each(|x| *x = 0.0);      // dense clear,  O(num_txps)
+...
+reduce_shards(shards, alpha_out);            // dense reduce, O(nshards * num_txps)
+```
+
+Each shard owned a private dense `num_txps` accumulator and processed a
+contiguous slice of classes with non-atomic adds — chosen over a shared
+`AtomicF64` array, which contended badly on hot transcripts.
+
+**Two defects.**
+
+1. **Determinism.** `nshards` tracked the thread count, so `-p` changed the
+   class partition and therefore the grouping of floating-point sums. On real
+   data `-p 4` and `-p 32` produced different `quant.sf`, *at default
+   precision*. Confirmed by construction: `-p 64` and `-p 80` (both clamped to
+   64) were byte-identical; `-p 16` differed.
+2. **Scaling.** Clear + reduce cost `O(nshards × num_txps)` per iteration
+   regardless of the data — ~30M ops at 64 shards against ~1.3M incidences of
+   real work — and grew with thread count while the work stayed fixed.
+
+### What it is now
+
+`ShardPlan` (`packed.rs`, ~line 400):
+
+- **`nshards` derives from the data alone**:
+  `nclasses.div_ceil(MIN_CLASSES_PER_SHARD=4096).clamp(1, MAX_SHARDS=64)`.
+  On the reference dataset that is 64 shards regardless of `-p`. Rayon
+  schedules them over whatever threads exist — a scheduling decision, which
+  cannot change arithmetic.
+- **`touched[s]`** — sorted, deduplicated transcript ids reachable from shard
+  `s`'s class range, computed **once** (labels never change between
+  iterations). The per-iteration clear touches only these.
+- **`contrib_start` / `contrib`** — CSR inversion of `touched`
+  (transcript → contributing shards, ascending). The reduction is
+  `par_iter` over transcripts, each an independent fixed-order sum over only
+  the shards that contribute. Parallel *and* deterministic.
+
+Per-iteration overhead is now `O(Σ|touched|)` ≈ `O(incidences)` rather than
+`O(nshards × num_txps)`.
+
+### Determinism invariants (do not break these)
+
+Any future change must preserve all four, or `quant.sf` stops being
+reproducible across `-p`:
+
+1. Shard count and boundaries depend only on the data.
+2. Each shard's accumulation order over its classes is fixed.
+3. The reduction sums a transcript's contributors in a fixed (ascending shard)
+   order.
+4. SQUAREM/DAAREM vector math is sequential (see §6) — if parallelized, it must
+   use a fixed-order reduction, not a nondeterministic one.
+
+Enforced by `packed.rs::shard_plan_determinism::em_result_is_independent_of_thread_count`,
+which compares bit-for-bit across rayon pools of 1/2/3/8/16 threads over **all
+four** configurations (plain EM, VBEM, plain+SQUAREM, VBEM+SQUAREM). It is
+verified to *fail* on the pre-#1167 tree (1809 of 5000 transcripts differ
+between 1 and 2 threads). Weights in that fixture are deliberately not
+exactly representable — with tidy powers of two every grouping agrees and the
+test proves nothing.
+
+---
+
+## 6. Convergence and acceleration
+
+### The loop
+
+`max_rel_diff(alpha_in, alpha_out, cutoff)` (`lib.rs:~250`) — max over
+transcripts of `|out−in|/out`, considering only transcripts with
+`alpha_in > alpha_check_cutoff` (without the cutoff a transcript oscillating
+between 1e-30 and 2e-30 blocks convergence forever). **This is a sequential
+loop over `num_txps`, run every iteration.**
+
+Buffers are swapped, not copied. `min_iter` floors the convergence check;
+`max_iter` is the hard stop.
+
+### Acceleration (`EmAccel`)
+
+- **`None`** (default) — plain fixed-point iteration, one M-step per iteration.
+  Output unchanged from historical salmon.
+- **`Squarem`** (SqS3) — per cycle: two M-steps `x1=F(x0)`, `x2=F(x1)`, form
+  `r = x1−x0` and `v = (x2−x1)−r`, extrapolate
+  `xp = x0 − 2αr + α²v` with `α = −‖r‖/‖v‖` clamped to `α ≤ −1`, halving back
+  toward −1 if any component goes negative; then a stabilizing third M-step
+  `x_next = F(xp)`. Three M-steps per cycle, far fewer cycles. Not
+  byte-identical to `None` (different iterate sequence, same fixpoint within
+  `rel_diff_tol`).
+- **`Daarem`** — damped Anderson acceleration with restarts and
+  residual-monotonicity control over a window of recent iterates
+  (`daarem.rs`, 539 lines). Better than SQUAREM on ill-conditioned,
+  high-dimensional problems.
+
+**The vector/norm math in SQUAREM and DAAREM is sequential over `num_txps`,
+deliberately**, so results do not depend on thread count. The comment says this
+is "cheap next to a per-class M-step" — that was true when the M-step cost
+~30 s. After #1167 the M-step is ~2× cheaper, so the ratio has moved and this
+should be re-measured before it is assumed still true.
+
+### Finalization
+
+`finalize_truncate_redistribute` (`lib.rs:~265`) — applies `min_alpha`
+truncation as a *mass-preserving redistribution* (a masked final M-step over
+the surviving members), not a rescale. Mass that cannot be redistributed
+(fully-truncated classes) is reported as `inference_truncated_mass`. A
+non-positive `min_alpha` makes it a no-op (used by the bias warm-up).
+
+---
+
+## 7. What has been done, with measurements
+
+| change | effect | where |
+|---|---|---|
+| CSR `PackedEqClasses` replacing per-class `Vec`s | (pre-existing) | `packed.rs` |
+| Per-shard dense accumulators replacing a shared `AtomicF64` array | removed CAS contention on hot transcripts | `packed.rs` |
+| `u64` CSR offsets | correctness past 4G incidences (#1097) | `packed.rs` |
+| SQUAREM, DAAREM | opt-in, far fewer M-steps | `lib.rs`, `daarem.rs` |
+| **Data-derived shard count** (#1167) | **fixed cross-`-p` reproducibility** | `packed.rs` |
+| **Sparse clear via `touched`** (#1167) | see below | `packed.rs` |
+| **Parallel sparse reduce via CSR inversion** (#1167) | see below | `packed.rs` |
+
+EM phase time, newton, same binary pair, back to back, sketch, 26.1M fragments:
+
+| `-p` | before #1167 | after #1167 | |
+|---|---|---|---|
+| 16 | 32.58 s | **15.19 s** | 2.14× |
+| 32 | 23.69 s | **13.95 s** | 1.70× |
+
+Mapping and RAD-read unchanged, so the effect is isolated to this phase.
+
+End-to-end wall on an EPYC 9575F (10M-pair equivalent workload, sketch):
+`-p 4` 1.03×, `-p 16` 1.06×, `-p 32` 1.14×, `-p 64` 1.17×.
+
+---
+
+## 8. Known remaining bottlenecks — the actual open questions
+
+**The EM still does not scale.** 15.19 s at `-p 16` vs 13.95 s at `-p 32` is
+9% for double the threads. #1167 removed a large constant factor, not the
+ceiling. Candidates, roughly in order of my confidence:
+
+1. **Dense per-shard accumulator memory traffic.** 64 shards × 238,442 × 8 B ≈
+   **122 MB** of accumulator working set, against ~55 MB of L3 on the Xeon and
+   far more on the EPYC — which is consistent with the fix helping more on the
+   EPYC than on newton. We now compute `touched[s]` anyway, so each shard's
+   accumulator could be **index-compressed** to its own touched set
+   (`buf[local_idx]` with a `tid → local_idx` map, or a sorted dense array
+   indexed by rank within `touched[s]`). That shrinks the working set to
+   `O(Σ|touched|)` ≈ 10 MB and makes the adds cache-local. This is the single
+   most promising item and it preserves all four determinism invariants.
+2. **Sequential `max_rel_diff` every iteration** — `O(num_txps)` serial, ~238k
+   per iteration. Parallelizable with a fixed-order max-reduction (max is
+   associative and exactly representable, so a tree reduction is deterministic).
+3. **VBEM's `fill_exp_theta` prologue** — `O(num_txps)` serial including
+   `num_txps` `digamma` calls, every M-step, on the *production default* path.
+   The global sum must be sequential (or a fixed-order tree reduce), but the
+   per-element `exp(digamma(...) − log_norm)` map is embarrassingly parallel.
+4. **SQUAREM/DAAREM vector math**, sequential over `num_txps` per cycle. Same
+   fixed-order-reduction caveat.
+5. **Shard count is capped at 64** and sized by classes, not by incidences.
+   Classes vary in size, so contiguous equal-count ranges are not equal-*work*
+   ranges; a work-balanced partition (equal incidence counts, still data-derived)
+   would reduce tail effects. Must remain independent of `-p`.
+6. **`em_step_seq` matters more than it looks** — every bootstrap replicate uses
+   it (`--numBootstraps` runs `replicates` sequential EMs inside a parallel
+   iterator), so improving the sequential kernel improves posterior runs.
+
+Things deliberately **not** worth revisiting, with reasons:
+
+- *Shared atomic accumulator instead of shards* — tried; CAS contention on hot
+  transcripts dominated. That is why shards exist.
+- *Caching `alpha_in[tid] * w` in scratch inside the parallel M-step* — tried;
+  the extra memory traffic cost more than the recomputed multiply.
+- *Making the shard count track threads* — this is the #1167 bug. Never again.
+
+---
+
+## 9. Test data provenance (on `newton`)
+
+Everything needed to reproduce the numbers above is staged on **`newton`**
+under **`/mnt/scratch7/rob_disktest/`** (spinning disk, ~105 MB/s; 461 GB free
+at time of writing). `/mnt/scratch1` is also rotational (~145 MB/s).
+
+```
+/mnt/scratch7/rob_disktest/
+├── bin/
+│   ├── salmon              pre-#1167 binary (baseline)
+│   └── salmon_fixed        post-#1167 binary
+├── data/
+│   ├── gencode_v49/        salmon index, 3.1 GB, 238,442 transcripts
+│   ├── SRR21186103_1.fastq.gz   839 MB
+│   └── SRR21186103_2.fastq.gz   837 MB
+└── *.tsv, *.log            results from the runs described here
+```
+
+**Dataset**: SRR21186103, human, paired-end 2×~100 bp, **26,135,185 fragments**,
+71.8% mapping rate against GENCODE v49. Copied from
+`/scratch1/rob/rshash_testing/human_reads/` on the submit host; the index came
+from `/scratch1/rob/flex_bench/salmon_idx/gencode_v49`.
+
+Scale it produces: **536,311 equivalence classes**, ~1.3M incidences,
+**2811 EM iterations** to convergence (deterministic path; the online path
+varies, 2555–2700).
+
+### Reproducing an EM measurement
+
+```bash
+cd /mnt/scratch7/rob_disktest
+./bin/salmon_fixed quant -i data/gencode_v49 -l A \
+  -1 data/SRR21186103_1.fastq.gz -2 data/SRR21186103_2.fastq.gz \
+  -p 32 --sketch -o out/whatever 2> run.log
+
+# per-phase timings (the log carries ANSI escapes — strip them first, this
+# tripped up an earlier parser):
+sed 's/\x1b\[[0-9;]*m//g' run.log \
+  | grep -oE 'phase="[a-z_]+" elapsed_s=[0-9.]+'
+```
+
+Phase names: `index_load`, `mapping`, `eff_length_collapse`, `em_bias`,
+`posterior`, `output` (phase 1), then `rad_read`, `em_bias`, `posterior`,
+`output` (phase 2). **The EM you care about is the *second* `em_bias`.** The
+phases sum to wall time, so an unaccounted remainder means a parse error.
+
+Use `--sketch` for EM work: mapping is cheap, so the EM is a large share and
+iteration counts are unaffected.
+
+Kernel/loop selection (verified against `salmon quant --help`):
+
+| flag | effect |
+|---|---|
+| *(none)* | VBEM — **the production default** |
+| `--useEM` | plain EM kernel |
+| `--meta` | plain EM + no range factorization (overrides `--useEM`) |
+| `--emAccel none\|squarem\|daarem` | convergence loop; `none` is the default |
+| `--perNucleotidePrior` | VBEM prior becomes `vb_prior * effLen` |
+| `--numBootstraps N` | N sequential EMs inside a parallel iterator (exercises `em_step_seq`) |
+
+Benchmark VBEM unless you specifically mean to measure plain EM — the default
+`EmOptions` says otherwise and it is an easy mistake.
+
+### Benchmarking caveats learned the hard way
+
+- **Warm the page cache first.** With 503 GB of RAM, the first run over this
+  1.7 GB of input is materially slower than later ones. An early A/B here
+  showed a "19% penalty" that was entirely cold-cache input reads attributed to
+  whichever arm ran first. Run once to warm, then measure.
+- **Do not interleave arms with other work.** Wall-time comparisons taken from
+  a script that ran other binaries between arms disagreed with back-to-back
+  phase measurements by ~20 points.
+- **The online path has enormous variance at high `-p`.** Four repeats at
+  `-p 64` gave 103.6, 59.8, 104.5, 55.5 s — bimodal, an 88% spread — while the
+  deterministic path held 39–42 s. Any single-run comparison against `--online`
+  at high thread counts is meaningless.
+- **`salmon --version` on a fresh binary first.** newton is Broadwell with no
+  AVX-512; the build config floors at `x86-64-v2` with runtime SIMD dispatch,
+  so binaries built on the AVX-512 submit host do run — but a
+  `target-cpu=native` build would `SIGILL` there.
+- No root on newton, so caches cannot be dropped between runs.
+
+### A smaller local fixture
+
+For quick iteration without newton, the determinism test's synthetic generator
+(`packed.rs::shard_plan_determinism`) builds 20,000 classes over 5,000
+transcripts with non-representable weights — enough to shard several times and
+to expose grouping differences, and it runs in under a second.

--- a/docs/em-architecture-and-optimization.md
+++ b/docs/em-architecture-and-optimization.md
@@ -44,10 +44,34 @@ Both funnel into **`run_em_counts(p, counts, opts, parallel, min_iter, init_alph
 (`lib.rs:279`), which owns the buffers, builds the shard plan, selects the
 M-step kernel, and drives one of three convergence loops.
 
-Note the argument order: `init_alphas` precedes `eff_lens` and both are
-`Option<&[f64]>`, so swapping them type-checks silently. That has bitten us
-once already (the bootstrap path passed effective lengths as the initial
-abundance vector; `uncertainty.rs:136` now has a comment about it).
+These two arguments used to be a live footgun: `init_alphas` precedes
+`eff_lens`, both were `Option<&[f64]>`, and swapping them type-checked
+silently. It shipped that way once — the bootstrap path passed effective
+lengths into the `init_alphas` slot, which left `--perNucleotidePrior` inert
+inside every replicate *and* warm-started each replicate from the
+effective-length vector, so the reported spread was drawn under a different
+prior than the point estimate it quantified.
+
+**That is now a compile error.** They are distinct newtypes,
+`InitAlphas<'a>` and `EffLens<'a>`, each wrapping `Option<&'a [f64]>`:
+
+```rust
+run_em_counts(p, counts, opts, parallel, min_iter,
+              InitAlphas::NONE,            // or InitAlphas::new(&warm)
+              EffLens::new(&eff_lengths))  // or EffLens::NONE
+```
+
+Three properties are worth preserving if you touch them:
+
+- **Zero overhead is asserted, not assumed** — a `const _: () = assert!(...)`
+  in `lib.rs` checks that both newtypes have the same layout as
+  `Option<&[f64]>` (16 bytes). If a future change makes them fatter, the crate
+  stops compiling.
+- **The swap is proven impossible** by a `compile_fail` doctest on
+  `InitAlphas`, which runs under `cargo test --doc` and doubles as API
+  documentation. Weakening the types breaks that test.
+- **No `Deref`, no `Into<Option<..>>`** — deliberately. An implicit conversion
+  back to the bare type would reopen the hole. The accessor is `pub(crate)`.
 
 ### Callers with different needs
 
@@ -255,6 +279,7 @@ non-positive `min_alpha` makes it a no-op (used by the bias warm-up).
 | Per-shard dense accumulators replacing a shared `AtomicF64` array | removed CAS contention on hot transcripts | `packed.rs` |
 | `u64` CSR offsets | correctness past 4G incidences (#1097) | `packed.rs` |
 | SQUAREM, DAAREM | opt-in, far fewer M-steps | `lib.rs`, `daarem.rs` |
+| `InitAlphas` / `EffLens` newtypes | made the argument-swap bug a compile error | `lib.rs` |
 | **Data-derived shard count** (#1167) | **fixed cross-`-p` reproducibility** | `packed.rs` |
 | **Sparse clear via `touched`** (#1167) | see below | `packed.rs` |
 | **Parallel sparse reduce via CSR inversion** (#1167) | see below | `packed.rs` |

--- a/docs/release-notes-2.6.0.md
+++ b/docs/release-notes-2.6.0.md
@@ -8,16 +8,29 @@ counts** — in every input mode: selective alignment, sketch, and alignment
 
 The decision is evidence-backed rather than aspirational (#1140):
 
-- **Speed**: deterministic is as fast or faster in every measured cell — on 10M
-  real read pairs, sketch is 13% faster wall / 20% less CPU at `-p 16` and 11%
-  faster at `-p 4`; selective alignment ties at `-p 16` and is ~7% faster at
-  `-p 4` — *including* the cost of writing and re-reading the intermediate.
-  Independently replicated on a hostile high-multimapping synthetic fixture.
+- **Speed**: hardware-dependent, and the honest summary is that deterministic
+  wins decisively where it matters most and costs a little elsewhere. On a
+  modern many-core machine (EPYC, NVMe) it is as fast or faster in every
+  measured cell: on 10M real read pairs, sketch is 13% faster wall / 20% less
+  CPU at `-p 16` and 11% faster at `-p 4`; selective alignment ties at `-p 16`
+  and is ~7% faster at `-p 4` — *including* the cost of writing and re-reading
+  the intermediate.
+
+  On an older CPU (Xeon E5-2699 v4, 26M real fragments) the picture is mixed:
+  deterministic is ~4% slower at `-p 16` and ~12% slower at `-p 32`, then
+  **twice as fast at `-p 64`**, where the online path's lock contention takes
+  over. It is also far more *predictable* there — across four repeats at
+  `-p 64` the online path ranged 55–105 s (bimodal), while deterministic held
+  39–42 s. When sizing a pipeline, that stability is usually worth more than
+  the mean.
 - **Accuracy**: statistically indistinguishable from the online path against
   ground truth (fourth-decimal differences, direction inconsistent, across two
   simulated samples and two multimapping regimes).
-- **Reproducibility**: `quant.sf` md5-identical at `-p 1/4/16`; the online path
-  produces a different file at every thread count.
+- **Reproducibility**: `quant.sf` byte-identical at every thread count, on real
+  data (26M fragments, 238k transcripts, verified at full `--sigDigits 9`
+  precision); the online path produces a different file at every thread count.
+  Enforced by a test that compares bit-for-bit across rayon pools of 1–16
+  threads, over plain EM, VBEM and SQUAREM.
 
 ## The deprecation path
 
@@ -57,9 +70,19 @@ The decision is evidence-backed rather than aspirational (#1140):
 
 ## Disk behavior of the intermediate
 
-The intermediate RAD is lz4-compressed (~110 MB per 1M read pairs on GENCODE
-v49; grows with the multimapping rate) and deleted on success. New in this
-release cycle:
+The intermediate RAD is lz4-compressed and deleted on success. Measured on
+GENCODE v49 with 26.1M real fragments: **~45 MB per 1M fragments in sketch mode
+and ~55 MB in selective alignment** (it grows with the multimapping rate).
+
+**Disk speed is not a factor.** Validated on rotational storage (measured
+105 MB/s): writing the RAD is entirely hidden behind mapping compute — the
+mapping phase takes 30.55 s with the RAD on a spinning disk versus 30.92 s with
+it in `/dev/shm` — and reading it back is bound by decompression rather than
+I/O. (Uncompressed, the RAD is 5× larger and still reads 2.7× *faster* than
+zstd.) Selective alignment is completely insensitive to disk speed. Fast
+scratch storage is not needed for the deterministic default.
+
+New in this release cycle:
 
 - **`--radScratchDir <dir>`** places it on node-local or memory-backed storage
   (e.g. `/dev/shm`), pid-suffixed so concurrent runs can share a scratch
@@ -67,7 +90,7 @@ release cycle:
 - A **startup preflight** warns when the target volume has less free space than
   the total compressed input, and the writer **checks free space during the
   pass**, so a filling disk fails in seconds with actionable advice
-  (`--radScratchDir`, `--radCompress zstd` for ~30% more shrink at ~11% wall)
+  (`--radScratchDir`, `--radCompress zstd` for ~53% more shrink at ~5.5% wall)
   instead of at the end of mapping. On failure, salmon-owned intermediates
   (including `.partial-*` files) are cleaned up; explicit `--writeRad` paths
   are never touched.


### PR DESCRIPTION
Stacked on #1167 (retarget to `develop` when that merges). Three commits.

## 1. Replace the 2.6.0 performance and disk figures with measured ones

The slow-disk validation on `newton` (#1140) measured several things the release notes asserted from a single machine.

- **Speed is now hardware-qualified.** "As fast or faster in every measured cell" is not true generally: on a Xeon E5-2699 v4 with 26M real fragments, deterministic is ~4% slower at `-p 16` and ~12% slower at `-p 32`, then **twice as fast at `-p 64`**. The notes also now carry the predictability difference, which matters more than the mean for pipeline sizing — across four repeats at `-p 64` the online path ranged **55–105 s (bimodal)** while deterministic held 39–42 s.
- **Reproducibility restated honestly.** It claimed "md5-identical at `-p 1/4/16`" on the strength of a 400-read fixture that could not have exposed a difference. Now: byte-identical at every thread count on 26M fragments at full `--sigDigits 9` precision, naming the test that enforces it.
- **The disk section leads with the finding**: disk speed is not a factor. Writing the RAD is hidden behind mapping compute (30.55 s on spinning disk vs 30.92 s in `/dev/shm`); reading it back is decompression-bound, not I/O-bound.
- **Two figures were simply wrong**, both understating the product: RAD size quoted as ~110 MB per 1M read pairs, measured **45 MB (sketch) / 55 MB (SA)**; `--radCompress zstd` quoted as ~30% shrink at ~11% wall, measured **53% at ~5.5%**.

## 2. `docs/em-architecture-and-optimization.md`

A briefing for whoever evaluates further EM optimization, so effort goes somewhere new rather than re-deriving what is here. Covers the CSR layout and its real scale, all four M-step kernels, the `ShardPlan` from #1167 with **the four determinism invariants any future change must preserve**, the convergence check, and the three acceleration loops.

It deliberately records **what has already been tried and rejected, with reasons** — shared atomic accumulator (CAS contention), caching the inner product in scratch (memory traffic beat the multiply), thread-derived shard counts (that is the #1167 bug) — and ranks the remaining candidates. Top of the list: each shard's dense 238k-entry accumulator gives a **122 MB working set against ~55 MB of L3**, and since `touched[s]` is now computed anyway, index-compressing each accumulator to its own touched set should cut that to ~10 MB without disturbing determinism.

Full test-data provenance on `newton` is included: paths, both binaries staged for A/B, the dataset and the scale it produces, how to extract per-phase timings (including the ANSI-escape trap that broke my first parser), a **verified** table of which flag selects which kernel, and the benchmarking caveats learned the hard way — warm the page cache, do not interleave arms, and treat any single-run `--online` comparison at high `-p` as meaningless.

## 3. Strong types for the `init_alphas` / `eff_lens` swap

`run_em_counts` takes `init_alphas: Option<&[f64]>` immediately followed by `eff_lens: Option<&[f64]>`. Structurally identical, so swapping them compiled silently — and it **shipped that way**: the bootstrap path passed effective lengths into the `init_alphas` slot, leaving `--perNucleotidePrior` inert inside every replicate *and* warm-starting each replicate from the effective-length vector. Reported spread was drawn under a different prior than the estimate it quantified.

A comment is not a guard. They are now distinct newtypes, converted across all four crates and 16 call sites:

```rust
run_em_counts(p, counts, opts, parallel, min_iter,
              InitAlphas::NONE,             // or InitAlphas::new(&warm)
              EffLens::new(&eff_lengths))   // or EffLens::NONE
```

Three properties keep it from decaying:

- **Zero overhead is asserted, not claimed** — `const _: () = assert!(size_of::<EffLens>() == size_of::<Option<&[f64]>>())`. Both 16 bytes; a fatter wrapper stops the crate compiling.
- **The swap is proven impossible** by a `compile_fail` doctest on `InitAlphas` that runs in CI and doubles as API documentation.
- **No `Deref`, no `Into<Option<..>>`**, deliberately — implicit conversion back to the bare type would reopen the hole. Accessor is `pub(crate)`.

The compiler found every affected site once the types diverged, including one a manual sweep would likely have missed (`init_alphas.as_deref()` in the online alignment path, which needed a `map_or` rather than a substitution).

Suite **343/0**, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cfXr9P5JDqoEtafmTGpNs