### PR TITLE
docs: sketch mode reports AS:i:0 (co-equal best mappings, no per-placement score)

### DIFF
--- a/website/src/content/docs/guides/mapping-modes.mdx
+++ b/website/src/content/docs/guides/mapping-modes.mdx
@@ -34,6 +34,11 @@ k-mer/equivalence-class hits without computing per-placement alignment scores.
 This is **faster** and is a good fit when you want throughput and your reference
 is high-quality.
 
+Because no per-placement score is computed, sketch mode reports every mapping
+for a read as a co-equal best mapping. In `--writeMappings`/`--writeBam` output
+the `AS` tag is therefore `0` for all records; a meaningful `AS` requires
+selective alignment (see [the pseudoalignment output contract](../../reference/output-formats/#the-pseudoalignment-output-contract)).
+
 ```sh
 salmon quant -i salmon_index -l A --sketch \
   -1 r1.fq.gz -2 r2.fq.gz -p 16 -o out

--- a/website/src/content/docs/reference/output-formats.md
+++ b/website/src/content/docs/reference/output-formats.md
@@ -471,6 +471,12 @@ them just because output was requested:
 - **`AS`** is the score salmon's mapper assigned to the placement — the same
   number quantification used — not a score recomputed from the record's own
   CIGAR. It is comparable across records within one run, not across aligners.
+  **In sketch mode (`--sketch`) there is no such score**: pseudoalignment maps
+  by k-mer/equivalence-class compatibility without computing a per-placement
+  alignment score, so `AS` is reported as `0` and every reported mapping is a
+  co-equal best mapping for the read as assessed by the algorithm. A meaningful
+  `AS` appears only under selective alignment (the default), which computes a
+  banded alignment score per candidate.
 - **`MAPQ`** reflects only the placement count, not alignment confidence — see
   below.
 


### PR DESCRIPTION
Per @rob-p's call, this is a documentation issue rather than a code change: sketch mode genuinely has no per-placement alignment score to report, so we document the semantics instead of inventing one.

Sketch mode (`--sketch`) maps by k-mer/equivalence-class compatibility and computes no per-placement alignment score, so in `--writeMappings`/`--writeBam` output the `AS` tag is `0` for every record and **all reported mappings are co-equal best mappings for the read as assessed by the algorithm.** A meaningful `AS` appears only under selective alignment (the default), which computes a banded score per candidate.

This is by design — distinct from the right-orphan `AS:i:0` bug fixed in #1180, which was in selective alignment (a real defect) and is unrelated to sketch's intentional score-free mapping.

Two touch points:
- The **`AS` bullet** in the "pseudoalignment output contract" section of `output-formats.md` — where a user seeing `AS:0` in a SAM/BAM file would look.
- A cross-referenced note in the **sketch section** of the mapping-modes guide.

No code change; closes the sketch-mode `AS` follow-up noted in #1179/#1181.