### PR TITLE
deps: declare paraseq-temp under its real name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,11 +101,18 @@ divan = "0.1"
 # TEMPORARY: a republication of paraseq's released 0.5.0 plus the resizable
 # worker pool offered upstream as noamteyssier/paraseq#78 (fixed spawn set with
 # parking; worker count bounded by construction). `ThreadPool` is what lets the
-# mapping thread count change mid-run, which the broker requires. The library
-# target is still named `paraseq`, so `use paraseq::...` is unchanged. `paraseq`
-# is the official crate -- move back once the pool lands there. Must match what
+# mapping thread count change mid-run, which the broker requires. `paraseq` is
+# the official crate -- move back once the pool lands there. Must match what
 # piscem-rs resolves, or two paraseq copies end up either side of its API.
-paraseq = { package = "paraseq-temp", version = "0.5.0-pre.2" }
+#
+# Declared under its real name rather than renamed to `paraseq`: the rename was
+# never needed (the crate's library target is itself named `paraseq`, so
+# `use paraseq::...` works either way) and it made the dependency invisible to
+# tooling. Dependabot's cargo parser skips a renamed manifest entry outright
+# (`next unless name == name_from_declaration(...)`), so this crate reached it
+# only through Cargo.lock, as an indirect dependency no version update would
+# ever be raised for.
+paraseq-temp = "0.5.0-pre.2"
 
 # Workspace-wide lints. Member crates opt in with `[lints] workspace = true`.
 [workspace.lints.rust]

--- a/crates/salmon-quant/Cargo.toml
+++ b/crates/salmon-quant/Cargo.toml
@@ -17,7 +17,7 @@ salmon-eqclass = { workspace = true }
 salmon-infer = { workspace = true }
 salmon-rad = { workspace = true }
 piscem-rs = { workspace = true }
-paraseq = { workspace = true }
+paraseq-temp = { workspace = true }
 thread-broker = { workspace = true }
 rapidgzip-core = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
Follow-up to the finding on #1170: the manifest renamed this dependency, and the rename made it invisible to Dependabot.

## The rename was never load-bearing

```toml
paraseq = { package = "paraseq-temp", version = "0.5.0-pre.2" }
```

`paraseq-temp`'s own manifest declares `[lib] name = "paraseq"`, so `use paraseq::...` resolves identically with or without the rename key. Not one line of code changes in this PR, and `Cargo.lock` is untouched: same crate, same version.

The comment above the entry says the rename exists so that `use paraseq::...` is unchanged. That reason does not hold, and the hazard the comment warns about (two paraseq copies either side of piscem-rs's API) is unrelated to the key: piscem-rs resolves `paraseq-temp` too, which is visible in `Cargo.lock`, and that is what keeps the two sides on one crate.

## What it cost

Dependabot's cargo parser drops a renamed manifest entry before building a dependency from it:

```ruby
# cargo/lib/dependabot/cargo/file_parser.rb, manifest_dependencies
next unless name == name_from_declaration(name, requirement)
```

`name` is `paraseq`, `name_from_declaration` returns `paraseq-temp`, so the entry is skipped. The crate then reaches the parser only through `Cargo.lock`, with no requirement attached, which makes it indirect and puts it outside the default `allow`.

Measured by running that parser over this workspace in the official updater image, before and after:

```
before   paraseq-temp   0.5.0-pre.2   TRANSITIVE (no manifest requirement)
after    paraseq-temp   0.5.0-pre.2   direct (1 req)
```

Everything else is unchanged in both runs (374 dependencies parsed either way; piscem-rs, libradicl, cf1-rs, sshash-lib, ksw2rs all direct as before).

## Why it matters beyond Dependabot

This is a pinned pre-release of a republished crate, waiting on noamteyssier/paraseq#78 to land upstream. It is exactly the dependency whose movement someone should be told about, and it was the one dependency no tool could see. The comment now records why it is not renamed, so the next person who finds `paraseq-temp = ...` uglier than `paraseq = ...` does not quietly undo it.

With this in, the `paraseq-temp` pattern in #1170's `combine-lab-upstream` group starts matching, which is the state that PR's description assumed. I will update its inline note once one of the two lands; whichever order suits you.