### PR TITLE
ci: let Dependabot open version updates, grouped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,11 +53,17 @@ updates:
       # and paraseq-temp 0.5.0-pre.2 commits). Kept in their own PR so such a
       # bump is never buried in a batch of unrelated ones.
       combine-lab-upstream:
-        # Minor and patch only, so a major from one of these lands on its own
-        # like every other major. Grouping a piscem-rs 1.0 with unrelated
-        # bumps is exactly what the separate group exists to prevent.
+        # Patch only, because all six are 0.x and Cargo's compatibility
+        # boundary there is the MINOR component: ^0.9.2 is >=0.9.2 <0.10.0, so
+        # 0.9.2 -> 0.9.3 is compatible and 0.9.2 -> 0.10.0 is breaking.
+        # Dependabot classifies by moved field, not by that boundary, which
+        # makes the breaking one `minor` to the grouping logic. Verified against
+        # dependabot-core rather than inferred: for a dependency at 0.9.2, the
+        # patch level covers `> 0.9.3, < 0.10` and the minor level starts at
+        # `>= 0.10.a`, with no 0.x special case anywhere. Allowing `minor` here
+        # would therefore batch a breaking upgrade of our own upstream crates
+        # into a routine PR, which is the case this group exists to isolate.
         update-types:
-          - minor
           - patch
         patterns:
           - piscem-rs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,18 +61,13 @@ updates:
           - patch
         patterns:
           - piscem-rs
-          # Both `paraseq` spellings are listed, and BOTH ARE INERT TODAY.
-          # `paraseq = { package = "paraseq-temp", ... }` is a rename, and
-          # dependabot-core's cargo parser skips a renamed manifest entry
-          # outright (`next unless name == name_from_declaration(...)` in
-          # cargo/lib/dependabot/cargo/file_parser.rb). Running that parser over
-          # this workspace confirms it: `paraseq` is not parsed at all, and
-          # `paraseq-temp` is seen only through Cargo.lock, with no requirement
-          # attached, which makes it indirect and therefore outside the default
-          # `allow`. So paraseq bumps stay manual, as they have been. The
-          # patterns are kept for the day the temporary republication goes away
-          # and the entry becomes an ordinary direct dependency again.
-          - paraseq
+          # `paraseq-temp`, not `paraseq`: the manifest used to rename it, and
+          # dependabot-core's cargo parser skips a renamed entry outright
+          # (`next unless name == name_from_declaration(...)` in
+          # cargo/lib/dependabot/cargo/file_parser.rb), which left the crate
+          # visible only through Cargo.lock as an indirect dependency no update
+          # would be raised for. The rename is gone, so this pattern matches a
+          # direct dependency; do not reintroduce it.
           - paraseq-temp
           - libradicl
           - cf1-rs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,9 +61,17 @@ updates:
           - patch
         patterns:
           - piscem-rs
-          # `paraseq` in the manifest is the `paraseq-temp` republication, so
-          # both spellings are listed rather than guessing which one Dependabot
-          # reports for a renamed package.
+          # Both `paraseq` spellings are listed, and BOTH ARE INERT TODAY.
+          # `paraseq = { package = "paraseq-temp", ... }` is a rename, and
+          # dependabot-core's cargo parser skips a renamed manifest entry
+          # outright (`next unless name == name_from_declaration(...)` in
+          # cargo/lib/dependabot/cargo/file_parser.rb). Running that parser over
+          # this workspace confirms it: `paraseq` is not parsed at all, and
+          # `paraseq-temp` is seen only through Cargo.lock, with no requirement
+          # attached, which makes it indirect and therefore outside the default
+          # `allow`. So paraseq bumps stay manual, as they have been. The
+          # patterns are kept for the day the temporary republication goes away
+          # and the entry becomes an ordinary direct dependency again.
           - paraseq
           - paraseq-temp
           - libradicl

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,21 @@
 # size produces a dozen individual bumps a week otherwise, and a wall of PRs is
 # reviewed by nobody, which is worse than no updates at all.
 #
-# NONE OF THIS APPLIES TO SECURITY UPDATES. GitHub only uses a `dependabot.yml`
-# entry for security updates when it sets no `target-branch`, and every entry
-# here sets one. So a security bump keeps arriving the way it does today:
-# against the default branch (`master`), ungrouped, without these commit
-# prefixes. That is deliberate (a security fix belongs on the release branch
-# directly, not queued behind `develop`), but it is worth knowing before
-# wondering why one showed up looking nothing like the PRs described below.
+# Every entry targets `develop`. Nothing here should ever open a PR against
+# `master`, which carries releases.
+#
+# NONE OF THIS APPLIES TO SECURITY UPDATES, and that is a constraint rather
+# than a preference. GitHub only uses a `dependabot.yml` entry for security
+# updates when it sets no `target-branch`, and every entry here sets one. So a
+# security bump keeps arriving against the *default* branch (`master`),
+# ungrouped and without these commit prefixes. The two settings cannot both be
+# satisfied from this file: dropping `target-branch` would bring security
+# updates under this config but send every version update to `master` too,
+# which is worse.
+#
+# The only way to get security PRs onto `develop` is to make `develop` the
+# repository's default branch. That is a repository setting, not a config
+# change, and it is deliberately not assumed here.
 version: 2
 updates:
   # ---- Rust workspace ------------------------------------------------------
@@ -32,9 +40,23 @@ updates:
     commit-message:
       prefix: chore(deps)
     groups:
-      # One PR a week for the routine movement. Patch and minor bumps of
-      # well-behaved crates are reviewed as a batch or not at all.
-      cargo-minor:
+      # One PR a week for the routine movement: patch level only, which is the
+      # tier that is mergeable on a glance.
+      #
+      # Minor is deliberately NOT batched here, for the same reason it is not
+      # batched in `combine-lab-upstream` below: 34 of this workspace's 55
+      # direct dependencies are 0.x, and for a 0.x requirement Cargo's
+      # compatibility boundary is the MINOR component, so `noodles-*`,
+      # `rapidgzip-core`, `sux`, `hashbrown`, `jiff`, `rand*`, `crossbeam*` and
+      # friends all break at a bump Dependabot classifies as `minor`. Batching
+      # those would hide a breaking upgrade inside a routine PR.
+      #
+      # Unmatched updates are not suppressed — they simply arrive ungrouped,
+      # one PR each, with their own diff and their own CI run. That is the
+      # point: a minor is a change to explain, and a major is a decision to
+      # make, neither of which is served by a batch. `open-pull-requests-limit`
+      # above bounds how many can be open at once, so the queue cannot run away.
+      cargo-patch:
         patterns:
           - "*"
         exclude-patterns:
@@ -46,7 +68,6 @@ updates:
           - sshash-lib
           - ksw2rs
         update-types:
-          - minor
           - patch
       # The lab's own upstream crates move with work happening in those repos,
       # and their bumps have carried deliberate floors (see the piscem-rs 0.9.2
@@ -100,6 +121,10 @@ updates:
     commit-message:
       prefix: chore(deps)
     groups:
+      # Minor IS batched here, unlike the cargo groups, and that is a choice
+      # rather than an oversight: this is the documentation site, so nothing it
+      # depends on can affect quantification results. Tightening it to patch
+      # would buy noise instead of safety.
       website-minor:
         patterns:
           - "*"
@@ -109,9 +134,15 @@ updates:
 
   # ---- GitHub Actions ------------------------------------------------------
   #
-  # The reason this file exists. One weekly PR that keeps every workflow on the
-  # same action versions, including the majors: an action major is a workflow
-  # change, visible in the diff, and CI is its own test.
+  # The reason this file exists: the workflows had drifted to three different
+  # `actions/checkout` majors with nothing to surface it. One weekly PR keeps
+  # every workflow on the same minor/patch versions.
+  #
+  # Majors are excluded from the group on purpose. An action major is a
+  # breaking workflow change — v4 to v5 of `checkout` or `upload-artifact` has
+  # changed defaults and outputs before — and "the diff is visible and CI is
+  # green" is not the standard we want for adopting one. Each arrives as its
+  # own PR, to be taken deliberately or closed.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -125,6 +156,9 @@ updates:
       actions:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   # ---- container base image ------------------------------------------------
   #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,13 +61,20 @@ updates:
           - patch
         patterns:
           - piscem-rs
-          # `paraseq-temp`, not `paraseq`: the manifest used to rename it, and
-          # dependabot-core's cargo parser skips a renamed entry outright
-          # (`next unless name == name_from_declaration(...)` in
-          # cargo/lib/dependabot/cargo/file_parser.rb), which left the crate
-          # visible only through Cargo.lock as an indirect dependency no update
-          # would be raised for. The rename is gone, so this pattern matches a
-          # direct dependency; do not reintroduce it.
+          # `paraseq-temp` is what the manifest declares today, and it has to
+          # stay declared under its real name: dependabot-core's cargo parser
+          # skips a renamed entry outright (`next unless name ==
+          # name_from_declaration(...)` in
+          # cargo/lib/dependabot/cargo/file_parser.rb), which is what once left
+          # this crate visible only through Cargo.lock, as an indirect
+          # dependency no update would be raised for. Do not reintroduce the
+          # rename.
+          #
+          # `paraseq` is listed alongside it for the day the resizable pool
+          # lands in noamteyssier/paraseq and the manifest moves back to the
+          # official crate. The group keeps matching then without anyone having
+          # to remember this file.
+          - paraseq
           - paraseq-temp
           - libradicl
           - cf1-rs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@
 # Everything below is grouped rather than per-dependency. A Rust workspace this
 # size produces a dozen individual bumps a week otherwise, and a wall of PRs is
 # reviewed by nobody, which is worse than no updates at all.
+#
+# NONE OF THIS APPLIES TO SECURITY UPDATES. GitHub only uses a `dependabot.yml`
+# entry for security updates when it sets no `target-branch`, and every entry
+# here sets one. So a security bump keeps arriving the way it does today:
+# against the default branch (`master`), ungrouped, without these commit
+# prefixes. That is deliberate (a security fix belongs on the release branch
+# directly, not queued behind `develop`), but it is worth knowing before
+# wondering why one showed up looking nothing like the PRs described below.
 version: 2
 updates:
   # ---- Rust workspace ------------------------------------------------------
@@ -45,6 +53,12 @@ updates:
       # and paraseq-temp 0.5.0-pre.2 commits). Kept in their own PR so such a
       # bump is never buried in a batch of unrelated ones.
       combine-lab-upstream:
+        # Minor and patch only, so a major from one of these lands on its own
+        # like every other major. Grouping a piscem-rs 1.0 with unrelated
+        # bumps is exactly what the separate group exists to prevent.
+        update-types:
+          - minor
+          - patch
         patterns:
           - piscem-rs
           # `paraseq` in the manifest is the `paraseq-temp` republication, so

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,110 @@
+# Dependency updates.
+#
+# Security updates already run without this file; what it adds is *version*
+# updates, and the reason to want them here is that the repository has drifted
+# in the one place drift is invisible: the workflows pin `actions/checkout` at
+# v4 in three files and v6 in a fourth, and `actions/upload-artifact` at v4 and
+# v7. Nobody chose that.
+#
+# Everything below is grouped rather than per-dependency. A Rust workspace this
+# size produces a dozen individual bumps a week otherwise, and a wall of PRs is
+# reviewed by nobody, which is worse than no updates at all.
+version: 2
+updates:
+  # ---- Rust workspace ------------------------------------------------------
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    # Against `develop`, not the default branch: `master` carries releases and
+    # every change lands through `develop` first.
+    target-branch: develop
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      # One PR a week for the routine movement. Patch and minor bumps of
+      # well-behaved crates are reviewed as a batch or not at all.
+      cargo-minor:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - piscem-rs
+          - paraseq
+          - paraseq-temp
+          - libradicl
+          - cf1-rs
+          - sshash-lib
+          - ksw2rs
+        update-types:
+          - minor
+          - patch
+      # The lab's own upstream crates move with work happening in those repos,
+      # and their bumps have carried deliberate floors (see the piscem-rs 0.9.2
+      # and paraseq-temp 0.5.0-pre.2 commits). Kept in their own PR so such a
+      # bump is never buried in a batch of unrelated ones.
+      combine-lab-upstream:
+        patterns:
+          - piscem-rs
+          # `paraseq` in the manifest is the `paraseq-temp` republication, so
+          # both spellings are listed rather than guessing which one Dependabot
+          # reports for a renamed package.
+          - paraseq
+          - paraseq-temp
+          - libradicl
+          - cf1-rs
+          - sshash-lib
+          - ksw2rs
+    # Majors stay ungrouped: each one is a decision, and each one deserves its
+    # own diff and its own CI run.
+
+  # ---- documentation site --------------------------------------------------
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: develop
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      website-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # ---- GitHub Actions ------------------------------------------------------
+  #
+  # The reason this file exists. One weekly PR that keeps every workflow on the
+  # same action versions, including the majors: an action major is a workflow
+  # change, visible in the diff, and CI is its own test.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: develop
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: ci(deps)
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # ---- container base image ------------------------------------------------
+  #
+  # Monthly, because the Dockerfile pins a Rust toolchain image (`rust:1.91-*`)
+  # and moving it is a toolchain decision rather than a dependency refresh.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    target-branch: develop
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: build(deps)


### PR DESCRIPTION
There is no `.github/dependabot.yml` in the repository. Security updates run without one (that is where #1121's js-yaml bump came from), but *version* updates do not, and the workflows show what that has cost:

| action | pinned at |
|---|---|
| `actions/checkout` | `v4` in `ci.yml`, `docker.yml`, `docs.yml`; `v6` in `release.yml` |
| `actions/upload-artifact` | `v4` in `docker.yml`; `v7` in `release.yml` |
| `actions/download-artifact` | `v4` in `docker.yml`; `v8` in `release.yml` |

Nobody chose that split, and nothing surfaces it today.

## What the config covers

Four ecosystems, which is what the repository actually has: the cargo workspace at `/`, the npm project under `/website`, the workflows, and the `Dockerfile`'s base image.

## Grouping, because ungrouped is worse than nothing

A Rust workspace this size produces roughly a dozen individual bumps a week. A wall of one-line PRs gets reviewed by nobody and trains everyone to ignore the label, so every ecosystem here batches:

- **`cargo-minor`** — one weekly PR for routine patch and minor movement.
- **`combine-lab-upstream`** — `piscem-rs`, `paraseq`/`paraseq-temp`, `libradicl`, `cf1-rs`, `sshash-lib`, `ksw2rs` in their own PR. These move with work happening in those repositories, and their bumps have carried deliberate decisions (the piscem-rs 0.9.2 "parked pool as a floor" commit, the paraseq-temp 0.5.0-pre.2 republication). A bump like that should never arrive buried in a batch of unrelated ones.
- **cargo majors** stay ungrouped: each is a decision, and each deserves its own diff and its own CI run.
- **`website-minor`** and **`actions`** batch wholesale. An action major is a workflow change, visible in the diff, and CI is its own test for it.
- **docker** is monthly and ungrouped, since `rust:1.91-bookworm` is a toolchain decision rather than a dependency refresh.

## Two details worth checking against your intent

- **`target-branch: develop`** on every entry. The default would be `master`, which carries releases, and everything else lands through `develop` first. Say if you would rather they target `master`.
- **Commit prefixes** are set explicitly (`chore(deps)`, `ci(deps)`, `build(deps)`) rather than left to Dependabot's inference from history.

Both are one-line changes if you want them differently, as is the whole grouping policy: if the lab-upstream group turns out to be noise rather than signal, an `ignore` entry for those crates replaces it.

Config validated as YAML; nothing else in the repository changes.
