### PR TITLE
docs(release-notes): note the right-orphan AS fix (#1180)

### DIFF
--- a/docs/release-notes-2.6.0.md
+++ b/docs/release-notes-2.6.0.md
@@ -181,6 +181,13 @@ Most of it is invisible from outside; these are the parts that are not.
   instead of a constant `1`, so `samtools view -q 255` means "uniquely placed"
   as downstream RNA-seq tooling expects. Previously that filter discarded the
   entire file.
+- **Right-orphan records carry their real alignment score.** In
+  `--writeMappings`/`--writeBam` output, every record for an orphan whose mapped
+  mate is read 2 reported `AS:i:0` for an alignment that actually scored ~180–300;
+  it now reports the true score, in both SAM and BAM. Left orphans and proper
+  pairs were already correct. This is output-only — `quant.sf` is unaffected.
+  (In sketch mode `AS` remains `0` for all records by design: pseudoalignment
+  computes no per-placement score, so every mapping is a co-equal best mapping.)
 
 ### Estimates that change
 


### PR DESCRIPTION
Adds a line to the 2.6.0 release notes for the right-orphan `AS:i:0` fix (#1180), which landed this cycle but was not yet in the notes.

Placed beside the MAPQ entry in the "Output that changes shape" section, since both are `--writeMappings`/`--writeBam` record-field corrections. Also notes that sketch-mode `AS:i:0` is by design (no per-placement score) so the two are not confused.

Should land on develop before the develop→master fast-forward, so it ships in 2.6.0.