### PR TITLE
refactor(cli): move the global allocator into its own module, document the gates for changing it

### DIFF
--- a/crates/salmon-cli/Cargo.toml
+++ b/crates/salmon-cli/Cargo.toml
@@ -28,7 +28,9 @@ tracing-subscriber = { workspace = true }
 indicatif = "0.18"
 
 [features]
-# Diagnostic: build with the system allocator instead of mimalloc.
+# Diagnostic: build with the system allocator instead of mimalloc. See
+# src/global_alloc.rs for how the choice is made and docs/allocator-choice.md
+# for what would have to be measured to change it.
 sysalloc = []
 
 [dev-dependencies]

--- a/crates/salmon-cli/examples/cache_bench.rs
+++ b/crates/salmon-cli/examples/cache_bench.rs
@@ -3,10 +3,16 @@
 //! AHashMap cap-256 + Vec cap-64) vs `clear()` (reuse), under whichever global
 //! allocator the binary is built with. Run with the default (mimalloc) and with
 //! `--features sysalloc` to contrast.
+//!
+//! Note what this does *not* measure: it allocates and frees on one thread,
+//! which is every allocator's fast path and not what the quant hot path does.
+//! Its ranking does not survive contact with a real run; see
+//! `docs/allocator-choice.md`.
 
-#[cfg(not(feature = "sysalloc"))]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+// Shared with the real binary so the two can never disagree about which
+// allocator a given set of feature flags selects.
+#[path = "../src/global_alloc.rs"]
+mod global_alloc;
 
 use piscem_rs::mapping::cache::MappingCache;
 use piscem_rs::mapping::sketch_hit_simple::SketchHitInfoSimple;
@@ -14,11 +20,7 @@ use std::hint::black_box;
 use std::time::Instant;
 
 fn main() {
-    let alloc_name = if cfg!(feature = "sysalloc") {
-        "system"
-    } else {
-        "mimalloc"
-    };
+    let alloc_name = global_alloc::NAME;
     // Enough iterations that per-op timing is not dominated by clock resolution.
     let n: u64 = 30_000_000;
 

--- a/crates/salmon-cli/src/global_alloc.rs
+++ b/crates/salmon-cli/src/global_alloc.rs
@@ -1,0 +1,31 @@
+//! Which global allocator the `salmon` binary is built with.
+//!
+//! The quant hot path is highly multithreaded and allocation-heavy (per-read
+//! scratch buffers allocated on a parser thread and freed on a worker thread),
+//! so the allocator is a real, measurable choice rather than a detail. mimalloc
+//! is the default, and `docs/allocator-choice.md` records both the measurement
+//! behind that default and what a candidate replacement would have to show
+//! before it is worth carrying:
+//!
+//! | build flags           | allocator     |
+//! |-----------------------|---------------|
+//! | (none)                | mimalloc      |
+//! | `--features sysalloc` | system malloc |
+//!
+//! [`NAME`] reports which one a build actually got, so a benchmark labels its
+//! own numbers instead of trusting the flags it was invoked with.
+//!
+//! This file is also pulled into `examples/cache_bench.rs` via `#[path]`, so
+//! the microbenchmark and the real binary can never disagree about which
+//! allocator is in play.
+
+/// Name of the allocator this binary was actually built with.
+pub const NAME: &str = if cfg!(feature = "sysalloc") {
+    "system"
+} else {
+    "mimalloc"
+};
+
+#[cfg(not(feature = "sysalloc"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/crates/salmon-cli/src/main.rs
+++ b/crates/salmon-cli/src/main.rs
@@ -30,11 +30,9 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 
-// mimalloc as the global allocator: the quant hot path is highly multithreaded
-// and allocation-heavy, where mimalloc markedly outperforms the system allocator.
-#[cfg(not(feature = "sysalloc"))]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+// The global allocator (mimalloc by default). See the module for why the quant
+// hot path is sensitive to this and how the diagnostic features select it.
+mod global_alloc;
 
 use salmon_align::{
     project_genome_bam_to_rad, quantify_alignments, quantify_rad, AlignQuantOptions,
@@ -3146,6 +3144,10 @@ fn main() -> Result<()> {
         )
         .with_writer(ProgressAwareWriter)
         .init();
+
+    // Which allocator this build selected. Only interesting when comparing
+    // builds, so it sits at debug rather than in the normal run banner.
+    tracing::debug!("global allocator: {}", global_alloc::NAME);
 
     if cli.no_version_check {
         tracing::debug!(

--- a/docs/allocator-choice.md
+++ b/docs/allocator-choice.md
@@ -1,0 +1,144 @@
+# Which global allocator salmon ships, and what would justify changing it
+
+salmon ships with mimalloc as its `#[global_allocator]`. This note records the
+measurement behind that choice, so the question does not have to be re-argued
+from first principles, and states the evidence a candidate replacement has to
+produce before it is worth carrying in the build.
+
+The short version: the alternatives were measured, none of them beat mimalloc
+end to end, and so none of them is in the tree. The measurement is kept here
+because a negative result nobody wrote down gets re-litigated every year.
+
+## Where the choice lives
+
+`crates/salmon-cli/src/global_alloc.rs` holds the `#[global_allocator]` and the
+`NAME` constant reporting which allocator a build actually got. `main.rs` logs
+it at debug level, and `examples/cache_bench.rs` pulls the same file in via
+`#[path]`, so the microbenchmark and the real binary can never disagree about
+what is in play:
+
+```
+cargo build --release -p salmon-cli                      # mimalloc (default)
+cargo build --release -p salmon-cli --features sysalloc  # system malloc
+
+RUST_LOG=debug ./salmon swim   #  -> "global allocator: mimalloc"
+```
+
+`sysalloc` exists as a diagnostic escape hatch (isolating an allocator-specific
+bug, or building where mimalloc will not). It is not a supported configuration.
+
+## The gates a replacement has to clear
+
+An allocator is not a free swap: it is native code linked into every build, a
+second thing to keep building on every platform salmon ships to, and a variable
+that every later performance measurement has to control for. A microbenchmark
+win does not pay for that. Before either adding an allocator as a build feature
+or changing the default, a proposal has to show:
+
+1. **An end-to-end win on a real quant run.** Either measurably faster wall
+   clock without a non-trivial increase in peak RSS, or the same wall clock
+   with a considerable decrease in peak RSS. Phase timings and allocator
+   microbenchmarks are diagnostics, not evidence.
+
+2. **That the win holds across the input, output, and option surfaces.** At a
+   minimum: selective alignment and sketch mode, with and without decoys,
+   with and without mapping output, and across a realistic range of `-p`.
+   An allocator that wins on one configuration and loses on another has
+   found a workload, not an improvement.
+
+Supporting discipline, since these numbers are easy to get wrong (see the traps
+below): repetitions with the arms interleaved rather than grouped, the spread
+reported alongside the median, `quant.sf` hashed to prove the arms are
+computing the same thing, and a warmed page cache.
+
+This is the same bar applied to other performance proposals in this repository:
+the hasher swap in #1126 (5 to 8 percent in isolation, 0 percent end to end)
+and the GPU backend in #1041 were both held to it.
+
+## The measurement behind the current default
+
+Round of 2026-08, on the four candidates that were built for it (mimalloc,
+jemalloc, snmalloc, system malloc):
+
+- Index: GENCODE v50 human transcripts, 654,828 references, k=31, m=19 (~2 GB
+  on disk).
+- Reads: 10M simulated 2x100 bp pairs, lognormal transcript abundance, ~250 bp
+  mean fragment, 0.5% substitution rate. Deterministic, so every allocator sees
+  byte-identical input.
+- `salmon quant -l A -p 16`, Apple M4 Max (16 cores), macOS.
+- 5 reps, allocators interleaved within each rep rather than grouped, so
+  thermal drift and background load hit all four equally.
+
+Only the `mapping` phase allocates heavily (per-read scratch buffers allocated
+on the parser thread and freed on a worker thread, the cross-thread free
+pattern allocators differ most on). `em_bias` is compute-bound and serves as a
+control: an allocator that "wins" there is measuring noise.
+
+Per-rep `mapping` seconds, median, from two independent clean rounds:
+
+| round | mimalloc | jemalloc | snmalloc | system |
+|-------|----------|----------|----------|--------|
+| A (4-way, 5 reps) | 31.0 | 33.2 | 30.8 | 42.7 |
+| B (2-way, 5 reps) | 34.1 | n/a | 36.3 | n/a |
+
+Peak RSS, round A: mimalloc 3.84 GiB, jemalloc 3.66, snmalloc 4.22, system 3.71.
+
+Read it as:
+
+- **System malloc is reliably and substantially worse**: +38% on the mapping
+  phase, ~+20% on total wall. This is the finding that justifies shipping some
+  replacement allocator at all, and it reproduced in every round.
+- **jemalloc does not win.** ~7% behind mimalloc on mapping, consistently. Its
+  strengths (fragmentation control, RSS on long-lived large heaps) are not what
+  a batch quant run is bounded by, and its macOS support is the weakest of the
+  three.
+- **mimalloc and snmalloc are tied.** Round A puts snmalloc marginally ahead,
+  round B puts mimalloc ahead by 6%; the rounds disagree in *direction*, which
+  means the difference is smaller than the noise floor. snmalloc also costs
+  ~0.4 GiB more peak RSS.
+
+So: keep mimalloc. Nothing here justifies a switch, and snmalloc's +0.4 GiB is
+a real cost against a speedup that does not reproduce.
+
+Note what this round does **not** establish, by gate 2's standard: it is one
+machine, one reference, one simulated read set, one option configuration. It is
+enough to conclude "no candidate showed a win worth carrying", which is what it
+concluded. It would not be enough to justify a switch had one of them looked
+good, and a future proposal should not treat it as a template for sufficiency.
+
+## Two traps this measurement fell into
+
+Worth recording, because both produced confident-looking wrong answers first.
+
+**A single-threaded allocation microbenchmark predicts nothing.**
+`examples/cache_bench.rs` (alloc+free of a `MappingCache` on one thread) ranks
+them snmalloc 43 ns/op, system 70, mimalloc 86, jemalloc 89: snmalloc twice as
+fast as mimalloc, and system malloc *beating* mimalloc. Neither survives contact
+with the real workload, where system malloc is worst by a wide margin.
+Same-thread alloc/free is snmalloc's fast path and macOS's nano-zone's fast
+path; it is not what salmon does.
+
+**The first round of the real benchmark was contaminated**: cold page cache
+over 4 GB of freshly written reads plus residual load. Mapping times ranged
+43-68s where the settled machine gives 29-37s, and the ranking came out
+snmalloc > jemalloc > mimalloc, the reverse of the clean result. Absolute
+numbers also drift between rounds (round B's mimalloc is 34.1 where round A's
+is 31.0 for the same binary), so **only within-round comparisons are valid**.
+Warm up, watch the spread, and distrust any ranking whose per-rep variance
+exceeds the gap it claims to have found.
+
+## Re-running it
+
+The alternate allocators are not features in the tree, so reproducing the table
+above means adding them back locally: `tikv-jemallocator` (pinned to 0.5, to
+match the `tikv-jemalloc-sys` that piscem-rs -> sux -> rdst already links, since
+two versions of a `links = "jemalloc"` native library cannot coexist in one
+graph) and `snmalloc-rs` 0.7, each behind its own feature, with the
+`#[global_allocator]` statics in `global_alloc.rs` selected by `cfg`.
+
+For the run itself, `scripts/bench_em_rad.sh` is the model to copy: interleaved
+arms, `/usr/bin/time -f '%e\t%U\t%S\t%M'` for wall, CPU and peak RSS, results
+appended to a TSV, and `quant.sf` hashed per row. That harness replays a RAD
+and therefore excludes mapping, which is exactly the phase an allocator moves,
+so an allocator round needs the full-quant equivalent rather than that script
+as-is.


### PR DESCRIPTION
## What this is now

Scoped down to the half you said you'd take: the allocator placement, plus the
documentation of what would gate changing it. No new dependency, no new feature,
no behavior change.

* `#[global_allocator]` moves out of `main.rs` into
  `crates/salmon-cli/src/global_alloc.rs`, alongside a `NAME` constant reporting
  which allocator a build actually got. The binary logs it at `debug`.
* `examples/cache_bench.rs` pulls that same file in via `#[path]`, so the
  microbenchmark and the real binary cannot disagree about what is in play.
* mimalloc stays the default; `sysalloc` stays the diagnostic escape hatch it
  already was on `master`. `Cargo.lock` is back to `master`'s.

Dropped from the previous revision: the `jemalloc` and `snmalloc` features and
their dependencies.

## The documentation half

`docs/allocator-choice.md` now leads with the negative result rather than the
microbenchmark, and states the bar rather than implying the features were their
own justification. It records:

1. **The gates.** An end-to-end win on a real quant run (faster wall clock
   without a non-trivial RSS increase, or the same wall clock with a
   considerable RSS decrease), and evidence that the win holds across the
   input, output and option surfaces (selective alignment and sketch, with and
   without decoys, with and without mapping output, across a realistic `-p`
   range). Plus the supporting discipline: interleaved arms, spread reported
   with the median, `quant.sf` hashed to prove the arms compute the same thing.
   It notes #1126 and #1041 as the same bar applied elsewhere.

2. **The measurement behind the current default**, which was already in the
   file and which agrees with you: a four-way end-to-end round (GENCODE v50,
   10M pairs, `-p 16`, 5 interleaved reps) where system malloc is +38% on the
   mapping phase, jemalloc is ~7% behind mimalloc, and snmalloc is inside the
   noise floor while costing ~0.4 GiB more peak RSS. Nothing there justifies a
   switch. The doc now also says explicitly what that round does *not*
   establish under gate 2: one machine, one reference, one simulated read set,
   one option configuration.

3. **The two traps**, since both produced confident wrong answers first: the
   single-threaded microbenchmark ranks the four allocators in an order the real
   workload contradicts, and a cold-page-cache first round produced the exact
   reverse of the settled ranking.

## Verification

`cargo fmt --all --check` clean. `cargo build -p salmon-cli --all-targets`
clean, and clean again with `--features sysalloc`.
`cargo clippy -p salmon-cli --all-targets` clean (the only remaining note is the
pre-existing future-incompat warning from the third-party `proc-macro-error2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
