### PR TITLE
feat(cli): INFO on explicit --deterministic; fix online-knob warning grammar

### DIFF
--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -2230,6 +2230,19 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
     // claim the one-pass path will run, and must not suppress the inert-knob
     // warnings below (`--rad X --online -f 0.9` used to drop `-f` silently
     // behind a misleading deprecation notice, #1140).
+    // `--deterministic` is the default since 2.6.0, so passing it explicitly is
+    // a no-op. Say so at INFO rather than staying silent: the flag lives in
+    // scripts and CI from the opt-in period, and a one-line note tells those
+    // users they can drop it without implying anything is wrong. (`--online`
+    // conflicts with `--deterministic` at the clap layer, so the two branches
+    // are mutually exclusive.)
+    if args.deterministic {
+        tracing::info!(
+            "--deterministic is the default since 2.6.0 and no longer needs to be passed; \
+             accepting it as a no-op. Pass --online for the deprecated one-pass path \
+             (removal planned for 2.7.0)."
+        );
+    }
     let online_path_exists = args.rad.is_none();
     if args.online && !online_path_exists {
         tracing::warn!(
@@ -2255,11 +2268,18 @@ fn run_quant(args: QuantArgs, quiet: bool) -> Result<()> {
             inert.push("--numPreAuxModelSamples");
         }
         if !inert.is_empty() {
+            // Agree with how many were passed: one flag reads "--forgettingFactor
+            // configures … to use it", several read "…, … configure … to use
+            // them". Same singular/plural care as `warn_inert_in_mode`.
+            let (subject, verb, pronoun) = if inert.len() == 1 {
+                (inert[0].to_string(), "configures", "it")
+            } else {
+                (inert.join(", "), "configure", "them")
+            };
             tracing::warn!(
-                "{} configure the online inference path, which the default deterministic \
+                "{subject} {verb} the online inference path, which the default deterministic \
                  mode does not run: ignored. Pass --online (deprecated, removal planned \
-                 for 2.7.0) to use them.",
-                inert.join(", ")
+                 for 2.7.0) to use {pronoun}."
             );
         }
     }

--- a/crates/salmon-cli/tests/input_validation.rs
+++ b/crates/salmon-cli/tests/input_validation.rs
@@ -554,3 +554,130 @@ fn rad_input_refuses_an_unwritable_output_directory_before_reading_the_rad() {
     perms.set_readonly(false);
     std::fs::set_permissions(&readonly, perms).unwrap();
 }
+
+/// `--deterministic` is the default since 2.6.0, so passing it explicitly must
+/// be an accepted no-op that says so at INFO — the flag lives in opt-in-era
+/// scripts and CI, and users should learn they can drop it without any hint that
+/// something is wrong. A default run must not print the note.
+#[test]
+fn explicit_deterministic_is_a_no_op_with_an_info_note() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fx = fixture(tmp.path());
+    let out = tmp.path().join("out");
+
+    let o = run(&[
+        os("quant"),
+        os("-i"),
+        fx.index.as_os_str(),
+        os("-l"),
+        os("A"),
+        os("-r"),
+        fx.se.as_os_str(),
+        os("--deterministic"),
+        os("-o"),
+        out.as_os_str(),
+    ]);
+    assert!(o.status.success(), "explicit --deterministic must succeed");
+    let err = String::from_utf8_lossy(&o.stderr);
+    assert!(
+        err.contains("--deterministic is the default since 2.6.0")
+            && err.contains("no longer needs to be passed"),
+        "explicit --deterministic must note it is the default: {err}"
+    );
+
+    // A default run (no flag) must be silent about it.
+    let out2 = tmp.path().join("out2");
+    let o2 = run(&[
+        os("quant"),
+        os("-i"),
+        fx.index.as_os_str(),
+        os("-l"),
+        os("A"),
+        os("-r"),
+        fx.se.as_os_str(),
+        os("-o"),
+        out2.as_os_str(),
+    ]);
+    assert!(o2.status.success());
+    assert!(
+        !String::from_utf8_lossy(&o2.stderr).contains("--deterministic is the default"),
+        "a default run must not print the deterministic note"
+    );
+}
+
+/// The online-only knobs (`--forgettingFactor`, `--numAuxModelSamples`,
+/// `--numPreAuxModelSamples`) warn-and-ignore when passed without `--online`,
+/// naming the 2.7.0 removal, and the message agrees in number: one flag
+/// "configures … to use it", several "configure … to use them".
+#[test]
+fn online_only_knobs_warn_without_online_and_agree_in_number() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fx = fixture(tmp.path());
+
+    // One knob → singular.
+    let one = run(&[
+        os("quant"),
+        os("-i"),
+        fx.index.as_os_str(),
+        os("-l"),
+        os("A"),
+        os("-r"),
+        fx.se.as_os_str(),
+        os("-f"),
+        os("0.7"),
+        os("-o"),
+        tmp.path().join("o1").as_os_str(),
+    ]);
+    assert!(one.status.success());
+    let e1 = String::from_utf8_lossy(&one.stderr);
+    assert!(
+        e1.contains("--forgettingFactor configures the online inference path")
+            && e1.contains("removal planned for 2.7.0")
+            && e1.contains("to use it."),
+        "single online knob must warn in the singular, naming 2.7.0: {e1}"
+    );
+
+    // Two knobs → plural.
+    let two = run(&[
+        os("quant"),
+        os("-i"),
+        fx.index.as_os_str(),
+        os("-l"),
+        os("A"),
+        os("-r"),
+        fx.se.as_os_str(),
+        os("-f"),
+        os("0.7"),
+        os("--numAuxModelSamples"),
+        os("1000"),
+        os("-o"),
+        tmp.path().join("o2").as_os_str(),
+    ]);
+    assert!(two.status.success());
+    let e2 = String::from_utf8_lossy(&two.stderr);
+    assert!(
+        e2.contains("configure the online inference path") && e2.contains("to use them."),
+        "two online knobs must warn in the plural: {e2}"
+    );
+
+    // Passing --online must suppress the inert-knob warning (the knobs now apply).
+    let online = run(&[
+        os("quant"),
+        os("-i"),
+        fx.index.as_os_str(),
+        os("-l"),
+        os("A"),
+        os("-r"),
+        fx.se.as_os_str(),
+        os("--online"),
+        os("-f"),
+        os("0.7"),
+        os("-o"),
+        tmp.path().join("o3").as_os_str(),
+    ]);
+    assert!(online.status.success());
+    assert!(
+        !String::from_utf8_lossy(&online.stderr).contains("configures the online inference path"),
+        "under --online the knob is honoured, not warned about"
+    );
+}


### PR DESCRIPTION
Answers "do we have a PR to flip the default": **the flip already merged in #1150.** `--deterministic` is the default, `--online` selects the deprecated one-pass path, and the three online-only knobs already warn-and-ignore without `--online`, naming the 2.7.0 removal. This PR closes the two gaps against your spec.

## 1. INFO on explicit `--deterministic`

`args.deterministic` was **never read** — passing the flag did nothing and said nothing. It now logs, at INFO:

```
--deterministic is the default since 2.6.0 and no longer needs to be passed;
accepting it as a no-op. Pass --online for the deprecated one-pass path
(removal planned for 2.7.0).
```

A default run (no flag) stays silent. Verified both ways.

## 2. The online-only flag set is complete — Ben's three are all of them

You asked to confirm the list. `QuantOptions` tags **exactly three** fields as online-phase, and I traced each to its sole consumer in the online EM:

| flag | field | warns without `--online`? |
|---|---|---|
| `--forgettingFactor` (`-f`) | `forgetting_factor` | ✓ |
| `--numAuxModelSamples` | `num_aux_model_samples` | ✓ |
| `--numPreAuxModelSamples` | `num_pre_aux_model_samples` | ✓ |

Everything else is both-mode or honoured by construction: `--initUniform` (the offline EM always starts uniform in reads mode; only online `-a` warm-starts), `--maxReadOcc`, `--biasSpeedSamp`, `--numGCBins`/`--conditionalGCBins`, `--vbPrior`, `--perNucleotidePrior`, `--scoreExp`, bootstrap/Gibbs. `--numBiasSamples` does not exist in this port (bias sampling is dual-phase now). **No other flag needs warn-without-online.**

## 3. Grammar fix found while verifying

The online-knob warning hard-coded the plural, so one flag read:

> `--forgettingFactor` **configure** the online inference path … to use **them**.

Now it agrees in number — "configures … to use it" for one, "configure … them" for several — the same care `warn_inert_in_mode` already takes (the #1162 item-6 class).

## Behaviour, all verified on the built binary

- explicit `--deterministic` → INFO; bare run → silent
- `-f 0.7` (no `--online`) → `configures … to use it.` naming 2.7.0
- `-f 0.7 --numAuxModelSamples 1000` → `configure … to use them.`
- `--online -f 0.7` → the knob is honoured, no inert-knob warning (and the `--online` deprecation warning fires)

Two integration tests pin all of the above. `cargo fmt`, `clippy -p salmon-cli --all-targets -D warnings`, and the `input_validation` suite (10 pass) are clean.