### PR TITLE
fix(quant): a record with no placement gets MAPQ 0, not 255

### DIFF
--- a/crates/salmon-quant/src/mapping_record.rs
+++ b/crates/salmon-quant/src/mapping_record.rs
@@ -183,7 +183,14 @@ pub fn complement(base: u8) -> u8 {
 /// #1141).
 pub fn mapping_quality(nh: usize) -> u8 {
     match nh {
-        0 | 1 => 255,
+        // No placements is not a case a mapped record can reach (the writer
+        // skips a fragment with none), so this arm exists for the record kinds
+        // that have no placement by construction: an unmapped read, once such
+        // records are written. 255 there would claim certainty about a
+        // placement that does not exist; 0 is what samtools convention expects
+        // on an unmapped record.
+        0 => 0,
+        1 => 255,
         2 => 3,
         3..=4 => 1,
         _ => 0,
@@ -438,6 +445,7 @@ mod tests {
         assert_eq!(mapping_quality(3), 1);
         assert_eq!(mapping_quality(4), 1);
         assert_eq!(mapping_quality(5), 0);
-        assert_eq!(mapping_quality(0), 255);
+        // An unmapped record has no placement to be confident about.
+        assert_eq!(mapping_quality(0), 0);
     }
 }

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -491,6 +491,7 @@ is what STAR reports, so `MAPQ` follows STAR's mapping:
 | 2 | 3 |
 | 3 or 4 | 1 |
 | 5 or more | 0 |
+| none (a record with no placement) | 0 |
 
 Matching STAR matters because the tools downstream of a salmon BAM are tuned to
 it: `samtools view -q 255` means "uniquely placed" to all of them. Before this,


### PR DESCRIPTION
Note 1 from your #1151 review, which merged before I could apply it, so it comes as a follow-up rather than a response commit.

The `nh == 0` arm returned 255. No mapped record reaches it, since a fragment with no placements never enters the record loop, so the arm is only about record kinds that have no placement by construction: an unmapped read, once #1142 or its successor writes them. 255 there claims certainty about a placement that does not exist, and 0 is what samtools convention expects on an unmapped record.

Your reasoning for doing it now rather than then is the part I would underline: whoever adds unmapped output is unlikely to go looking for this function's edge case, and the failure would be a plausible-looking 255 rather than anything that breaks.

One line, its test line, and a row in the docs table so the `MAPQ` section covers the no-placement case rather than only `NH >= 1`.

Note 2 (the `#1150` contract paragraph reconciliation) is yours and I have left it alone.