### PR TITLE
fix(map): right-orphan records reported AS:i:0 instead of the anchor score

### DIFF
--- a/crates/salmon-map/src/mapper.rs
+++ b/crates/salmon-map/src/mapper.rs
@@ -458,6 +458,26 @@ fn index_seq<R: RefProvider>(refs: &R, tid: u32) -> &[u8] {
     refs.ref_seq(tid)
 }
 
+/// read1's `AS` component for an orphan, given the anchor (placed mate) score.
+///
+/// The SAM writer reconstructs read2's score as `score - r1_score` (see
+/// [`ScoredMapping::r1_score`]). For an orphan only one mate is placed, so the
+/// unmapped mate contributes 0. When the anchor is the *left* mate, read1 is the
+/// anchor and carries its score; when the anchor is the *right* mate, read1 is
+/// the unmapped one and must be 0 — otherwise `score - r1_score` collapses to 0
+/// and every right-orphan record reports `AS:i:0` for an alignment that really
+/// scored ~180–200. Both orphan constructors below route through here so the two
+/// cannot drift apart, which is exactly how the right side went unfixed while the
+/// left was correct.
+#[inline]
+fn orphan_read1_score(anchor_is_left: bool, anchor_score: i32) -> i32 {
+    if anchor_is_left {
+        anchor_score
+    } else {
+        0
+    }
+}
+
 /// Build an orphan [`RawMapping`] for a single mate's validated chain (used when
 /// a concordant pair is rejected but one mate aligns well — the salmon `m1`/`m2`
 /// orphan-rescue). `is_left` selects read1 vs read2.
@@ -489,7 +509,7 @@ fn orphan_raw(
         r1_pos: if is_left { start } else { -1 },
         r2_pos: if is_left { -1 } else { start },
         r2_fw: false,
-        r1_score: score,
+        r1_score: orphan_read1_score(is_left, score),
     }
 }
 
@@ -679,7 +699,7 @@ fn push_orphan_or_recovered<R: RefProvider>(
             anchor.chain.ref_start()
         },
         r2_fw: false,
-        r1_score: anchor_aln.score,
+        r1_score: orphan_read1_score(anchor_is_left, anchor_aln.score),
     });
 }
 
@@ -733,5 +753,30 @@ fn recover_mate(
         let partner_end_abs = win_start + aln.end_col as i32;
         let partner_start_abs = partner_end_abs - partner_read.len() as i32;
         Some((aln.score, (a_e - partner_start_abs).max(0)))
+    }
+}
+
+#[cfg(test)]
+mod orphan_as_tests {
+    use super::*;
+
+    /// A left orphan's read1 carries the anchor score; a right orphan's read1 is
+    /// the unmapped mate and must be 0, so the SAM writer's `score - r1_score`
+    /// yields the real anchor score rather than 0. This is the invariant that was
+    /// violated for right orphans (every such record reported `AS:i:0` for an
+    /// alignment scoring ~180–200); both orphan constructors route through this
+    /// helper so they cannot diverge again.
+    #[test]
+    fn right_orphan_read1_score_is_zero_so_read2_as_is_the_anchor_score() {
+        let anchor_score = 194;
+        // Left orphan: read1 is the anchor.
+        assert_eq!(orphan_read1_score(true, anchor_score), anchor_score);
+        // Right orphan: read1 is unmapped -> 0, and the writer emits
+        // score - r1_score = anchor_score - 0 = anchor_score.
+        assert_eq!(orphan_read1_score(false, anchor_score), 0);
+        assert_eq!(
+            anchor_score - orphan_read1_score(false, anchor_score),
+            anchor_score
+        );
     }
 }


### PR DESCRIPTION
Independent fix for the one thing @BenjaminDEMAILLE flagged in #1141 as being in our category rather than his. Confirmed his report in full and fixed it as its own small PR, separate from the #1141 mapping-output decision (which stays deferred per @rob-p).

## The bug

The SAM writer reconstructs read2's `AS` as `score - r1_score`. For an orphan only one mate is placed, so the unmapped mate must contribute 0 — but both orphan constructors set `r1_score = anchor_score` unconditionally. For a **right** orphan (read1 is the unmapped mate), `score - r1_score` collapses to **0**. Left orphans were correct because the writer reads their `r1_score` directly, which is why the defect was one-sided.

## Confirmed, not assumed — 2M real fragments, selective alignment

| record class | count | before | after |
|---|---|---|---|
| left-orphan | 834,288 | ✓ real score | ✓ real score |
| **right-orphan** | **717,526** | **100% `AS:i:0`** | **100% real (min 196, max 300)** |
| paired READ1 | 22,265,435 | ✓ | ✓ |
| paired READ2 | 22,265,435 | ✓ | ✓ |

Two constructors carried it (`orphan_raw`, and the true-orphan arm of `push_orphan_or_recovered`); the proper-pair and single-end paths were already correct.

## Safety

`r1_score` feeds **only** the SAM `AS` reconstruction — it never reaches the RAD or inference (verified: no consumer outside the mapper and `mapping_record.rs`). The same `--writeMappings` run produces a **byte-identical `quant.sf`** before and after (`b6ce28f8…` both). Zero effect on quantification or determinism, exactly as Ben noted.

## The fix

One rule, `orphan_read1_score(anchor_is_left, anchor_score)`, routed through by both constructors so they cannot diverge again — which is how the right side stayed broken while the left was fixed. Unit test pins both directions and the `score - r1_score` reconstruction.

## Scope

Selective alignment only. **Sketch mode** reports `AS:i:0` for right orphans *and* for every proper-pair mate (46.5M of them), because pseudoalignment has no per-base alignment score. Giving sketch a meaningful `AS` — or omitting it — is a separate semantic question worth its own issue, deliberately not bundled here.

## Recommendation for 2.6.0

Take it. It is the same class as the output-contract fixes already merged, it is surgical and provably quant-neutral, and 2.6.0 is the release newly emphasizing output correctness — a `--writeMappings` file where 1.5% of records claim a false zero score is a poor look for it. The rest of #1141 (CIGAR synthesis, `AS`-vs-`NM` self-consistency) genuinely needs design work and stays deferred.

Validation: `cargo fmt`, `cargo clippy -p salmon-map --all-targets -D warnings`, `cargo test -p salmon-map -p salmon-quant` (110 pass, 0 fail) all clean.