### PR TITLE
fix(cli): the two #1162 items that #1166 dropped

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -1939,25 +1939,76 @@ fn bytecount_newlines(b: &[u8]) -> u64 {
 /// the readiness sweep found it had never been written for reads-vs-`-a`/`--rad`,
 /// where ~30 mapping flags were accepted in total silence (#1140).
 ///
-/// `mode` names the selected mode as the user would recognise it, and `why`
-/// explains in one clause why the flags cannot apply — a warning that only says
-/// "ignored" leaves the user unsure whether they typed the wrong flag or chose
-/// the wrong mode. Singular and plural are handled so a single flag does not
-/// read as "`--writeRad` shape an intermediate RAD".
-fn warn_inert_in_mode(mode: &str, why: &str, flags: &[(&str, bool)]) {
+/// `mode` names the selected mode as the user would recognise it, and the `why_*`
+/// pair explains in one clause why the flags cannot apply — a warning that only
+/// says "ignored" leaves the user unsure whether they typed the wrong flag or
+/// chose the wrong mode.
+///
+/// Agreement is this function's job, not the callers'. It owns *both* halves:
+/// the subject verb ("`--writeRad` has" / "`--x`, `--y` have") and the pronoun
+/// and verb opening the reason ("it shapes" / "they shape"). Callers used to
+/// pass the reason with a hard-coded "they …", so a lone flag read as
+/// "`--decoyThreshold` has no effect …: they configure salmon's read mapper" —
+/// the exact defect the doc above this function already claimed was handled,
+/// because only the subject half had been (#1162).
+///
+/// `why_verb` is `Some((third-person singular, plural))` when the reason's
+/// subject is the flags themselves, so its pronoun and verb have to agree with
+/// how many were passed; the pair is given explicitly rather than by appending
+/// an "s" to a stem, so an irregular verb cannot be silently mangled later.
+/// It is `None` when the reason supplies its own subject — the mode ("it writes
+/// no intermediate RAD") or a noun phrase ("posterior sampling happens …") — in
+/// which case `why_rest` is used verbatim and no agreement applies.
+fn warn_inert_in_mode(
+    mode: &str,
+    why_verb: Option<(&str, &str)>,
+    why_rest: &str,
+    flags: &[(&str, bool)],
+) {
+    if let Some(msg) = inert_in_mode_message(mode, why_verb, why_rest, flags) {
+        tracing::warn!("{msg}");
+    }
+}
+
+/// The message [`warn_inert_in_mode`] logs, split out so the agreement rules can
+/// be asserted directly. Returns `None` when no listed flag was passed.
+///
+/// Kept separate because the defect this guards was invisible at the call sites:
+/// the warning read correctly in every test that passed two flags and wrongly in
+/// every case that passed one, and nothing asserted the singular form (#1162).
+fn inert_in_mode_message(
+    mode: &str,
+    why_verb: Option<(&str, &str)>,
+    why_rest: &str,
+    flags: &[(&str, bool)],
+) -> Option<String> {
     let named: Vec<&str> = flags
         .iter()
         .filter_map(|&(name, passed)| passed.then_some(name))
         .collect();
     if named.is_empty() {
-        return;
+        return None;
     }
-    let (subject, verb) = if named.len() == 1 {
+    let single = named.len() == 1;
+    let (subject, verb) = if single {
         (named[0].to_string(), "has")
     } else {
         (named.join(", "), "have")
     };
-    tracing::warn!("{subject} {verb} no effect in {mode}: {why}. Ignored.");
+    let why = match why_verb {
+        Some((singular_verb, plural_verb)) => {
+            let (pronoun, agreed) = if single {
+                ("it", singular_verb)
+            } else {
+                ("they", plural_verb)
+            };
+            format!("{pronoun} {agreed} {why_rest}")
+        }
+        None => why_rest.to_string(),
+    };
+    Some(format!(
+        "{subject} {verb} no effect in {mode}: {why}. Ignored."
+    ))
 }
 
 /// The reads-mode mapping/scoring/seeding knobs, paired with whether the user
@@ -2234,8 +2285,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if let Some(bam) = args.alignments {
         warn_inert_in_mode(
             "alignment mode (-a)",
-            "they configure salmon's read mapper, and these alignments were produced by \
-             another aligner",
+            Some(("configures", "configure")),
+            "salmon's read mapper, and these alignments were produced by another aligner",
             &reads_only_flags,
         );
         if args.index.is_some() {
@@ -2399,8 +2450,9 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         // (#1140: a flag that does nothing must say so).
         warn_inert_in_mode(
             "the deprecated online alignment path (--online -a)",
-            "they shape the intermediate RAD, which that path never writes (the default \
-             deterministic mode honours them)",
+            Some(("shapes", "shape")),
+            "the intermediate RAD, which that path never writes (the default deterministic \
+             mode honours them)",
             &[
                 ("--writeRad", args.write_rad.is_some()),
                 ("--keepRad", args.keep_rad),
@@ -2475,7 +2527,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if let Some(rad_path) = args.rad {
         warn_inert_in_mode(
             "RAD-input mode (--rad)",
-            "they configure salmon's read mapper, and a RAD already holds the mappings",
+            Some(("configures", "configure")),
+            "salmon's read mapper, and a RAD already holds the mappings",
             &reads_only_flags,
         );
         if args.index.is_some() {
@@ -2495,7 +2548,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
         // one have nothing to act on (#1140).
         warn_inert_in_mode(
             "RAD-input mode (--rad)",
-            "they shape an intermediate RAD, and the --rad file is the input",
+            Some(("shapes", "shape")),
+            "an intermediate RAD, and the --rad file is the input",
             &[
                 ("--writeRad", args.write_rad.is_some()),
                 ("--keepRad", args.keep_rad),
@@ -2510,6 +2564,25 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             "RAD-input mode (--rad)",
             "a RAD carries no read names or sequences, so SAM/BAM records cannot be reconstructed",
         );
+        // Fail on an unwritable output directory *before* reading the RAD and
+        // running the EM, as the reads, alignment and genome-projection drivers
+        // already do. Without this the run did the whole job and then discarded
+        // it: on the 26M-fragment benchmark the failure arrived at 12.74 s
+        // against a 12.81 s successful run, i.e. after the entire inference,
+        // and the message named no path (#1162).
+        //
+        // `aux_info` rather than the output directory alone, because that is the
+        // one the write actually failed on. Creating only the parent would still
+        // succeed for an existing-but-read-only `-o`, which is the more likely
+        // way to hit this than a missing parent.
+        let aux_dir = args.output.join("aux_info");
+        std::fs::create_dir_all(&aux_dir).with_context(|| {
+            format!(
+                "creating output directory {} (needed before quantification; \
+                 check that it is writable)",
+                args.output.display()
+            )
+        })?;
         // The RAD reuses alignment mode's inference/output; AlignQuantOptions
         // carries the relevant knobs (lib type, EM/VBEM, score-exp, FLD prior,
         // bootstrap/Gibbs). `bam` is unused by the RAD path.
@@ -2618,7 +2691,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     // help means a user who passes one here learns nothing.
     warn_inert_in_mode(
         "reads mode",
-        "they configure how salmon reads *existing* alignments, and reads mode produces its \
+        Some(("configures", "configure")),
+        "how salmon reads *existing* alignments, and reads mode produces its \
          own (reads mode uses --discardOrphansQuasi for the orphan policy)",
         &[
             ("--errorModel", args.error_model),
@@ -2633,7 +2707,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if !args.unmated.is_empty() {
         warn_inert_in_mode(
             "single-end mode (-r)",
-            "they describe how two mates relate, and single-end reads have no mate",
+            Some(("describes", "describe")),
+            "how two mates relate, and single-end reads have no mate",
             &[
                 ("--recoverOrphans", args.recover_orphans),
                 ("--allowDovetail", args.allow_dovetail),
@@ -2670,6 +2745,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if args.online {
         warn_inert_in_mode(
             "the deprecated one-pass reads path (--online)",
+            None,
             "it writes no intermediate RAD",
             &[
                 ("--writeRad", args.write_rad.is_some()),
@@ -2687,6 +2763,7 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if args.skip_quant {
         warn_inert_in_mode(
             "a --skipQuant run",
+            None,
             "posterior sampling happens inside the quantification pass that --skipQuant \
              skips (quantify the kept RAD with --rad to draw samples from it)",
             &[
@@ -2701,7 +2778,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if args.thinning_factor.is_some() && args.num_gibbs_samples == 0 {
         warn_inert_in_mode(
             "a run without Gibbs sampling",
-            "it thins a Gibbs chain, which needs --numGibbsSamples",
+            Some(("thins", "thin")),
+            "a Gibbs chain, which needs --numGibbsSamples",
             &[("--thinningFactor", true)],
         );
     }
@@ -2709,7 +2787,8 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     if !(args.seq_bias || args.gc_bias || args.pos_bias) {
         warn_inert_in_mode(
             "a run without bias correction",
-            "they tune the bias model, which needs --seqBias, --gcBias or --posBias",
+            Some(("tunes", "tune")),
+            "the bias model, which needs --seqBias, --gcBias or --posBias",
             &[
                 ("--numGCBins", args.num_gc_bins.is_some()),
                 ("--conditionalGCBins", args.conditional_gc_bins.is_some()),
@@ -3233,6 +3312,81 @@ mod tests {
     /// Parse a `quant` command line and return just the two mapping-output paths.
     fn write_flags(extra: &[&str]) -> Result<(Option<PathBuf>, Option<PathBuf>), clap::Error> {
         quant_args(extra).map(|args| (args.write_mappings, args.write_bam))
+    }
+
+    /// One inert flag must not be described in the plural.
+    ///
+    /// The warning read "`--decoyThreshold` has no effect in RAD-input mode
+    /// (--rad): **they configure** salmon's read mapper" — the subject agreed
+    /// while the reason did not. It survived because the helper's own doc
+    /// comment claimed singular and plural were handled, and every test that
+    /// exercised it happened to pass more than one flag (#1162).
+    #[test]
+    fn inert_flag_reason_agrees_with_how_many_were_passed() {
+        let verb = Some(("configures", "configure"));
+        let rest = "salmon's read mapper, and a RAD already holds the mappings";
+
+        let one = inert_in_mode_message(
+            "RAD-input mode (--rad)",
+            verb,
+            rest,
+            &[("--decoyThreshold", true), ("--sketch", false)],
+        )
+        .expect("one flag was passed");
+        assert!(
+            one.starts_with("--decoyThreshold has no effect"),
+            "subject should be singular: {one}"
+        );
+        assert!(
+            one.contains("it configures salmon's read mapper"),
+            "reason should be singular too: {one}"
+        );
+        assert!(!one.contains("they"), "no plural anywhere: {one}");
+
+        let many = inert_in_mode_message(
+            "RAD-input mode (--rad)",
+            verb,
+            rest,
+            &[("--sketch", true), ("--decoyThreshold", true)],
+        )
+        .expect("two flags were passed");
+        assert!(
+            many.starts_with("--sketch, --decoyThreshold have no effect"),
+            "subject should be plural: {many}"
+        );
+        assert!(
+            many.contains("they configure salmon's read mapper"),
+            "reason should be plural: {many}"
+        );
+    }
+
+    /// A reason that supplies its own subject is used verbatim: forcing a
+    /// pronoun onto it would produce "it it writes no intermediate RAD".
+    #[test]
+    fn inert_reason_with_its_own_subject_is_left_alone() {
+        let msg = inert_in_mode_message(
+            "the deprecated one-pass reads path (--online)",
+            None,
+            "it writes no intermediate RAD",
+            &[("--keepRad", true)],
+        )
+        .expect("one flag was passed");
+        assert!(
+            msg.ends_with("(--online): it writes no intermediate RAD. Ignored."),
+            "reason should be verbatim: {msg}"
+        );
+    }
+
+    /// Nothing passed, nothing said.
+    #[test]
+    fn inert_message_is_silent_when_no_flag_was_passed() {
+        assert!(inert_in_mode_message(
+            "RAD-input mode (--rad)",
+            Some(("configures", "configure")),
+            "salmon's read mapper",
+            &[("--sketch", false)],
+        )
+        .is_none());
     }
 
     /// `-a` with read inputs must be a parse error, not a silent choice of the

--- a/crates/salmon-cli/tests/input_validation.rs
+++ b/crates/salmon-cli/tests/input_validation.rs
@@ -497,3 +497,60 @@ fn requests_that_cannot_be_honoured_say_so() {
         "--thinningFactor must not warn when Gibbs sampling runs"
     );
 }
+
+/// `--rad` with an unwritable `-o` must fail at invocation, naming the path.
+///
+/// It used to read the whole RAD and run the entire EM first, then fail with a
+/// message carrying no path at all: on the 26M-fragment benchmark the failure
+/// arrived at 12.74 s against a 12.81 s successful run. The reads, alignment and
+/// genome-projection drivers all checked up front; only the RAD driver did not
+/// (#1162).
+///
+/// The RAD here is deliberately not a real one. The check must precede reading
+/// it, so an invalid RAD proves the ordering: if the directory check ever moved
+/// after the read, this would fail with a RAD parse error instead.
+#[test]
+fn rad_input_refuses_an_unwritable_output_directory_before_reading_the_rad() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rad = tmp.path().join("not-really.rad");
+    std::fs::write(&rad, b"this is not a RAD").unwrap();
+
+    let readonly = tmp.path().join("readonly");
+    std::fs::create_dir(&readonly).unwrap();
+    let mut perms = std::fs::metadata(&readonly).unwrap().permissions();
+    perms.set_readonly(true);
+    std::fs::set_permissions(&readonly, perms).unwrap();
+
+    let out = readonly.join("out");
+    let o = run(&[
+        os("quant"),
+        os("--rad"),
+        rad.as_os_str(),
+        os("-l"),
+        os("A"),
+        os("-o"),
+        out.as_os_str(),
+    ]);
+    assert!(!o.status.success(), "an unwritable -o must fail");
+    let err = String::from_utf8_lossy(&o.stderr);
+    assert!(
+        err.contains("creating output directory") && err.contains(&*out.to_string_lossy()),
+        "the failure must name the directory it could not create: {err}"
+    );
+    assert!(
+        !err.contains("RAD-input quantification failed"),
+        "the check must run before the RAD is read, not after: {err}"
+    );
+
+    // Leave the directory removable by the tempdir guard.
+    let mut perms = std::fs::metadata(&readonly).unwrap().permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o755);
+    }
+    #[cfg(not(unix))]
+    #[allow(clippy::permissions_set_readonly_false)]
+    perms.set_readonly(false);
+    std::fs::set_permissions(&readonly, perms).unwrap();
+}


### PR DESCRIPTION
Closes the remainder of #1162.

I verified all seven items against a build of `develop` rather than against #1166's description. **Five were done. Two had never been touched** — and neither appears in #1166 at all, as a fix or as a deferral. Groups 4+5 were staged across five parallel agents and I never reconciled the assembled result against the tracking issue's table, which is what you had asked for.

| # | item | status before this PR |
|---|---|---|
| 1 | `-a --gcBias` without `-t` | done in #1166 |
| 2 | FASTQ errors name no file/record | **path** done in #1166; record identifier upstream |
| 3 | `--rad` unwritable `-o` | **never touched** |
| 4 | `-2` without `-1` | done in #1166 |
| 5 | `--decoyThreshold` sketch warning | done in #1166 |
| 6 | single-flag plural verb | **never touched** |
| 7 | `--skipQuant --dumpEq` | done in #1166 |

## Item 3 — `--rad` with an unwritable `-o`

It read the whole RAD and ran the entire EM before failing, with no path in the message. Measured on the 26M-fragment benchmark:

| | elapsed |
|---|---:|
| failing run (unwritable `-o`) | 12.74 s |
| successful run, same command | 12.81 s |

`rad_read` 2.09 s + `em_bias` 10.54 s — so the failure landed after all the work was done and discarded. Now:

```
Error: creating output directory /…/ro3/out (needed before quantification; check that it is writable)
Caused by: Permission denied (os error 13)
```

at **0.00 s**. The reads, alignment and genome-projection drivers already did this; the RAD driver was the only one that did not.

It creates `aux_info` rather than just the output directory. Creating only the parent still succeeds when `-o` exists but is read-only — the likelier way to hit this — and `aux_info` is the write that actually failed. Both cases now fail at 0.00 s; I tested them separately.

## Item 6 — single-flag warnings in the plural

`warn_inert_in_mode` conjugated its *subject* correctly but the reason clause came from callers with a hard-coded "they":

```
before: --decoyThreshold has no effect in RAD-input mode (--rad): they configure salmon's read mapper…
after:  --decoyThreshold has no effect in RAD-input mode (--rad): it configures salmon's read mapper…
after:  --sketch, --decoyThreshold have no effect in …: they configure salmon's read mapper…   (unchanged)
```

Nine call sites, including one carrying the mirror-image defect — a hard-coded *singular* `"it thins a Gibbs chain"`. Agreement now belongs to the helper, which takes the verb as an explicit `(singular, plural)` pair rather than appending an `"s"` to a stem, so an irregular verb cannot be mangled later.

It is deliberately optional (`Option<(&str, &str)>`): two reasons supply their own subject — the mode (`"it writes no intermediate RAD"`) and a noun phrase (`"posterior sampling happens …"`) — and forcing a pronoun onto those would have produced *"it it writes no intermediate RAD"*. Those pass `None` and are used verbatim.

**How it survived:** the helper's own doc comment claimed singular and plural were handled and cited the exact failing example, while only the subject half had been implemented. Every existing test that exercised it happened to pass more than one flag. The message construction is now split into `inert_in_mode_message` so the agreement rules are asserted directly rather than inferred from a log line.

## Correction on item 2

My first report said mid-file FASTQ errors named no file. That was wrong — a grep filter of mine hid the line. #1166 did chain the path, and it works on the mid-file case:

```
Error: deterministic mapping pass failed
Caused by: 0: while reading /…/mid.fq
           1: mapping failed: FASTX error: Invalid FASTQ separator: X, expected '+'
```

Only the **record identifier** is missing, and that is genuinely upstream: paraseq's error carries no record identity. #1162 should stay open for that one item, or be closed with it re-filed against paraseq — your call.

## Tests

Four new, three of them unit tests on the extracted message builder (singular, plural, own-subject verbatim, and silence when nothing was passed), plus an end-to-end test that an unwritable `-o` fails **before** the RAD is read. That last one deliberately uses an invalid RAD: if the check ever moves back after the read, the test fails with a parse error instead of the directory error.

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace --release` all clean.

Closes #1162.