### PR TITLE
ci: auto-merge the Dependabot updates that are not decisions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,70 @@
+# Auto-merge the Dependabot updates that are not decisions.
+#
+# The grouping in .github/dependabot.yml exists so the routine movement arrives
+# as a few PRs a week rather than a dozen. This finishes that thought: a grouped
+# patch/minor bump with green CI does not need a human to press the button, and
+# a queue of them waiting for one is how a dependency policy quietly stops
+# working.
+#
+# What is deliberately NOT auto-merged, and why:
+#
+#   * majors, in any ecosystem. `update-type` on a grouped PR is the highest
+#     semver change in the group (dependabot/fetch-metadata resolves it against
+#     `['major', 'minor', 'patch']` in priority order), so one major anywhere in
+#     a group holds the whole group for review.
+#   * the `combine-lab-upstream` group. piscem-rs, paraseq-temp, libradicl and
+#     friends move with work happening in those repositories, and their bumps
+#     have carried deliberate floors. Those are decisions.
+#   * anything targeting a branch other than `develop`. Security updates land on
+#     the default branch (a `target-branch` in dependabot.yml excludes an entry
+#     from security updates), and a security fix going straight to the release
+#     branch unread is not something a workflow should decide.
+#   * the container base image, which is a toolchain choice.
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    # `pull_request_target` runs in the base repository's context with a
+    # writable token, which is what Dependabot's own documentation prescribes
+    # for this: a workflow triggered by Dependabot gets a read-only token
+    # otherwise. Nothing here checks out or executes the PR's code, which is the
+    # condition that makes `pull_request_target` safe.
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.base.ref == 'develop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read what Dependabot is proposing
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for routine updates
+        if: >-
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+          && steps.metadata.outputs.dependency-group != 'combine-lab-upstream'
+          && steps.metadata.outputs.package-ecosystem != 'docker'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Say why this one waits for a human
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+          || steps.metadata.outputs.dependency-group == 'combine-lab-upstream'
+          || steps.metadata.outputs.package-ecosystem == 'docker'
+        run: |
+          gh pr comment "$PR_URL" --body "Not auto-merged: ${REASON}. Merge it by hand once you have looked at it."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REASON: >-
+            ${{ steps.metadata.outputs.update-type == 'version-update:semver-major' && 'the group contains a major version change'
+            || steps.metadata.outputs.dependency-group == 'combine-lab-upstream' && 'these crates move with work upstream and their bumps have carried deliberate floors'
+            || 'the container base image is a toolchain choice' }}


### PR DESCRIPTION
Pairs with #1170. That PR groups the updates so they arrive as a few PRs a week; this one merges the ones that are not decisions, because a queue of green patch bumps waiting for a human is how a dependency policy quietly stops working.

## Policy

| | auto-merged |
|---|---|
| cargo `cargo-minor` group (patch/minor) | yes |
| npm `website-minor` group (patch/minor) | yes |
| `github-actions` group, patch/minor | yes |
| any group containing a **major** | no |
| `combine-lab-upstream` group | no |
| docker base image | no |
| anything not targeting `develop` | no |

The excluded PRs get a comment saying which rule applied, rather than sitting there looking forgotten.

Two of those deserve their reasoning stated:

- **`combine-lab-upstream`** is excluded because those bumps have carried decisions, not just numbers (the piscem-rs 0.9.2 "parked pool as a floor" commit, the paraseq-temp republication).
- **Anything not targeting `develop`** means security updates, which land on the default branch: a `target-branch` in `dependabot.yml` excludes an entry from security updates, as you noted on #1170. A security fix merging into the release branch unread is not something a workflow should decide.

## What I verified rather than copied

Most auto-merge examples in circulation are subtly stale, so:

- **`update-type` on a grouped PR** is the *highest* semver change in the group, not the first dependency's. Checked in `fetch-metadata`'s source rather than inferred: `UPDATE_TYPES_PRIORITY.find(semverLevel => semverLevels.has(semverLevel))`, with the priority array ordered major, minor, patch. That is what makes "one major anywhere holds the group" work.
- **`dependency-group`** comes from the commit trailer (`dependency-group:\s(?<name>\S*)`), so gating on the group name is reliable.
- **`fetch-metadata@v3.1.0`** is the current release. The examples everywhere, including some official docs pages, still say `@v2`.
- **actionlint** passes on the new file (the repo's existing shellcheck findings in `release.yml` are untouched and pre-existing).

## One prerequisite I cannot check from here, and it matters

`gh pr merge --auto` only *waits* if the PR is not already mergeable. **If no status checks are required on `develop`, an auto-merge request on a mergeable PR merges immediately, before CI finishes.** That would be the opposite of the intent.

My token cannot read this repository's merge settings (`allow_auto_merge` comes back null) or its branch protection (`/branches/develop/protection` returns 404, which is either "no protection" or "no access"). So before this is useful, two things need to be true on the repo side:

1. **Allow auto-merge** enabled in repository settings.
2. **Required status checks on `develop`**, at minimum the four `build-test` matrix jobs.

If you would rather not depend on branch protection, say so and I will switch the workflow to wait for CI itself (`gh pr checks --watch --fail-fast` before a plain `gh pr merge --squash`). That version is self-contained and needs no repo settings; it costs a runner sitting idle for the length of CI, which for a handful of PRs a week is nothing. I did not default to it because `--auto` is the mechanism GitHub built for this, and holding a runner for 20 minutes to reimplement it is the sort of thing that looks clever and ages badly.

Merge order: after #1170, or with it; on its own this workflow simply never fires, since without that config Dependabot only raises security PRs, which this deliberately does not touch.
