### PR TITLE
deps: adopt libradicl 0.18 + hashbrown 0.17 for 2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,7 +2815,7 @@ version = "2.5.1"
 dependencies = [
  "ahash",
  "divan",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "ksw2rs",
  "piscem-rs",
  "salmon-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,15 +1656,16 @@ dependencies = [
 
 [[package]]
 name = "libradicl"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7518c918544220380ff5ff33b243771a8757872150dd280e6cc9355cddf3043b"
+checksum = "3a1d9494fd770a1d6a07d679f6b722c48fea53dc9c64a4e95e13b71066308c4e"
 dependencies = [
  "ahash",
  "anyhow",
  "bincode",
  "bio-types",
  "bytemuck",
+ "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
  "dashmap",
@@ -1683,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "libradicl-macros"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9974b750aed4376bb9e67feede0446f5fbba1f3bcf398bf155e5ddee34828824"
+checksum = "8dbcfb3a9fd7e663131c333ddc7ed932fc1c6a0d14ac75508992193c4bbb4e0d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ dashmap = "6"
 ahash = "0.8"
 # raw hash table, for caches that must probe with a borrowed key (no key
 # allocation on a lookup that hits)
-hashbrown = "0.15"
+hashbrown = "0.17"
 # numerics
 statrs = "0.19"
 # rng (PCG, matching salmon's pcg usage)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ thread-broker = "0.1.0"
 rapidgzip-core = "0.3"
 # RAD-format I/O (chunk compression + backpatchable file tags); the `zstd`
 # feature enables zstd-compressed RAD chunks (lz4 is always available).
-libradicl = { version = "0.17", features = ["zstd"] }
+libradicl = { version = "0.18", features = ["zstd"] }
 
 # dev / test helpers
 tempfile = "3"


### PR DESCRIPTION
Per @rob-p's call in the pre-2.6.0 dependency scan: adopt libradicl 0.18 (COMBINE-lab upstream, a deliberate 0.x-minor decision).

0.18 requires `noodles ^0.115`, which the tree already resolves to `0.115.0`, so **no noodles bump is forced** (the coupling that usually accompanies a libradicl bump does not bite here).

Verified against the release contract, not assumed:

- **Builds clean.** Our full RAD API surface (`chunk`/`header`/`readers`/`writers`/`record`/`rad_types`) is source-compatible; no code changes needed.
- **`cargo test --workspace --release`: 355 passed, 0 failed** (2 ignored), including all RAD round-trip and output-contract tests.
- **Determinism intact and output unchanged.** `quant.sf` is byte-identical across `-p 1/16/64` at `--sigDigits 9` on the 26M-fragment RAD, and the hash (`2a86764f…`) is **the same one the libradicl-0.17 build produced** — so 0.18 alters no quantification output.
- fmt + `clippy --workspace --all-targets -D warnings` clean.

Diff is two files: `Cargo.toml` (the pin) and `Cargo.lock` (libradicl + libradicl-macros 0.17 → 0.18). This lands before the 2.6.0 version bump.